### PR TITLE
Removed dependency on IWshRuntimeLibrary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,5 +155,5 @@ $RECYCLE.BIN/
 # Mac desktop service store files
 .DS_Store
 
-.vs/DS4Windows/*/sqlite3/storage.ide
+.vs/
 

--- a/DS4Windows/DS4Forms/WinProgs.cs
+++ b/DS4Windows/DS4Forms/WinProgs.cs
@@ -473,36 +473,54 @@ namespace DS4Windows
 
         public static string ResolveShortcut(string filePath)
         {
-            // IWshRuntimeLibrary is in the COM library "Windows Script Host Object Model"
-            IWshRuntimeLibrary.WshShell shell = new IWshRuntimeLibrary.WshShell();
+            string result = null;
 
+            Type t = Type.GetTypeFromCLSID(new Guid("72C24DD5-D70A-438B-8A42-98424B88AFB8")); //Windows Script Host Shell Object
+            dynamic shell = Activator.CreateInstance(t);
             try
             {
-                IWshRuntimeLibrary.IWshShortcut shortcut = (IWshRuntimeLibrary.IWshShortcut)shell.CreateShortcut(filePath);
-                return shortcut.TargetPath;
+                var lnk = shell.CreateShortcut(filePath);
+                try
+                {
+                    result = lnk.TargetPath;
+                }
+                finally
+                {
+                    Marshal.FinalReleaseComObject(lnk);
+                }
             }
-            catch (COMException)
+            finally
             {
-                // A COMException is thrown if the file is not a valid shortcut (.lnk) file 
-                return null;
+                Marshal.FinalReleaseComObject(shell);
             }
+
+            return result;
         }
 
         public static string ResolveShortcutAndArgument(string filePath)
         {
-            // IWshRuntimeLibrary is in the COM library "Windows Script Host Object Model"
-            IWshRuntimeLibrary.WshShell shell = new IWshRuntimeLibrary.WshShell();
+            string result = null;
 
+            Type t = Type.GetTypeFromCLSID(new Guid("72C24DD5-D70A-438B-8A42-98424B88AFB8")); // Windows Script Host Shell Object
+            dynamic shell = Activator.CreateInstance(t);
             try
             {
-                IWshRuntimeLibrary.IWshShortcut shortcut = (IWshRuntimeLibrary.IWshShortcut)shell.CreateShortcut(filePath);
-                return shortcut.TargetPath + " " + shortcut.Arguments;
+                var lnk = shell.CreateShortcut(filePath);
+                try
+                {
+                    result = lnk.TargetPath + " " + lnk.Arguments;
+                }
+                finally
+                {
+                    Marshal.FinalReleaseComObject(lnk);
+                }
             }
-            catch (COMException)
+            finally
             {
-                // A COMException is thrown if the file is not a valid shortcut (.lnk) file 
-                return null;
+                Marshal.FinalReleaseComObject(shell);
             }
+
+            return result;
         }
 
         private void cBTurnOffDS4W_CheckedChanged(object sender, EventArgs e)

--- a/DS4Windows/DS4Windows.csproj
+++ b/DS4Windows/DS4Windows.csproj
@@ -1086,17 +1086,6 @@
     <None Include="App.config" />
   </ItemGroup>
   <ItemGroup>
-    <COMReference Include="IWshRuntimeLibrary">
-      <Guid>{F935DC20-1CF0-11D0-ADB9-00C04FD58A0B}</Guid>
-      <VersionMajor>1</VersionMajor>
-      <VersionMinor>0</VersionMinor>
-      <Lcid>0</Lcid>
-      <WrapperTool>tlbimp</WrapperTool>
-      <Isolated>False</Isolated>
-      <EmbedInteropTypes>True</EmbedInteropTypes>
-    </COMReference>
-  </ItemGroup>
-  <ItemGroup>
     <Content Include="HidLibrary\LICENSE" />
     <Content Include="Resources\360 fades.png" />
     <None Include="Resources\360 map.png" />
@@ -1185,11 +1174,6 @@
       <Visible>False</Visible>
       <ProductName>Microsoft .NET Framework 4.5.2 %28x86 and x64%29</ProductName>
       <Install>true</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5 SP1</ProductName>
-      <Install>false</Install>
     </BootstrapperPackage>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
Used the same implementation found at [appShortcutToStartup()](https://github.com/Ryochan7/DS4Windows/blob/jay/DS4Windows/DS4Forms/DS4Form.cs#L1777)
Other then that, added the whole path under `.vs` to git ignore.
Not sure what was the `BootstrapperPackage` of `.Net 3.5` needed for, but it didn't compile for me with it and it did without it (VS2017 Community).
You might want to make sure you can compile without it before merging.