### PR TITLE
Language switch

### DIFF
--- a/DS4Windows/DS4Control/ScpUtil.cs
+++ b/DS4Windows/DS4Control/ScpUtil.cs
@@ -441,6 +441,12 @@ namespace DS4Windows
             get { return m_Config.formLocationY; }
         }
 
+        public static string UseLang
+        {
+            set { m_Config.useLang = value; }
+            get { return m_Config.useLang; }
+        }
+
         public static bool DownloadLang
         {
             set { m_Config.downloadLang = value; }
@@ -1345,6 +1351,7 @@ namespace DS4Windows
             { new Dictionary<string, int>(), new Dictionary<string, int>(), new Dictionary<string, int>(),
               new Dictionary<string, int>(), new Dictionary<string, int>() };
 
+        public string useLang = "";
         public bool downloadLang = true;
         public bool useWhiteIcon;
         public bool flashWhenLate = true;
@@ -2832,6 +2839,8 @@ namespace DS4Windows
                     catch { missingSetting = true; }
                     try { Item = m_Xdoc.SelectSingleNode("/Profile/CloseMinimizes"); Boolean.TryParse(Item.InnerText, out closeMini); }
                     catch { missingSetting = true; }
+                    try { Item = m_Xdoc.SelectSingleNode("/Profile/UseLang"); useLang = Item.InnerText; }
+                    catch { missingSetting = true; }
                     try { Item = m_Xdoc.SelectSingleNode("/Profile/DownloadLang"); Boolean.TryParse(Item.InnerText, out downloadLang); }
                     catch { missingSetting = true; }
                     try { Item = m_Xdoc.SelectSingleNode("/Profile/FlashWhenLate"); Boolean.TryParse(Item.InnerText, out flashWhenLate); }
@@ -2902,6 +2911,7 @@ namespace DS4Windows
             XmlNode xmlQuickCharge = m_Xdoc.CreateNode(XmlNodeType.Element, "QuickCharge", null); xmlQuickCharge.InnerText = quickCharge.ToString(); Node.AppendChild(xmlQuickCharge);
             XmlNode xmlFirstXinputPort = m_Xdoc.CreateNode(XmlNodeType.Element, "FirstXinputPort", null); xmlFirstXinputPort.InnerText = firstXinputPort.ToString(); Node.AppendChild(xmlFirstXinputPort);
             XmlNode xmlCloseMini = m_Xdoc.CreateNode(XmlNodeType.Element, "CloseMinimizes", null); xmlCloseMini.InnerText = closeMini.ToString(); Node.AppendChild(xmlCloseMini);
+            XmlNode xmlUseLang = m_Xdoc.CreateNode(XmlNodeType.Element, "UseLang", null); xmlUseLang.InnerText = useLang.ToString(); Node.AppendChild(xmlUseLang);
             XmlNode xmlDownloadLang = m_Xdoc.CreateNode(XmlNodeType.Element, "DownloadLang", null); xmlDownloadLang.InnerText = downloadLang.ToString(); Node.AppendChild(xmlDownloadLang);
             XmlNode xmlFlashWhenLate = m_Xdoc.CreateNode(XmlNodeType.Element, "FlashWhenLate", null); xmlFlashWhenLate.InnerText = flashWhenLate.ToString(); Node.AppendChild(xmlFlashWhenLate);
             XmlNode xmlFlashWhenLateAt = m_Xdoc.CreateNode(XmlNodeType.Element, "FlashWhenLateAt", null); xmlFlashWhenLateAt.InnerText = flashWhenLateAt.ToString(); Node.AppendChild(xmlFlashWhenLateAt);

--- a/DS4Windows/DS4Forms/DS4Form.Designer.cs
+++ b/DS4Windows/DS4Forms/DS4Form.Designer.cs
@@ -146,6 +146,7 @@
             this.lbUseXIPorts = new System.Windows.Forms.Label();
             this.nUDXIPorts = new System.Windows.Forms.NumericUpDown();
             this.lbLastXIPort = new System.Windows.Forms.Label();
+            this.languagePackComboBox1 = new DS4Windows.DS4Forms.LanguagePackComboBox();
             this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
             this.linkProfiles = new System.Windows.Forms.LinkLabel();
             this.lnkControllers = new System.Windows.Forms.LinkLabel();
@@ -892,6 +893,7 @@
             this.fLPSettings.Controls.Add(this.cBUpdate);
             this.fLPSettings.Controls.Add(this.pNUpdate);
             this.fLPSettings.Controls.Add(this.pnlXIPorts);
+            this.fLPSettings.Controls.Add(this.languagePackComboBox1);
             this.fLPSettings.Controls.Add(this.flowLayoutPanel1);
             this.fLPSettings.Name = "fLPSettings";
             // 
@@ -1135,6 +1137,14 @@
             // 
             resources.ApplyResources(this.lbLastXIPort, "lbLastXIPort");
             this.lbLastXIPort.Name = "lbLastXIPort";
+            // 
+            // languagePackComboBox1
+            // 
+            resources.ApplyResources(this.languagePackComboBox1, "languagePackComboBox1");
+            this.languagePackComboBox1.LanguageAssemblyName = "DS4Windows.resources.dll";
+            this.languagePackComboBox1.Name = "languagePackComboBox1";
+            this.languagePackComboBox1.ProbingPath = "Lang";
+            this.languagePackComboBox1.SelectedValueChanged += new System.EventHandler(this.languagePackComboBox1_SelectedValueChanged);
             // 
             // flowLayoutPanel1
             // 
@@ -1430,6 +1440,7 @@
         private System.Windows.Forms.Panel panel3;
         private System.Windows.Forms.Button exportLogTxtBtn;
         private System.Windows.Forms.Button btnClear;
+        private DS4Forms.LanguagePackComboBox languagePackComboBox1;
         //private System.Windows.Forms.ToolStripMenuItem toolStripMenuItem2;
     }
 }

--- a/DS4Windows/DS4Forms/DS4Form.cs
+++ b/DS4Windows/DS4Forms/DS4Form.cs
@@ -89,7 +89,7 @@ namespace DS4Windows
         public DS4Form(string[] args)
         {
             Global.Load();
-            Program.SetCulture(UseLang);
+            this.setCulture(UseLang);
 
             InitializeComponent();
             ThemeUtil.SetTheme(lvDebug);
@@ -428,6 +428,16 @@ namespace DS4Windows
 
                 control.MouseHover += Items_MouseHover;
             }
+        }
+
+        private void setCulture(string culture)
+        {
+            try
+            {
+                Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo(culture);
+                CultureInfo.DefaultThreadCurrentUICulture = CultureInfo.GetCultureInfo(culture);
+            }
+            catch { /* Skip setting culture that we cannot set */ }
         }
 
         private void populateHoverTextDict()

--- a/DS4Windows/DS4Forms/DS4Form.cs
+++ b/DS4Windows/DS4Forms/DS4Form.cs
@@ -88,6 +88,9 @@ namespace DS4Windows
 
         public DS4Form(string[] args)
         {
+            Global.Load();
+            Program.SetCulture(UseLang);
+
             InitializeComponent();
             ThemeUtil.SetTheme(lvDebug);
 
@@ -181,7 +184,6 @@ namespace DS4Windows
             Log.TrayIconLog += ShowNotification;
 
             Directory.CreateDirectory(appdatapath);
-            Global.Load();
             if (!Save()) //if can't write to file
             {
                 if (MessageBox.Show("Cannot write at current location\nCopy Settings to appdata?", "DS4Windows",
@@ -2485,6 +2487,13 @@ namespace DS4Windows
                 }
                 catch { }
             }
+        }
+
+        private void languagePackComboBox1_SelectedValueChanged(object sender, EventArgs e)
+        {
+            UseLang = ((DS4Forms.LanguagePackComboBox)sender).SelectedValue.ToString();
+            Save();
+            MessageBox.Show("DS4Windows must be restarted in order to have an effect.");
         }
 
         private void cBFlashWhenLate_CheckedChanged(object sender, EventArgs e)

--- a/DS4Windows/DS4Forms/DS4Form.cs
+++ b/DS4Windows/DS4Forms/DS4Form.cs
@@ -2501,9 +2501,13 @@ namespace DS4Windows
 
         private void languagePackComboBox1_SelectedValueChanged(object sender, EventArgs e)
         {
-            UseLang = ((DS4Forms.LanguagePackComboBox)sender).SelectedValue.ToString();
-            Save();
-            MessageBox.Show("DS4Windows must be restarted in order to have an effect.");
+            string newValue = ((DS4Forms.LanguagePackComboBox)sender).SelectedValue.ToString();
+            if (newValue != UseLang)
+            {
+                UseLang = newValue;
+                Save();
+                MessageBox.Show(Properties.Resources.LanguagePackApplyRestartRequired, Text, MessageBoxButtons.OK, MessageBoxIcon.Information);
+            }
         }
 
         private void cBFlashWhenLate_CheckedChanged(object sender, EventArgs e)

--- a/DS4Windows/DS4Forms/DS4Form.cs.resx
+++ b/DS4Windows/DS4Forms/DS4Form.cs.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -117,27 +117,183 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="chTime.Text" xml:space="preserve">
-    <value>Čas</value>
-  </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="lbLastMessage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>861, 22</value>
+  <data name="assignToController1ToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>214, 26</value>
   </data>
-  <data name="llbHelp.Location" type="System.Drawing.Point, System.Drawing">
-    <value>874, 11</value>
+  <data name="assignToController1ToolStripMenuItem.Text" xml:space="preserve">
+    <value>Přiřadit ovladači č.1</value>
   </data>
-  <data name="llbHelp.Size" type="System.Drawing.Size, System.Drawing">
-    <value>168, 17</value>
+  <data name="assignToController2ToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>214, 26</value>
   </data>
-  <data name="llbHelp.Text" xml:space="preserve">
-    <value>Kláv. zkratky/O programu</value>
+  <data name="assignToController2ToolStripMenuItem.Text" xml:space="preserve">
+    <value>Přiřadit ovladači č.2</value>
+  </data>
+  <data name="assignToController3ToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>214, 26</value>
+  </data>
+  <data name="assignToController3ToolStripMenuItem.Text" xml:space="preserve">
+    <value>Přiřadit ovladači č.3</value>
+  </data>
+  <data name="assignToController4ToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>214, 26</value>
+  </data>
+  <data name="assignToController4ToolStripMenuItem.Text" xml:space="preserve">
+    <value>Přiřadit ovladači č.4</value>
+  </data>
+  <data name="bnEditC1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>1018, 22</value>
+  </data>
+  <data name="bnEditC1.Text" xml:space="preserve">
+    <value>Změnit</value>
+  </data>
+  <data name="bnEditC2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>1018, 58</value>
+  </data>
+  <data name="bnEditC2.Text" xml:space="preserve">
+    <value>Změnit</value>
+  </data>
+  <data name="bnEditC3.Location" type="System.Drawing.Point, System.Drawing">
+    <value>1018, 94</value>
+  </data>
+  <data name="bnEditC3.Text" xml:space="preserve">
+    <value>Změnit</value>
+  </data>
+  <data name="bnEditC4.Location" type="System.Drawing.Point, System.Drawing">
+    <value>1018, 130</value>
+  </data>
+  <data name="bnEditC4.Text" xml:space="preserve">
+    <value>Změnit</value>
+  </data>
+  <data name="bnLight1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>1072, 22</value>
+  </data>
+  <data name="bnLight1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>46, 28</value>
+  </data>
+  <data name="bnLight2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>1072, 58</value>
+  </data>
+  <data name="bnLight2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>46, 28</value>
+  </data>
+  <data name="bnLight3.Location" type="System.Drawing.Point, System.Drawing">
+    <value>1072, 94</value>
+  </data>
+  <data name="bnLight3.Size" type="System.Drawing.Size, System.Drawing">
+    <value>46, 28</value>
+  </data>
+  <data name="bnLight4.Location" type="System.Drawing.Point, System.Drawing">
+    <value>1072, 130</value>
+  </data>
+  <data name="bnLight4.Size" type="System.Drawing.Size, System.Drawing">
+    <value>46, 28</value>
   </data>
   <data name="btnClear.Text" xml:space="preserve">
     <value>Vymazat</value>
   </data>
+  <data name="btnStartStop.Text" xml:space="preserve">
+    <value>Start</value>
+  </data>
+  <data name="cBCloseMini.Size" type="System.Drawing.Size, System.Drawing">
+    <value>181, 21</value>
+  </data>
+  <data name="cBCloseMini.Text" xml:space="preserve">
+    <value>Zavřít při minimalizování</value>
+  </data>
+  <data name="cBController1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>872, 23</value>
+  </data>
+  <data name="cBController2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>872, 59</value>
+  </data>
+  <data name="cBController3.Location" type="System.Drawing.Point, System.Drawing">
+    <value>872, 95</value>
+  </data>
+  <data name="cBController4.Location" type="System.Drawing.Point, System.Drawing">
+    <value>872, 131</value>
+  </data>
+  <data name="cBDisconnectBT.Size" type="System.Drawing.Size, System.Drawing">
+    <value>201, 21</value>
+  </data>
+  <data name="cBDisconnectBT.Text" xml:space="preserve">
+    <value>Odpojit od BT při zastavení</value>
+  </data>
+  <data name="cBDownloadLangauge.Size" type="System.Drawing.Size, System.Drawing">
+    <value>348, 21</value>
+  </data>
+  <data name="cBDownloadLangauge.Text" xml:space="preserve">
+    <value>Při aktualizaci stáhnout také nové jazykové balíčky</value>
+  </data>
+  <data name="cBFlashWhenLate.Size" type="System.Drawing.Size, System.Drawing">
+    <value>177, 21</value>
+  </data>
+  <data name="cBFlashWhenLate.Text" xml:space="preserve">
+    <value>Blikat při vysoké latenci</value>
+  </data>
+  <data name="cBoxNotifications.Items" xml:space="preserve">
+    <value>Žádný</value>
+  </data>
+  <data name="cBoxNotifications.Items1" xml:space="preserve">
+    <value>Pouze varování</value>
+  </data>
+  <data name="cBoxNotifications.Items2" xml:space="preserve">
+    <value>Vše</value>
+  </data>
+  <data name="cBQuickCharge.Size" type="System.Drawing.Size, System.Drawing">
+    <value>126, 21</value>
+  </data>
+  <data name="cBQuickCharge.Text" xml:space="preserve">
+    <value>Rychlé nabíjení</value>
+  </data>
+  <data name="cBSwipeProfiles.Size" type="System.Drawing.Size, System.Drawing">
+    <value>289, 21</value>
+  </data>
+  <data name="cBSwipeProfiles.Text" xml:space="preserve">
+    <value>Pro změnu profilu přejeďte po touchpadu</value>
+  </data>
+  <data name="cBUpdate.Size" type="System.Drawing.Size, System.Drawing">
+    <value>253, 21</value>
+  </data>
+  <data name="cBUpdate.Text" xml:space="preserve">
+    <value>Při spuštění kontrolovat aktualizace</value>
+  </data>
+  <data name="cBUpdateTime.Items" xml:space="preserve">
+    <value>hodin</value>
+  </data>
+  <data name="cBUpdateTime.Items1" xml:space="preserve">
+    <value>dní</value>
+  </data>
+  <data name="cBUpdateTime.Location" type="System.Drawing.Point, System.Drawing">
+    <value>211, 0</value>
+  </data>
+  <data name="chData.Text" xml:space="preserve">
+    <value>Data</value>
+  </data>
+  <data name="chTime.Text" xml:space="preserve">
+    <value>Čas</value>
+  </data>
+  <data name="cMCustomLed.Size" type="System.Drawing.Size, System.Drawing">
+    <value>214, 56</value>
+  </data>
+  <data name="cMProfile.Size" type="System.Drawing.Size, System.Drawing">
+    <value>215, 264</value>
+  </data>
   <data name="cMTaskbar.Size" type="System.Drawing.Size, System.Drawing">
     <value>304, 192</value>
+  </data>
+  <data name="deleteToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>214, 26</value>
+  </data>
+  <data name="deleteToolStripMenuItem.Text" xml:space="preserve">
+    <value>Odstranit (Del)</value>
+  </data>
+  <data name="duplicateToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>214, 26</value>
+  </data>
+  <data name="duplicateToolStripMenuItem.Text" xml:space="preserve">
+    <value>Duplikovat (Ctrl+D)</value>
   </data>
   <data name="editProfileForController1ToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>303, 26</value>
@@ -163,17 +319,11 @@
   <data name="editProfileForController4ToolStripMenuItem.Text" xml:space="preserve">
     <value>Upravit profil ovladače č. 4</value>
   </data>
-  <data name="toolStripSeparator1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>300, 6</value>
+  <data name="editToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>214, 26</value>
   </data>
-  <data name="startToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>303, 26</value>
-  </data>
-  <data name="openToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>303, 26</value>
-  </data>
-  <data name="openToolStripMenuItem.Text" xml:space="preserve">
-    <value>Otevřít</value>
+  <data name="editToolStripMenuItem.Text" xml:space="preserve">
+    <value>Změnit</value>
   </data>
   <data name="exitToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>303, 26</value>
@@ -181,53 +331,80 @@
   <data name="exitToolStripMenuItem.Text" xml:space="preserve">
     <value>Ukončit (prostřední tlačítko myši)</value>
   </data>
-  <data name="tabControllers.Text" xml:space="preserve">
-    <value>Ovladače</value>
+  <data name="exportToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>214, 26</value>
   </data>
-  <data name="bnLight3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>1072, 94</value>
+  <data name="exportToolStripMenuItem.Text" xml:space="preserve">
+    <value>Exportovat</value>
   </data>
-  <data name="bnLight3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>46, 28</value>
+  <data name="flowLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>369, 13</value>
   </data>
-  <data name="pBStatus1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>522, 26</value>
+  <data name="flowLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>185, 85</value>
   </data>
-  <data name="bnEditC3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>1018, 94</value>
+  <data name="hideDS4CheckBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>146, 21</value>
   </data>
-  <data name="bnEditC3.Text" xml:space="preserve">
-    <value>Změnit</value>
+  <data name="hideDS4CheckBox.Text" xml:space="preserve">
+    <value>Skrýt DS4 ovladač</value>
   </data>
-  <data name="bnEditC4.Location" type="System.Drawing.Point, System.Drawing">
-    <value>1018, 130</value>
+  <data name="importToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>214, 26</value>
   </data>
-  <data name="bnEditC4.Text" xml:space="preserve">
-    <value>Změnit</value>
+  <data name="importToolStripMenuItem.Text" xml:space="preserve">
+    <value>Importovat</value>
   </data>
-  <data name="cBController1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>872, 23</value>
+  <data name="languagePackComboBox1.InvariantCultureText" xml:space="preserve">
+    <value>Ne (anglické UI)</value>
   </data>
-  <data name="bnEditC2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>1018, 58</value>
+  <data name="languagePackComboBox1.LabelText" xml:space="preserve">
+    <value>Použít jazykový balíček</value>
   </data>
-  <data name="bnEditC2.Text" xml:space="preserve">
-    <value>Změnit</value>
+  <data name="lbBatt1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>740, 27</value>
   </data>
-  <data name="cBController2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>872, 59</value>
+  <data name="lbBatt2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>740, 63</value>
   </data>
-  <data name="cBController3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>872, 95</value>
+  <data name="lbBatt3.Location" type="System.Drawing.Point, System.Drawing">
+    <value>740, 99</value>
   </data>
-  <data name="bnEditC1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>1018, 22</value>
+  <data name="lbBatt4.Location" type="System.Drawing.Point, System.Drawing">
+    <value>740, 135</value>
   </data>
-  <data name="bnEditC1.Text" xml:space="preserve">
-    <value>Změnit</value>
+  <data name="lbBattery.Location" type="System.Drawing.Point, System.Drawing">
+    <value>732, 0</value>
   </data>
-  <data name="cBController4.Location" type="System.Drawing.Point, System.Drawing">
-    <value>872, 131</value>
+  <data name="lbBattery.Text" xml:space="preserve">
+    <value>Baterie</value>
+  </data>
+  <data name="lbCheckEvery.Size" type="System.Drawing.Size, System.Drawing">
+    <value>128, 17</value>
+  </data>
+  <data name="lbCheckEvery.Text" xml:space="preserve">
+    <value>Kontrolovat kažých</value>
+  </data>
+  <data name="lbID.Text" xml:space="preserve">
+    <value>ID</value>
+  </data>
+  <data name="lbLastMessage.Size" type="System.Drawing.Size, System.Drawing">
+    <value>861, 22</value>
+  </data>
+  <data name="lbLastXIPort.Location" type="System.Drawing.Point, System.Drawing">
+    <value>209, 4</value>
+  </data>
+  <data name="lbMsLatency.Location" type="System.Drawing.Point, System.Drawing">
+    <value>237, 5</value>
+  </data>
+  <data name="lbNoControllers.Text" xml:space="preserve">
+    <value>Žádné připojené ovladače (max. 4)</value>
+  </data>
+  <data name="lbNotifications.Size" type="System.Drawing.Size, System.Drawing">
+    <value>125, 17</value>
+  </data>
+  <data name="lbNotifications.Text" xml:space="preserve">
+    <value>Zobrazit oznámení</value>
   </data>
   <data name="lbSelectedProfile.Location" type="System.Drawing.Point, System.Drawing">
     <value>886, 0</value>
@@ -247,23 +424,77 @@
   <data name="lbStatus.Text" xml:space="preserve">
     <value>Stav</value>
   </data>
-  <data name="lbBattery.Location" type="System.Drawing.Point, System.Drawing">
-    <value>732, 0</value>
+  <data name="lbUseXIPorts.Size" type="System.Drawing.Size, System.Drawing">
+    <value>127, 17</value>
   </data>
-  <data name="lbBattery.Text" xml:space="preserve">
-    <value>Baterie</value>
+  <data name="lbUseXIPorts.Text" xml:space="preserve">
+    <value>Použít Xinput porty</value>
   </data>
-  <data name="lbBatt1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>740, 27</value>
+  <data name="linkProfiles.Size" type="System.Drawing.Size, System.Drawing">
+    <value>93, 17</value>
   </data>
-  <data name="lbBatt2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>740, 63</value>
+  <data name="linkProfiles.Text" xml:space="preserve">
+    <value>Složka profilu</value>
   </data>
-  <data name="lbBatt3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>740, 99</value>
+  <data name="linkSetup.Size" type="System.Drawing.Size, System.Drawing">
+    <value>132, 17</value>
   </data>
-  <data name="lbBatt4.Location" type="System.Drawing.Point, System.Drawing">
-    <value>740, 135</value>
+  <data name="linkSetup.Text" xml:space="preserve">
+    <value>Nastavení ovladače</value>
+  </data>
+  <data name="linkUninstall.Size" type="System.Drawing.Size, System.Drawing">
+    <value>177, 17</value>
+  </data>
+  <data name="linkUninstall.Text" xml:space="preserve">
+    <value>Odinstalovat VBus ovladač</value>
+  </data>
+  <data name="llbHelp.Location" type="System.Drawing.Point, System.Drawing">
+    <value>874, 11</value>
+  </data>
+  <data name="llbHelp.Size" type="System.Drawing.Size, System.Drawing">
+    <value>168, 17</value>
+  </data>
+  <data name="llbHelp.Text" xml:space="preserve">
+    <value>Kláv. zkratky/O programu</value>
+  </data>
+  <data name="lLBUpdate.Size" type="System.Drawing.Size, System.Drawing">
+    <value>162, 17</value>
+  </data>
+  <data name="lLBUpdate.Text" xml:space="preserve">
+    <value>Zkontrolovat aktualizace</value>
+  </data>
+  <data name="lnkControllers.Size" type="System.Drawing.Size, System.Drawing">
+    <value>102, 17</value>
+  </data>
+  <data name="lnkControllers.Text" xml:space="preserve">
+    <value>Ovládací panel</value>
+  </data>
+  <data name="newProfileToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>214, 26</value>
+  </data>
+  <data name="newProfileToolStripMenuItem.Text" xml:space="preserve">
+    <value>Nový profil</value>
+  </data>
+  <data name="nUDLatency.Location" type="System.Drawing.Point, System.Drawing">
+    <value>174, 2</value>
+  </data>
+  <data name="nUDUpdateTime.Location" type="System.Drawing.Point, System.Drawing">
+    <value>148, 1</value>
+  </data>
+  <data name="nUDXIPorts.Location" type="System.Drawing.Point, System.Drawing">
+    <value>146, 1</value>
+  </data>
+  <data name="openToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>303, 26</value>
+  </data>
+  <data name="openToolStripMenuItem.Text" xml:space="preserve">
+    <value>Otevřít</value>
+  </data>
+  <data name="panel2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>266, 28</value>
+  </data>
+  <data name="pBStatus1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>522, 26</value>
   </data>
   <data name="pBStatus2.Location" type="System.Drawing.Point, System.Drawing">
     <value>522, 62</value>
@@ -274,95 +505,44 @@
   <data name="pBStatus4.Location" type="System.Drawing.Point, System.Drawing">
     <value>522, 134</value>
   </data>
-  <data name="bnLight1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>1072, 22</value>
+  <data name="pnlXIPorts.Size" type="System.Drawing.Size, System.Drawing">
+    <value>253, 28</value>
   </data>
-  <data name="bnLight1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>46, 28</value>
+  <data name="pNUpdate.Size" type="System.Drawing.Size, System.Drawing">
+    <value>289, 28</value>
   </data>
-  <data name="bnLight2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>1072, 58</value>
+  <data name="startMinimizedCheckBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>173, 21</value>
   </data>
-  <data name="bnLight2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>46, 28</value>
+  <data name="startMinimizedCheckBox.Text" xml:space="preserve">
+    <value>Spustit minimalizovaně</value>
   </data>
-  <data name="bnLight4.Location" type="System.Drawing.Point, System.Drawing">
-    <value>1072, 130</value>
+  <data name="startToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>303, 26</value>
   </data>
-  <data name="bnLight4.Size" type="System.Drawing.Size, System.Drawing">
-    <value>46, 28</value>
+  <data name="startToolStripMenuItem.Text" xml:space="preserve">
+    <value>Start</value>
   </data>
-  <data name="lbNoControllers.Text" xml:space="preserve">
-    <value>Žádné připojené ovladače (max. 4)</value>
+  <data name="StartWindowsCheckBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>189, 21</value>
+  </data>
+  <data name="StartWindowsCheckBox.Text" xml:space="preserve">
+    <value>Spustit při startu systému</value>
+  </data>
+  <data name="tabAutoProfiles.Text" xml:space="preserve">
+    <value>Automatické profily</value>
+  </data>
+  <data name="tabControllers.Text" xml:space="preserve">
+    <value>Ovladače</value>
+  </data>
+  <data name="tabLog.Text" xml:space="preserve">
+    <value>Protokol</value>
   </data>
   <data name="tabProfiles.Text" xml:space="preserve">
     <value>Profily</value>
   </data>
-  <data name="cMProfile.Size" type="System.Drawing.Size, System.Drawing">
-    <value>215, 264</value>
-  </data>
-  <data name="editToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>214, 26</value>
-  </data>
-  <data name="editToolStripMenuItem.Text" xml:space="preserve">
-    <value>Změnit</value>
-  </data>
-  <data name="assignToController1ToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>214, 26</value>
-  </data>
-  <data name="assignToController1ToolStripMenuItem.Text" xml:space="preserve">
-    <value>Přiřadit ovladači č.1</value>
-  </data>
-  <data name="assignToController2ToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>214, 26</value>
-  </data>
-  <data name="assignToController2ToolStripMenuItem.Text" xml:space="preserve">
-    <value>Přiřadit ovladači č.2</value>
-  </data>
-  <data name="assignToController3ToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>214, 26</value>
-  </data>
-  <data name="assignToController3ToolStripMenuItem.Text" xml:space="preserve">
-    <value>Přiřadit ovladači č.3</value>
-  </data>
-  <data name="assignToController4ToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>214, 26</value>
-  </data>
-  <data name="assignToController4ToolStripMenuItem.Text" xml:space="preserve">
-    <value>Přiřadit ovladači č.4</value>
-  </data>
-  <data name="deleteToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>214, 26</value>
-  </data>
-  <data name="deleteToolStripMenuItem.Text" xml:space="preserve">
-    <value>Odstranit (Del)</value>
-  </data>
-  <data name="duplicateToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>214, 26</value>
-  </data>
-  <data name="duplicateToolStripMenuItem.Text" xml:space="preserve">
-    <value>Duplikovat (Ctrl+D)</value>
-  </data>
-  <data name="newProfileToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>214, 26</value>
-  </data>
-  <data name="newProfileToolStripMenuItem.Text" xml:space="preserve">
-    <value>Nový profil</value>
-  </data>
-  <data name="importToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>214, 26</value>
-  </data>
-  <data name="importToolStripMenuItem.Text" xml:space="preserve">
-    <value>Importovat</value>
-  </data>
-  <data name="exportToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>214, 26</value>
-  </data>
-  <data name="exportToolStripMenuItem.Text" xml:space="preserve">
-    <value>Exportovat</value>
-  </data>
-  <data name="tSOptions.Text" xml:space="preserve">
-    <value>Možnosti profilu</value>
+  <data name="tabSettings.Text" xml:space="preserve">
+    <value>Nastavení</value>
   </data>
   <data name="toolStripLabel1.Size" type="System.Drawing.Size, System.Drawing">
     <value>98, 24</value>
@@ -370,44 +550,14 @@
   <data name="toolStripLabel1.Text" xml:space="preserve">
     <value>Název profilu</value>
   </data>
-  <data name="tSTBProfile.Text" xml:space="preserve">
-    <value>&lt;zadejte název profilu&gt;</value>
-  </data>
-  <data name="tSBSaveProfile.Size" type="System.Drawing.Size, System.Drawing">
-    <value>112, 24</value>
-  </data>
-  <data name="tSBSaveProfile.Text" xml:space="preserve">
-    <value>Uložit profil</value>
+  <data name="toolStripSeparator1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>300, 6</value>
   </data>
   <data name="tSBCancel.Size" type="System.Drawing.Size, System.Drawing">
     <value>70, 24</value>
   </data>
   <data name="tSBCancel.Text" xml:space="preserve">
     <value>Zrušit</value>
-  </data>
-  <data name="tSBKeepSize.Size" type="System.Drawing.Size, System.Drawing">
-    <value>207, 24</value>
-  </data>
-  <data name="tSBKeepSize.Text" xml:space="preserve">
-    <value>Pamatovat si velikost okna</value>
-  </data>
-  <data name="tsBNewProfle.Size" type="System.Drawing.Size, System.Drawing">
-    <value>67, 24</value>
-  </data>
-  <data name="tsBNewProfle.Text" xml:space="preserve">
-    <value>Nový</value>
-  </data>
-  <data name="tsBNewProfle.ToolTipText" xml:space="preserve">
-    <value>Vytvořit nový profil</value>
-  </data>
-  <data name="tsBEditProfile.Size" type="System.Drawing.Size, System.Drawing">
-    <value>80, 24</value>
-  </data>
-  <data name="tsBEditProfile.Text" xml:space="preserve">
-    <value>Změnit</value>
-  </data>
-  <data name="tsBEditProfile.ToolTipText" xml:space="preserve">
-    <value>Upravit vybraný profil (Enter)</value>
   </data>
   <data name="tsBDeleteProfile.Size" type="System.Drawing.Size, System.Drawing">
     <value>94, 24</value>
@@ -427,14 +577,14 @@
   <data name="tSBDupProfile.ToolTipText" xml:space="preserve">
     <value>Duplikovat vybraný profil (Ctrl+D)</value>
   </data>
-  <data name="tSBImportProfile.Size" type="System.Drawing.Size, System.Drawing">
-    <value>107, 24</value>
+  <data name="tsBEditProfile.Size" type="System.Drawing.Size, System.Drawing">
+    <value>80, 24</value>
   </data>
-  <data name="tSBImportProfile.Text" xml:space="preserve">
-    <value>Importovat</value>
+  <data name="tsBEditProfile.Text" xml:space="preserve">
+    <value>Změnit</value>
   </data>
-  <data name="tSBImportProfile.ToolTipText" xml:space="preserve">
-    <value>Importovat profil</value>
+  <data name="tsBEditProfile.ToolTipText" xml:space="preserve">
+    <value>Upravit vybraný profil (Enter)</value>
   </data>
   <data name="tSBExportProfile.Size" type="System.Drawing.Size, System.Drawing">
     <value>105, 24</value>
@@ -445,179 +595,41 @@
   <data name="tSBExportProfile.ToolTipText" xml:space="preserve">
     <value>Exportovat vybraný profil</value>
   </data>
-  <data name="tabAutoProfiles.Text" xml:space="preserve">
-    <value>Automatické profily</value>
+  <data name="tSBImportProfile.Size" type="System.Drawing.Size, System.Drawing">
+    <value>107, 24</value>
   </data>
-  <data name="tabSettings.Text" xml:space="preserve">
-    <value>Nastavení</value>
+  <data name="tSBImportProfile.Text" xml:space="preserve">
+    <value>Importovat</value>
   </data>
-  <data name="hideDS4CheckBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>146, 21</value>
+  <data name="tSBImportProfile.ToolTipText" xml:space="preserve">
+    <value>Importovat profil</value>
   </data>
-  <data name="hideDS4CheckBox.Text" xml:space="preserve">
-    <value>Skrýt DS4 ovladač</value>
+  <data name="tSBKeepSize.Size" type="System.Drawing.Size, System.Drawing">
+    <value>207, 24</value>
   </data>
-  <data name="cBSwipeProfiles.Size" type="System.Drawing.Size, System.Drawing">
-    <value>289, 21</value>
+  <data name="tSBKeepSize.Text" xml:space="preserve">
+    <value>Pamatovat si velikost okna</value>
   </data>
-  <data name="cBSwipeProfiles.Text" xml:space="preserve">
-    <value>Pro změnu profilu přejeďte po touchpadu</value>
+  <data name="tsBNewProfle.Size" type="System.Drawing.Size, System.Drawing">
+    <value>67, 24</value>
   </data>
-  <data name="StartWindowsCheckBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>189, 21</value>
+  <data name="tsBNewProfle.Text" xml:space="preserve">
+    <value>Nový</value>
   </data>
-  <data name="StartWindowsCheckBox.Text" xml:space="preserve">
-    <value>Spustit při startu systému</value>
+  <data name="tsBNewProfle.ToolTipText" xml:space="preserve">
+    <value>Vytvořit nový profil</value>
   </data>
-  <data name="startMinimizedCheckBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>173, 21</value>
+  <data name="tSBSaveProfile.Size" type="System.Drawing.Size, System.Drawing">
+    <value>112, 24</value>
   </data>
-  <data name="startMinimizedCheckBox.Text" xml:space="preserve">
-    <value>Spustit minimalizovaně</value>
+  <data name="tSBSaveProfile.Text" xml:space="preserve">
+    <value>Uložit profil</value>
   </data>
-  <data name="lbNotifications.Size" type="System.Drawing.Size, System.Drawing">
-    <value>125, 17</value>
+  <data name="tSOptions.Text" xml:space="preserve">
+    <value>Možnosti profilu</value>
   </data>
-  <data name="lbNotifications.Text" xml:space="preserve">
-    <value>Zobrazit oznámení</value>
-  </data>
-  <data name="cBoxNotifications.Items" xml:space="preserve">
-    <value>Žádný</value>
-  </data>
-  <data name="cBoxNotifications.Items1" xml:space="preserve">
-    <value>Pouze varování</value>
-  </data>
-  <data name="cBoxNotifications.Items2" xml:space="preserve">
-    <value>Vše</value>
-  </data>
-  <data name="cBDisconnectBT.Size" type="System.Drawing.Size, System.Drawing">
-    <value>201, 21</value>
-  </data>
-  <data name="cBDisconnectBT.Text" xml:space="preserve">
-    <value>Odpojit od BT při zastavení</value>
-  </data>
-  <data name="panel2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>266, 28</value>
-  </data>
-  <data name="nUDLatency.Location" type="System.Drawing.Point, System.Drawing">
-    <value>174, 2</value>
-  </data>
-  <data name="lbMsLatency.Location" type="System.Drawing.Point, System.Drawing">
-    <value>237, 5</value>
-  </data>
-  <data name="cBFlashWhenLate.Size" type="System.Drawing.Size, System.Drawing">
-    <value>177, 21</value>
-  </data>
-  <data name="cBFlashWhenLate.Text" xml:space="preserve">
-    <value>Blikat při vysoké latenci</value>
-  </data>
-  <data name="cBCloseMini.Size" type="System.Drawing.Size, System.Drawing">
-    <value>181, 21</value>
-  </data>
-  <data name="cBCloseMini.Text" xml:space="preserve">
-    <value>Zavřít při minimalizování</value>
-  </data>
-  <data name="cBQuickCharge.Size" type="System.Drawing.Size, System.Drawing">
-    <value>126, 21</value>
-  </data>
-  <data name="cBQuickCharge.Text" xml:space="preserve">
-    <value>Rychlé nabíjení</value>
-  </data>
-  <data name="cBDownloadLangauge.Size" type="System.Drawing.Size, System.Drawing">
-    <value>348, 21</value>
-  </data>
-  <data name="cBDownloadLangauge.Text" xml:space="preserve">
-    <value>Při aktualizaci stáhnout také nové jazykové balíčky</value>
-  </data>
-  <data name="cBUpdate.Size" type="System.Drawing.Size, System.Drawing">
-    <value>253, 21</value>
-  </data>
-  <data name="cBUpdate.Text" xml:space="preserve">
-    <value>Při spuštění kontrolovat aktualizace</value>
-  </data>
-  <data name="pNUpdate.Size" type="System.Drawing.Size, System.Drawing">
-    <value>289, 28</value>
-  </data>
-  <data name="cBUpdateTime.Items" xml:space="preserve">
-    <value>hodin</value>
-  </data>
-  <data name="cBUpdateTime.Items1" xml:space="preserve">
-    <value>dní</value>
-  </data>
-  <data name="cBUpdateTime.Location" type="System.Drawing.Point, System.Drawing">
-    <value>211, 0</value>
-  </data>
-  <data name="lbCheckEvery.Size" type="System.Drawing.Size, System.Drawing">
-    <value>128, 17</value>
-  </data>
-  <data name="lbCheckEvery.Text" xml:space="preserve">
-    <value>Kontrolovat kažých</value>
-  </data>
-  <data name="nUDUpdateTime.Location" type="System.Drawing.Point, System.Drawing">
-    <value>148, 1</value>
-  </data>
-  <data name="pnlXIPorts.Size" type="System.Drawing.Size, System.Drawing">
-    <value>253, 28</value>
-  </data>
-  <data name="lbUseXIPorts.Size" type="System.Drawing.Size, System.Drawing">
-    <value>127, 17</value>
-  </data>
-  <data name="lbUseXIPorts.Text" xml:space="preserve">
-    <value>Použít Xinput porty</value>
-  </data>
-  <data name="nUDXIPorts.Location" type="System.Drawing.Point, System.Drawing">
-    <value>146, 1</value>
-  </data>
-  <data name="lbLastXIPort.Location" type="System.Drawing.Point, System.Drawing">
-    <value>209, 4</value>
-  </data>
-  <data name="flowLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>369, 13</value>
-  </data>
-  <data name="flowLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>185, 85</value>
-  </data>
-  <data name="linkProfiles.Size" type="System.Drawing.Size, System.Drawing">
-    <value>93, 17</value>
-  </data>
-  <data name="linkProfiles.Text" xml:space="preserve">
-    <value>Složka profilu</value>
-  </data>
-  <data name="lnkControllers.Size" type="System.Drawing.Size, System.Drawing">
-    <value>102, 17</value>
-  </data>
-  <data name="lnkControllers.Text" xml:space="preserve">
-    <value>Ovládací panel</value>
-  </data>
-  <data name="linkUninstall.Size" type="System.Drawing.Size, System.Drawing">
-    <value>177, 17</value>
-  </data>
-  <data name="linkUninstall.Text" xml:space="preserve">
-    <value>Odinstalovat VBus ovladač</value>
-  </data>
-  <data name="linkSetup.Size" type="System.Drawing.Size, System.Drawing">
-    <value>132, 17</value>
-  </data>
-  <data name="linkSetup.Text" xml:space="preserve">
-    <value>Nastavení ovladače</value>
-  </data>
-  <data name="lLBUpdate.Size" type="System.Drawing.Size, System.Drawing">
-    <value>162, 17</value>
-  </data>
-  <data name="lLBUpdate.Text" xml:space="preserve">
-    <value>Zkontrolovat aktualizace</value>
-  </data>
-  <data name="tabLog.Text" xml:space="preserve">
-    <value>Protokol</value>
-  </data>
-  <data name="cMCustomLed.Size" type="System.Drawing.Size, System.Drawing">
-    <value>214, 56</value>
-  </data>
-  <data name="useProfileColorToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>213, 26</value>
-  </data>
-  <data name="useProfileColorToolStripMenuItem.Text" xml:space="preserve">
-    <value>Použít barvu profilu</value>
+  <data name="tSTBProfile.Text" xml:space="preserve">
+    <value>&lt;zadejte název profilu&gt;</value>
   </data>
   <data name="useCustomColorToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>213, 26</value>
@@ -625,16 +637,10 @@
   <data name="useCustomColorToolStripMenuItem.Text" xml:space="preserve">
     <value>Použít vlastní barvu</value>
   </data>
-  <data name="btnStartStop.Text" xml:space="preserve">
-    <value>Start</value>
+  <data name="useProfileColorToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>213, 26</value>
   </data>
-  <data name="chData.Text" xml:space="preserve">
-    <value>Data</value>
-  </data>
-  <data name="lbID.Text" xml:space="preserve">
-    <value>ID</value>
-  </data>
-  <data name="startToolStripMenuItem.Text" xml:space="preserve">
-    <value>Start</value>
+  <data name="useProfileColorToolStripMenuItem.Text" xml:space="preserve">
+    <value>Použít barvu profilu</value>
   </data>
 </root>

--- a/DS4Windows/DS4Forms/DS4Form.resx
+++ b/DS4Windows/DS4Forms/DS4Form.resx
@@ -454,7 +454,7 @@
     <value>0</value>
   </data>
   <data name="tLPControllers.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="bnLight3" Row="3" RowSpan="1" Column="6" ColumnSpan="1" /&gt;&lt;Control Name="pBStatus1" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="lbPad1" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="lbPad2" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="bnEditC3" Row="3" RowSpan="1" Column="5" ColumnSpan="1" /&gt;&lt;Control Name="bnEditC4" Row="4" RowSpan="1" Column="5" ColumnSpan="1" /&gt;&lt;Control Name="lbPad3" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="lbPad4" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="cBController1" Row="1" RowSpan="1" Column="4" ColumnSpan="1" /&gt;&lt;Control Name="bnEditC2" Row="2" RowSpan="1" Column="5" ColumnSpan="1" /&gt;&lt;Control Name="cBController2" Row="2" RowSpan="1" Column="4" ColumnSpan="1" /&gt;&lt;Control Name="cBController3" Row="3" RowSpan="1" Column="4" ColumnSpan="1" /&gt;&lt;Control Name="bnEditC1" Row="1" RowSpan="1" Column="5" ColumnSpan="1" /&gt;&lt;Control Name="cBController4" Row="4" RowSpan="1" Column="4" ColumnSpan="1" /&gt;&lt;Control Name="lbSelectedProfile" Row="0" RowSpan="1" Column="4" ColumnSpan="1" /&gt;&lt;Control Name="lbID" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="lbStatus" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="lbBattery" Row="0" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="lbBatt1" Row="1" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="lbBatt2" Row="2" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="lbBatt3" Row="3" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="lbBatt4" Row="4" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="pBStatus2" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="pBStatus3" Row="3" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="pBStatus4" Row="4" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="bnLight1" Row="1" RowSpan="1" Column="6" ColumnSpan="1" /&gt;&lt;Control Name="bnLight2" Row="2" RowSpan="1" Column="6" ColumnSpan="1" /&gt;&lt;Control Name="bnLight4" Row="4" RowSpan="1" Column="6" ColumnSpan="1" /&gt;&lt;Control Name="lbLinkProfile" Row="0" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="linkCB1" Row="1" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="linkCB2" Row="2" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="linkCB3" Row="3" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="linkCB4" Row="4" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,62.29144,Percent,20.02225,Percent,17.68632,Absolute,80,AutoSize,0,AutoSize,0,Absolute,83" /&gt;&lt;Rows Styles="AutoSize,0,Percent,25,Percent,25,Percent,25,Percent,25" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="bnLight3" Row="3" RowSpan="1" Column="6" ColumnSpan="1" /&gt;&lt;Control Name="pBStatus1" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="lbPad1" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="lbPad2" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="bnEditC3" Row="3" RowSpan="1" Column="5" ColumnSpan="1" /&gt;&lt;Control Name="bnEditC4" Row="4" RowSpan="1" Column="5" ColumnSpan="1" /&gt;&lt;Control Name="lbPad3" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="lbPad4" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="cBController1" Row="1" RowSpan="1" Column="4" ColumnSpan="1" /&gt;&lt;Control Name="bnEditC2" Row="2" RowSpan="1" Column="5" ColumnSpan="1" /&gt;&lt;Control Name="cBController2" Row="2" RowSpan="1" Column="4" ColumnSpan="1" /&gt;&lt;Control Name="cBController3" Row="3" RowSpan="1" Column="4" ColumnSpan="1" /&gt;&lt;Control Name="bnEditC1" Row="1" RowSpan="1" Column="5" ColumnSpan="1" /&gt;&lt;Control Name="cBController4" Row="4" RowSpan="1" Column="4" ColumnSpan="1" /&gt;&lt;Control Name="lbSelectedProfile" Row="0" RowSpan="1" Column="4" ColumnSpan="1" /&gt;&lt;Control Name="lbID" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="lbStatus" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="lbBattery" Row="0" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="lbBatt1" Row="1" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="lbBatt2" Row="2" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="lbBatt3" Row="3" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="lbBatt4" Row="4" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="pBStatus2" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="pBStatus3" Row="3" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="pBStatus4" Row="4" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="bnLight1" Row="1" RowSpan="1" Column="6" ColumnSpan="1" /&gt;&lt;Control Name="bnLight2" Row="2" RowSpan="1" Column="6" ColumnSpan="1" /&gt;&lt;Control Name="bnLight4" Row="4" RowSpan="1" Column="6" ColumnSpan="1" /&gt;&lt;Control Name="lbLinkProfile" Row="0" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="linkCB1" Row="1" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="linkCB2" Row="2" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="linkCB3" Row="3" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="linkCB4" Row="4" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,62,29144,Percent,20,02225,Percent,17,68632,Absolute,80,AutoSize,0,AutoSize,0,Absolute,90" /&gt;&lt;Rows Styles="AutoSize,0,Percent,25,Percent,25,Percent,25,Percent,25" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="&gt;&gt;lbNoControllers.Name" xml:space="preserve">
     <value>lbNoControllers</value>
@@ -1062,24 +1062,6 @@
   <data name="&gt;&gt;cBUpdate.ZOrder" xml:space="preserve">
     <value>11</value>
   </data>
-  <data name="cBUpdateTime.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
-  </data>
-  <data name="cBUpdateTime.Items" xml:space="preserve">
-    <value>hours</value>
-  </data>
-  <data name="cBUpdateTime.Items1" xml:space="preserve">
-    <value>days</value>
-  </data>
-  <data name="cBUpdateTime.Location" type="System.Drawing.Point, System.Drawing">
-    <value>126, 0</value>
-  </data>
-  <data name="cBUpdateTime.Size" type="System.Drawing.Size, System.Drawing">
-    <value>60, 21</value>
-  </data>
-  <data name="cBUpdateTime.TabIndex" type="System.Int32, mscorlib">
-    <value>43</value>
-  </data>
   <data name="&gt;&gt;cBUpdateTime.Name" xml:space="preserve">
     <value>cBUpdateTime</value>
   </data>
@@ -1092,27 +1074,6 @@
   <data name="&gt;&gt;cBUpdateTime.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="lbCheckEvery.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Left</value>
-  </data>
-  <data name="lbCheckEvery.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lbCheckEvery.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lbCheckEvery.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 3</value>
-  </data>
-  <data name="lbCheckEvery.Size" type="System.Drawing.Size, System.Drawing">
-    <value>67, 13</value>
-  </data>
-  <data name="lbCheckEvery.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="lbCheckEvery.Text" xml:space="preserve">
-    <value>Check every</value>
-  </data>
   <data name="&gt;&gt;lbCheckEvery.Name" xml:space="preserve">
     <value>lbCheckEvery</value>
   </data>
@@ -1124,18 +1085,6 @@
   </data>
   <data name="&gt;&gt;lbCheckEvery.ZOrder" xml:space="preserve">
     <value>1</value>
-  </data>
-  <data name="nUDUpdateTime.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
-  </data>
-  <data name="nUDUpdateTime.Location" type="System.Drawing.Point, System.Drawing">
-    <value>76, 1</value>
-  </data>
-  <data name="nUDUpdateTime.Size" type="System.Drawing.Size, System.Drawing">
-    <value>44, 20</value>
-  </data>
-  <data name="nUDUpdateTime.TabIndex" type="System.Int32, mscorlib">
-    <value>42</value>
   </data>
   <data name="&gt;&gt;nUDUpdateTime.Name" xml:space="preserve">
     <value>nUDUpdateTime</value>
@@ -1173,27 +1122,6 @@
   <data name="&gt;&gt;pNUpdate.ZOrder" xml:space="preserve">
     <value>12</value>
   </data>
-  <data name="lbUseXIPorts.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Left</value>
-  </data>
-  <data name="lbUseXIPorts.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lbUseXIPorts.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lbUseXIPorts.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 3</value>
-  </data>
-  <data name="lbUseXIPorts.Size" type="System.Drawing.Size, System.Drawing">
-    <value>86, 13</value>
-  </data>
-  <data name="lbUseXIPorts.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="lbUseXIPorts.Text" xml:space="preserve">
-    <value>Use Xinput Ports</value>
-  </data>
   <data name="&gt;&gt;lbUseXIPorts.Name" xml:space="preserve">
     <value>lbUseXIPorts</value>
   </data>
@@ -1206,18 +1134,6 @@
   <data name="&gt;&gt;lbUseXIPorts.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="nUDXIPorts.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
-  </data>
-  <data name="nUDXIPorts.Location" type="System.Drawing.Point, System.Drawing">
-    <value>100, 1</value>
-  </data>
-  <data name="nUDXIPorts.Size" type="System.Drawing.Size, System.Drawing">
-    <value>44, 20</value>
-  </data>
-  <data name="nUDXIPorts.TabIndex" type="System.Int32, mscorlib">
-    <value>42</value>
-  </data>
   <data name="&gt;&gt;nUDXIPorts.Name" xml:space="preserve">
     <value>nUDXIPorts</value>
   </data>
@@ -1229,27 +1145,6 @@
   </data>
   <data name="&gt;&gt;nUDXIPorts.ZOrder" xml:space="preserve">
     <value>1</value>
-  </data>
-  <data name="lbLastXIPort.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
-  </data>
-  <data name="lbLastXIPort.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lbLastXIPort.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lbLastXIPort.Location" type="System.Drawing.Point, System.Drawing">
-    <value>150, 3</value>
-  </data>
-  <data name="lbLastXIPort.Size" type="System.Drawing.Size, System.Drawing">
-    <value>19, 13</value>
-  </data>
-  <data name="lbLastXIPort.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="lbLastXIPort.Text" xml:space="preserve">
-    <value>- 4</value>
   </data>
   <data name="&gt;&gt;lbLastXIPort.Name" xml:space="preserve">
     <value>lbLastXIPort</value>
@@ -1284,26 +1179,38 @@
   <data name="&gt;&gt;pnlXIPorts.ZOrder" xml:space="preserve">
     <value>13</value>
   </data>
+  <data name="languagePackComboBox1.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="languagePackComboBox1.InvariantCultureText" xml:space="preserve">
+    <value>No (English UI)</value>
+  </data>
+  <data name="languagePackComboBox1.LabelText" xml:space="preserve">
+    <value>Use language pack</value>
+  </data>
+  <data name="languagePackComboBox1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>274, 89</value>
+  </data>
+  <data name="languagePackComboBox1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>260, 27</value>
+  </data>
+  <data name="languagePackComboBox1.TabIndex" type="System.Int32, mscorlib">
+    <value>60</value>
+  </data>
+  <data name="&gt;&gt;languagePackComboBox1.Name" xml:space="preserve">
+    <value>languagePackComboBox1</value>
+  </data>
+  <data name="&gt;&gt;languagePackComboBox1.Type" xml:space="preserve">
+    <value>DS4Windows.DS4Forms.LanguagePackComboBox, DS4Windows, Version=1.4.106.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;languagePackComboBox1.Parent" xml:space="preserve">
+    <value>fLPSettings</value>
+  </data>
+  <data name="&gt;&gt;languagePackComboBox1.ZOrder" xml:space="preserve">
+    <value>14</value>
+  </data>
   <data name="flowLayoutPanel1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
-  </data>
-  <data name="linkProfiles.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="linkProfiles.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="linkProfiles.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 0</value>
-  </data>
-  <data name="linkProfiles.Size" type="System.Drawing.Size, System.Drawing">
-    <value>65, 13</value>
-  </data>
-  <data name="linkProfiles.TabIndex" type="System.Int32, mscorlib">
-    <value>50</value>
-  </data>
-  <data name="linkProfiles.Text" xml:space="preserve">
-    <value>Profile folder</value>
   </data>
   <data name="&gt;&gt;linkProfiles.Name" xml:space="preserve">
     <value>linkProfiles</value>
@@ -1317,24 +1224,6 @@
   <data name="&gt;&gt;linkProfiles.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="lnkControllers.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lnkControllers.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lnkControllers.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 13</value>
-  </data>
-  <data name="lnkControllers.Size" type="System.Drawing.Size, System.Drawing">
-    <value>70, 13</value>
-  </data>
-  <data name="lnkControllers.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
-  </data>
-  <data name="lnkControllers.Text" xml:space="preserve">
-    <value>Control Panel</value>
-  </data>
   <data name="&gt;&gt;lnkControllers.Name" xml:space="preserve">
     <value>lnkControllers</value>
   </data>
@@ -1346,27 +1235,6 @@
   </data>
   <data name="&gt;&gt;lnkControllers.ZOrder" xml:space="preserve">
     <value>1</value>
-  </data>
-  <data name="linkUninstall.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="linkUninstall.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="linkUninstall.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 26</value>
-  </data>
-  <data name="linkUninstall.Size" type="System.Drawing.Size, System.Drawing">
-    <value>106, 13</value>
-  </data>
-  <data name="linkUninstall.TabIndex" type="System.Int32, mscorlib">
-    <value>44</value>
-  </data>
-  <data name="linkUninstall.Text" xml:space="preserve">
-    <value>Uninstall VBus Driver</value>
-  </data>
-  <data name="linkUninstall.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleCenter</value>
   </data>
   <data name="&gt;&gt;linkUninstall.Name" xml:space="preserve">
     <value>linkUninstall</value>
@@ -1380,24 +1248,6 @@
   <data name="&gt;&gt;linkUninstall.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
-  <data name="linkSetup.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="linkSetup.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="linkSetup.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 39</value>
-  </data>
-  <data name="linkSetup.Size" type="System.Drawing.Size, System.Drawing">
-    <value>115, 13</value>
-  </data>
-  <data name="linkSetup.TabIndex" type="System.Int32, mscorlib">
-    <value>52</value>
-  </data>
-  <data name="linkSetup.Text" xml:space="preserve">
-    <value>Controller/Driver Setup</value>
-  </data>
   <data name="&gt;&gt;linkSetup.Name" xml:space="preserve">
     <value>linkSetup</value>
   </data>
@@ -1409,27 +1259,6 @@
   </data>
   <data name="&gt;&gt;linkSetup.ZOrder" xml:space="preserve">
     <value>3</value>
-  </data>
-  <data name="lLBUpdate.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lLBUpdate.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lLBUpdate.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 52</value>
-  </data>
-  <data name="lLBUpdate.Size" type="System.Drawing.Size, System.Drawing">
-    <value>116, 13</value>
-  </data>
-  <data name="lLBUpdate.TabIndex" type="System.Int32, mscorlib">
-    <value>49</value>
-  </data>
-  <data name="lLBUpdate.Text" xml:space="preserve">
-    <value>Check for Update Now</value>
-  </data>
-  <data name="lLBUpdate.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleCenter</value>
   </data>
   <data name="&gt;&gt;lLBUpdate.Name" xml:space="preserve">
     <value>lLBUpdate</value>
@@ -1447,7 +1276,7 @@
     <value>TopDown</value>
   </data>
   <data name="flowLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>274, 89</value>
+    <value>274, 122</value>
   </data>
   <data name="flowLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
     <value>122, 65</value>
@@ -1465,7 +1294,7 @@
     <value>fLPSettings</value>
   </data>
   <data name="&gt;&gt;flowLayoutPanel1.ZOrder" xml:space="preserve">
-    <value>14</value>
+    <value>15</value>
   </data>
   <data name="fLPSettings.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -2014,7 +1843,7 @@
     <value>0</value>
   </data>
   <data name="tLPControllers.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="bnLight3" Row="3" RowSpan="1" Column="6" ColumnSpan="1" /&gt;&lt;Control Name="pBStatus1" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="lbPad1" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="lbPad2" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="bnEditC3" Row="3" RowSpan="1" Column="5" ColumnSpan="1" /&gt;&lt;Control Name="bnEditC4" Row="4" RowSpan="1" Column="5" ColumnSpan="1" /&gt;&lt;Control Name="lbPad3" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="lbPad4" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="cBController1" Row="1" RowSpan="1" Column="4" ColumnSpan="1" /&gt;&lt;Control Name="bnEditC2" Row="2" RowSpan="1" Column="5" ColumnSpan="1" /&gt;&lt;Control Name="cBController2" Row="2" RowSpan="1" Column="4" ColumnSpan="1" /&gt;&lt;Control Name="cBController3" Row="3" RowSpan="1" Column="4" ColumnSpan="1" /&gt;&lt;Control Name="bnEditC1" Row="1" RowSpan="1" Column="5" ColumnSpan="1" /&gt;&lt;Control Name="cBController4" Row="4" RowSpan="1" Column="4" ColumnSpan="1" /&gt;&lt;Control Name="lbSelectedProfile" Row="0" RowSpan="1" Column="4" ColumnSpan="1" /&gt;&lt;Control Name="lbID" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="lbStatus" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="lbBattery" Row="0" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="lbBatt1" Row="1" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="lbBatt2" Row="2" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="lbBatt3" Row="3" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="lbBatt4" Row="4" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="pBStatus2" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="pBStatus3" Row="3" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="pBStatus4" Row="4" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="bnLight1" Row="1" RowSpan="1" Column="6" ColumnSpan="1" /&gt;&lt;Control Name="bnLight2" Row="2" RowSpan="1" Column="6" ColumnSpan="1" /&gt;&lt;Control Name="bnLight4" Row="4" RowSpan="1" Column="6" ColumnSpan="1" /&gt;&lt;Control Name="lbLinkProfile" Row="0" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="linkCB1" Row="1" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="linkCB2" Row="2" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="linkCB3" Row="3" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="linkCB4" Row="4" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,62.29144,Percent,20.02225,Percent,17.68632,Absolute,80,AutoSize,0,AutoSize,0,Absolute,83" /&gt;&lt;Rows Styles="AutoSize,0,Percent,25,Percent,25,Percent,25,Percent,25" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="bnLight3" Row="3" RowSpan="1" Column="6" ColumnSpan="1" /&gt;&lt;Control Name="pBStatus1" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="lbPad1" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="lbPad2" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="bnEditC3" Row="3" RowSpan="1" Column="5" ColumnSpan="1" /&gt;&lt;Control Name="bnEditC4" Row="4" RowSpan="1" Column="5" ColumnSpan="1" /&gt;&lt;Control Name="lbPad3" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="lbPad4" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="cBController1" Row="1" RowSpan="1" Column="4" ColumnSpan="1" /&gt;&lt;Control Name="bnEditC2" Row="2" RowSpan="1" Column="5" ColumnSpan="1" /&gt;&lt;Control Name="cBController2" Row="2" RowSpan="1" Column="4" ColumnSpan="1" /&gt;&lt;Control Name="cBController3" Row="3" RowSpan="1" Column="4" ColumnSpan="1" /&gt;&lt;Control Name="bnEditC1" Row="1" RowSpan="1" Column="5" ColumnSpan="1" /&gt;&lt;Control Name="cBController4" Row="4" RowSpan="1" Column="4" ColumnSpan="1" /&gt;&lt;Control Name="lbSelectedProfile" Row="0" RowSpan="1" Column="4" ColumnSpan="1" /&gt;&lt;Control Name="lbID" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="lbStatus" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="lbBattery" Row="0" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="lbBatt1" Row="1" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="lbBatt2" Row="2" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="lbBatt3" Row="3" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="lbBatt4" Row="4" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="pBStatus2" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="pBStatus3" Row="3" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="pBStatus4" Row="4" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="bnLight1" Row="1" RowSpan="1" Column="6" ColumnSpan="1" /&gt;&lt;Control Name="bnLight2" Row="2" RowSpan="1" Column="6" ColumnSpan="1" /&gt;&lt;Control Name="bnLight4" Row="4" RowSpan="1" Column="6" ColumnSpan="1" /&gt;&lt;Control Name="lbLinkProfile" Row="0" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="linkCB1" Row="1" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="linkCB2" Row="2" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="linkCB3" Row="3" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="linkCB4" Row="4" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,62,29144,Percent,20,02225,Percent,17,68632,Absolute,80,AutoSize,0,AutoSize,0,Absolute,90" /&gt;&lt;Rows Styles="AutoSize,0,Percent,25,Percent,25,Percent,25,Percent,25" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="bnLight3.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -2026,10 +1855,10 @@
     <value>NoControl</value>
   </data>
   <data name="bnLight3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>814, 89</value>
+    <value>807, 89</value>
   </data>
   <data name="bnLight3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>79, 22</value>
+    <value>86, 22</value>
   </data>
   <data name="bnLight3.TabIndex" type="System.Int32, mscorlib">
     <value>50</value>
@@ -2053,7 +1882,7 @@
     <value>NoControl</value>
   </data>
   <data name="pBStatus1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>396, 34</value>
+    <value>391, 34</value>
   </data>
   <data name="pBStatus1.Size" type="System.Drawing.Size, System.Drawing">
     <value>39, 20</value>
@@ -2155,7 +1984,7 @@
     <value>NoControl</value>
   </data>
   <data name="bnEditC3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>774, 89</value>
+    <value>767, 89</value>
   </data>
   <data name="bnEditC3.Size" type="System.Drawing.Size, System.Drawing">
     <value>34, 22</value>
@@ -2185,7 +2014,7 @@
     <value>NoControl</value>
   </data>
   <data name="bnEditC4.Location" type="System.Drawing.Point, System.Drawing">
-    <value>774, 117</value>
+    <value>767, 117</value>
   </data>
   <data name="bnEditC4.Size" type="System.Drawing.Size, System.Drawing">
     <value>34, 22</value>
@@ -2284,7 +2113,7 @@
     <value>None</value>
   </data>
   <data name="cBController1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>657, 33</value>
+    <value>650, 33</value>
   </data>
   <data name="cBController1.Size" type="System.Drawing.Size, System.Drawing">
     <value>111, 21</value>
@@ -2311,7 +2140,7 @@
     <value>NoControl</value>
   </data>
   <data name="bnEditC2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>774, 61</value>
+    <value>767, 61</value>
   </data>
   <data name="bnEditC2.Size" type="System.Drawing.Size, System.Drawing">
     <value>34, 22</value>
@@ -2338,7 +2167,7 @@
     <value>None</value>
   </data>
   <data name="cBController2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>657, 61</value>
+    <value>650, 61</value>
   </data>
   <data name="cBController2.Size" type="System.Drawing.Size, System.Drawing">
     <value>111, 21</value>
@@ -2362,7 +2191,7 @@
     <value>None</value>
   </data>
   <data name="cBController3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>657, 89</value>
+    <value>650, 89</value>
   </data>
   <data name="cBController3.Size" type="System.Drawing.Size, System.Drawing">
     <value>111, 21</value>
@@ -2389,7 +2218,7 @@
     <value>NoControl</value>
   </data>
   <data name="bnEditC1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>774, 33</value>
+    <value>767, 33</value>
   </data>
   <data name="bnEditC1.Size" type="System.Drawing.Size, System.Drawing">
     <value>34, 22</value>
@@ -2416,7 +2245,7 @@
     <value>None</value>
   </data>
   <data name="cBController4.Location" type="System.Drawing.Point, System.Drawing">
-    <value>657, 117</value>
+    <value>650, 117</value>
   </data>
   <data name="cBController4.Size" type="System.Drawing.Size, System.Drawing">
     <value>111, 21</value>
@@ -2449,7 +2278,7 @@
     <value>NoControl</value>
   </data>
   <data name="lbSelectedProfile.Location" type="System.Drawing.Point, System.Drawing">
-    <value>658, 7</value>
+    <value>651, 7</value>
   </data>
   <data name="lbSelectedProfile.Size" type="System.Drawing.Size, System.Drawing">
     <value>109, 15</value>
@@ -2521,7 +2350,7 @@
     <value>NoControl</value>
   </data>
   <data name="lbStatus.Location" type="System.Drawing.Point, System.Drawing">
-    <value>392, 7</value>
+    <value>387, 7</value>
   </data>
   <data name="lbStatus.Size" type="System.Drawing.Size, System.Drawing">
     <value>47, 15</value>
@@ -2557,7 +2386,7 @@
     <value>NoControl</value>
   </data>
   <data name="lbBattery.Location" type="System.Drawing.Point, System.Drawing">
-    <value>498, 7</value>
+    <value>491, 7</value>
   </data>
   <data name="lbBattery.Size" type="System.Drawing.Size, System.Drawing">
     <value>51, 15</value>
@@ -2593,7 +2422,7 @@
     <value>NoControl</value>
   </data>
   <data name="lbBatt1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>504, 36</value>
+    <value>497, 36</value>
   </data>
   <data name="lbBatt1.Size" type="System.Drawing.Size, System.Drawing">
     <value>39, 15</value>
@@ -2629,7 +2458,7 @@
     <value>NoControl</value>
   </data>
   <data name="lbBatt2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>504, 64</value>
+    <value>497, 64</value>
   </data>
   <data name="lbBatt2.Size" type="System.Drawing.Size, System.Drawing">
     <value>39, 15</value>
@@ -2665,7 +2494,7 @@
     <value>NoControl</value>
   </data>
   <data name="lbBatt3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>504, 92</value>
+    <value>497, 92</value>
   </data>
   <data name="lbBatt3.Size" type="System.Drawing.Size, System.Drawing">
     <value>39, 15</value>
@@ -2701,7 +2530,7 @@
     <value>NoControl</value>
   </data>
   <data name="lbBatt4.Location" type="System.Drawing.Point, System.Drawing">
-    <value>504, 120</value>
+    <value>497, 120</value>
   </data>
   <data name="lbBatt4.Size" type="System.Drawing.Size, System.Drawing">
     <value>39, 15</value>
@@ -2731,7 +2560,7 @@
     <value>NoControl</value>
   </data>
   <data name="pBStatus2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>396, 62</value>
+    <value>391, 62</value>
   </data>
   <data name="pBStatus2.Size" type="System.Drawing.Size, System.Drawing">
     <value>39, 20</value>
@@ -2761,7 +2590,7 @@
     <value>NoControl</value>
   </data>
   <data name="pBStatus3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>396, 90</value>
+    <value>391, 90</value>
   </data>
   <data name="pBStatus3.Size" type="System.Drawing.Size, System.Drawing">
     <value>39, 20</value>
@@ -2791,7 +2620,7 @@
     <value>NoControl</value>
   </data>
   <data name="pBStatus4.Location" type="System.Drawing.Point, System.Drawing">
-    <value>396, 118</value>
+    <value>391, 118</value>
   </data>
   <data name="pBStatus4.Size" type="System.Drawing.Size, System.Drawing">
     <value>39, 20</value>
@@ -2824,10 +2653,10 @@
     <value>NoControl</value>
   </data>
   <data name="bnLight1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>814, 33</value>
+    <value>807, 33</value>
   </data>
   <data name="bnLight1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>79, 22</value>
+    <value>86, 22</value>
   </data>
   <data name="bnLight1.TabIndex" type="System.Int32, mscorlib">
     <value>50</value>
@@ -2854,10 +2683,10 @@
     <value>NoControl</value>
   </data>
   <data name="bnLight2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>814, 61</value>
+    <value>807, 61</value>
   </data>
   <data name="bnLight2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>79, 22</value>
+    <value>86, 22</value>
   </data>
   <data name="bnLight2.TabIndex" type="System.Int32, mscorlib">
     <value>51</value>
@@ -2884,10 +2713,10 @@
     <value>NoControl</value>
   </data>
   <data name="bnLight4.Location" type="System.Drawing.Point, System.Drawing">
-    <value>814, 117</value>
+    <value>807, 117</value>
   </data>
   <data name="bnLight4.Size" type="System.Drawing.Size, System.Drawing">
-    <value>79, 22</value>
+    <value>86, 22</value>
   </data>
   <data name="bnLight4.TabIndex" type="System.Int32, mscorlib">
     <value>52</value>
@@ -2917,7 +2746,7 @@
     <value>NoControl</value>
   </data>
   <data name="lbLinkProfile.Location" type="System.Drawing.Point, System.Drawing">
-    <value>580, 0</value>
+    <value>573, 0</value>
   </data>
   <data name="lbLinkProfile.Size" type="System.Drawing.Size, System.Drawing">
     <value>67, 30</value>
@@ -2956,7 +2785,7 @@
     <value>NoControl</value>
   </data>
   <data name="linkCB1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>606, 37</value>
+    <value>599, 37</value>
   </data>
   <data name="linkCB1.Size" type="System.Drawing.Size, System.Drawing">
     <value>15, 14</value>
@@ -2989,7 +2818,7 @@
     <value>NoControl</value>
   </data>
   <data name="linkCB2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>606, 65</value>
+    <value>599, 65</value>
   </data>
   <data name="linkCB2.Size" type="System.Drawing.Size, System.Drawing">
     <value>15, 14</value>
@@ -3022,7 +2851,7 @@
     <value>NoControl</value>
   </data>
   <data name="linkCB3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>606, 93</value>
+    <value>599, 93</value>
   </data>
   <data name="linkCB3.Size" type="System.Drawing.Size, System.Drawing">
     <value>15, 14</value>
@@ -3055,7 +2884,7 @@
     <value>NoControl</value>
   </data>
   <data name="linkCB4.Location" type="System.Drawing.Point, System.Drawing">
-    <value>606, 121</value>
+    <value>599, 121</value>
   </data>
   <data name="linkCB4.Size" type="System.Drawing.Size, System.Drawing">
     <value>15, 14</value>
@@ -3663,6 +3492,339 @@
   <data name="&gt;&gt;cBFlashWhenLate.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
+  <data name="cBUpdateTime.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="cBUpdateTime.Items" xml:space="preserve">
+    <value>hours</value>
+  </data>
+  <data name="cBUpdateTime.Items1" xml:space="preserve">
+    <value>days</value>
+  </data>
+  <data name="cBUpdateTime.Location" type="System.Drawing.Point, System.Drawing">
+    <value>126, 0</value>
+  </data>
+  <data name="cBUpdateTime.Size" type="System.Drawing.Size, System.Drawing">
+    <value>60, 21</value>
+  </data>
+  <data name="cBUpdateTime.TabIndex" type="System.Int32, mscorlib">
+    <value>43</value>
+  </data>
+  <data name="&gt;&gt;cBUpdateTime.Name" xml:space="preserve">
+    <value>cBUpdateTime</value>
+  </data>
+  <data name="&gt;&gt;cBUpdateTime.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cBUpdateTime.Parent" xml:space="preserve">
+    <value>pNUpdate</value>
+  </data>
+  <data name="&gt;&gt;cBUpdateTime.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="lbCheckEvery.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="lbCheckEvery.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lbCheckEvery.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lbCheckEvery.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 3</value>
+  </data>
+  <data name="lbCheckEvery.Size" type="System.Drawing.Size, System.Drawing">
+    <value>67, 13</value>
+  </data>
+  <data name="lbCheckEvery.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="lbCheckEvery.Text" xml:space="preserve">
+    <value>Check every</value>
+  </data>
+  <data name="&gt;&gt;lbCheckEvery.Name" xml:space="preserve">
+    <value>lbCheckEvery</value>
+  </data>
+  <data name="&gt;&gt;lbCheckEvery.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lbCheckEvery.Parent" xml:space="preserve">
+    <value>pNUpdate</value>
+  </data>
+  <data name="&gt;&gt;lbCheckEvery.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="nUDUpdateTime.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="nUDUpdateTime.Location" type="System.Drawing.Point, System.Drawing">
+    <value>76, 1</value>
+  </data>
+  <data name="nUDUpdateTime.Size" type="System.Drawing.Size, System.Drawing">
+    <value>44, 20</value>
+  </data>
+  <data name="nUDUpdateTime.TabIndex" type="System.Int32, mscorlib">
+    <value>42</value>
+  </data>
+  <data name="&gt;&gt;nUDUpdateTime.Name" xml:space="preserve">
+    <value>nUDUpdateTime</value>
+  </data>
+  <data name="&gt;&gt;nUDUpdateTime.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nUDUpdateTime.Parent" xml:space="preserve">
+    <value>pNUpdate</value>
+  </data>
+  <data name="&gt;&gt;nUDUpdateTime.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="lbUseXIPorts.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="lbUseXIPorts.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lbUseXIPorts.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lbUseXIPorts.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 3</value>
+  </data>
+  <data name="lbUseXIPorts.Size" type="System.Drawing.Size, System.Drawing">
+    <value>86, 13</value>
+  </data>
+  <data name="lbUseXIPorts.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="lbUseXIPorts.Text" xml:space="preserve">
+    <value>Use Xinput Ports</value>
+  </data>
+  <data name="&gt;&gt;lbUseXIPorts.Name" xml:space="preserve">
+    <value>lbUseXIPorts</value>
+  </data>
+  <data name="&gt;&gt;lbUseXIPorts.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lbUseXIPorts.Parent" xml:space="preserve">
+    <value>pnlXIPorts</value>
+  </data>
+  <data name="&gt;&gt;lbUseXIPorts.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="nUDXIPorts.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="nUDXIPorts.Location" type="System.Drawing.Point, System.Drawing">
+    <value>100, 1</value>
+  </data>
+  <data name="nUDXIPorts.Size" type="System.Drawing.Size, System.Drawing">
+    <value>44, 20</value>
+  </data>
+  <data name="nUDXIPorts.TabIndex" type="System.Int32, mscorlib">
+    <value>42</value>
+  </data>
+  <data name="&gt;&gt;nUDXIPorts.Name" xml:space="preserve">
+    <value>nUDXIPorts</value>
+  </data>
+  <data name="&gt;&gt;nUDXIPorts.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nUDXIPorts.Parent" xml:space="preserve">
+    <value>pnlXIPorts</value>
+  </data>
+  <data name="&gt;&gt;nUDXIPorts.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="lbLastXIPort.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="lbLastXIPort.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lbLastXIPort.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lbLastXIPort.Location" type="System.Drawing.Point, System.Drawing">
+    <value>150, 3</value>
+  </data>
+  <data name="lbLastXIPort.Size" type="System.Drawing.Size, System.Drawing">
+    <value>19, 13</value>
+  </data>
+  <data name="lbLastXIPort.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="lbLastXIPort.Text" xml:space="preserve">
+    <value>- 4</value>
+  </data>
+  <data name="&gt;&gt;lbLastXIPort.Name" xml:space="preserve">
+    <value>lbLastXIPort</value>
+  </data>
+  <data name="&gt;&gt;lbLastXIPort.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lbLastXIPort.Parent" xml:space="preserve">
+    <value>pnlXIPorts</value>
+  </data>
+  <data name="&gt;&gt;lbLastXIPort.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="linkProfiles.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="linkProfiles.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="linkProfiles.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 0</value>
+  </data>
+  <data name="linkProfiles.Size" type="System.Drawing.Size, System.Drawing">
+    <value>65, 13</value>
+  </data>
+  <data name="linkProfiles.TabIndex" type="System.Int32, mscorlib">
+    <value>50</value>
+  </data>
+  <data name="linkProfiles.Text" xml:space="preserve">
+    <value>Profile folder</value>
+  </data>
+  <data name="&gt;&gt;linkProfiles.Name" xml:space="preserve">
+    <value>linkProfiles</value>
+  </data>
+  <data name="&gt;&gt;linkProfiles.Type" xml:space="preserve">
+    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;linkProfiles.Parent" xml:space="preserve">
+    <value>flowLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;linkProfiles.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="lnkControllers.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lnkControllers.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lnkControllers.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 13</value>
+  </data>
+  <data name="lnkControllers.Size" type="System.Drawing.Size, System.Drawing">
+    <value>70, 13</value>
+  </data>
+  <data name="lnkControllers.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
+  </data>
+  <data name="lnkControllers.Text" xml:space="preserve">
+    <value>Control Panel</value>
+  </data>
+  <data name="&gt;&gt;lnkControllers.Name" xml:space="preserve">
+    <value>lnkControllers</value>
+  </data>
+  <data name="&gt;&gt;lnkControllers.Type" xml:space="preserve">
+    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lnkControllers.Parent" xml:space="preserve">
+    <value>flowLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;lnkControllers.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="linkUninstall.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="linkUninstall.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="linkUninstall.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 26</value>
+  </data>
+  <data name="linkUninstall.Size" type="System.Drawing.Size, System.Drawing">
+    <value>106, 13</value>
+  </data>
+  <data name="linkUninstall.TabIndex" type="System.Int32, mscorlib">
+    <value>44</value>
+  </data>
+  <data name="linkUninstall.Text" xml:space="preserve">
+    <value>Uninstall VBus Driver</value>
+  </data>
+  <data name="linkUninstall.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleCenter</value>
+  </data>
+  <data name="&gt;&gt;linkUninstall.Name" xml:space="preserve">
+    <value>linkUninstall</value>
+  </data>
+  <data name="&gt;&gt;linkUninstall.Type" xml:space="preserve">
+    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;linkUninstall.Parent" xml:space="preserve">
+    <value>flowLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;linkUninstall.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="linkSetup.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="linkSetup.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="linkSetup.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 39</value>
+  </data>
+  <data name="linkSetup.Size" type="System.Drawing.Size, System.Drawing">
+    <value>115, 13</value>
+  </data>
+  <data name="linkSetup.TabIndex" type="System.Int32, mscorlib">
+    <value>52</value>
+  </data>
+  <data name="linkSetup.Text" xml:space="preserve">
+    <value>Controller/Driver Setup</value>
+  </data>
+  <data name="&gt;&gt;linkSetup.Name" xml:space="preserve">
+    <value>linkSetup</value>
+  </data>
+  <data name="&gt;&gt;linkSetup.Type" xml:space="preserve">
+    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;linkSetup.Parent" xml:space="preserve">
+    <value>flowLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;linkSetup.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="lLBUpdate.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lLBUpdate.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lLBUpdate.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 52</value>
+  </data>
+  <data name="lLBUpdate.Size" type="System.Drawing.Size, System.Drawing">
+    <value>116, 13</value>
+  </data>
+  <data name="lLBUpdate.TabIndex" type="System.Int32, mscorlib">
+    <value>49</value>
+  </data>
+  <data name="lLBUpdate.Text" xml:space="preserve">
+    <value>Check for Update Now</value>
+  </data>
+  <data name="lLBUpdate.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleCenter</value>
+  </data>
+  <data name="&gt;&gt;lLBUpdate.Name" xml:space="preserve">
+    <value>lLBUpdate</value>
+  </data>
+  <data name="&gt;&gt;lLBUpdate.Type" xml:space="preserve">
+    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lLBUpdate.Parent" xml:space="preserve">
+    <value>flowLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;lLBUpdate.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
   <data name="&gt;&gt;exportLogTxtBtn.Name" xml:space="preserve">
     <value>exportLogTxtBtn</value>
   </data>
@@ -4063,7 +4225,7 @@
     <value>advColorDialog</value>
   </data>
   <data name="&gt;&gt;advColorDialog.Type" xml:space="preserve">
-    <value>DS4Windows.AdvancedColorDialog, DS4Windows, Version=1.4.101.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>DS4Windows.AdvancedColorDialog, DS4Windows, Version=1.4.106.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>DS4Form</value>

--- a/DS4Windows/DS4Forms/DS4Form.ru-RU.resx
+++ b/DS4Windows/DS4Forms/DS4Form.ru-RU.resx
@@ -117,24 +117,93 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="chTime.Text" xml:space="preserve">
-    <value>Время</value>
-  </data>
-  <data name="chData.Text" xml:space="preserve">
-    <value>Дата</value>
-  </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="llbHelp.Location" type="System.Drawing.Point, System.Drawing">
-    <value>718, 8</value>
+  <data name="assignToController1ToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>238, 22</value>
   </data>
-  <data name="llbHelp.Size" type="System.Drawing.Size, System.Drawing">
-    <value>174, 13</value>
+  <data name="assignToController1ToolStripMenuItem.Text" xml:space="preserve">
+    <value>Присвоить 1-му контроллеру</value>
   </data>
-  <data name="llbHelp.Text" xml:space="preserve">
-    <value>Горячие клавиши / О программе</value>
+  <data name="assignToController2ToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>238, 22</value>
   </data>
-  <data name="lbTest.Location" type="System.Drawing.Point, System.Drawing">
-    <value>600, 8</value>
+  <data name="assignToController2ToolStripMenuItem.Text" xml:space="preserve">
+    <value>Присвоить 2-му контроллеру</value>
+  </data>
+  <data name="assignToController3ToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>238, 22</value>
+  </data>
+  <data name="assignToController3ToolStripMenuItem.Text" xml:space="preserve">
+    <value>Присвоить 3-му контроллеру</value>
+  </data>
+  <data name="assignToController4ToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>238, 22</value>
+  </data>
+  <data name="assignToController4ToolStripMenuItem.Text" xml:space="preserve">
+    <value>Присвоить 4-му контроллеру</value>
+  </data>
+  <data name="bnEditC1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>639, 33</value>
+  </data>
+  <data name="bnEditC1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>129, 26</value>
+  </data>
+  <data name="bnEditC1.Text" xml:space="preserve">
+    <value>Редактировать</value>
+  </data>
+  <data name="bnEditC2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>639, 65</value>
+  </data>
+  <data name="bnEditC2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>129, 26</value>
+  </data>
+  <data name="bnEditC2.Text" xml:space="preserve">
+    <value>Редактировать</value>
+  </data>
+  <data name="bnEditC3.Location" type="System.Drawing.Point, System.Drawing">
+    <value>639, 97</value>
+  </data>
+  <data name="bnEditC3.Size" type="System.Drawing.Size, System.Drawing">
+    <value>129, 26</value>
+  </data>
+  <data name="bnEditC3.Text" xml:space="preserve">
+    <value>Редактировать</value>
+  </data>
+  <data name="bnEditC4.Location" type="System.Drawing.Point, System.Drawing">
+    <value>639, 129</value>
+  </data>
+  <data name="bnEditC4.Size" type="System.Drawing.Size, System.Drawing">
+    <value>129, 28</value>
+  </data>
+  <data name="bnEditC4.Text" xml:space="preserve">
+    <value>Редактировать</value>
+  </data>
+  <data name="bnLight1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>774, 33</value>
+  </data>
+  <data name="bnLight1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>119, 26</value>
+  </data>
+  <data name="bnLight2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>774, 65</value>
+  </data>
+  <data name="bnLight2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>119, 26</value>
+  </data>
+  <data name="bnLight3.Location" type="System.Drawing.Point, System.Drawing">
+    <value>774, 97</value>
+  </data>
+  <data name="bnLight3.Size" type="System.Drawing.Size, System.Drawing">
+    <value>119, 26</value>
+  </data>
+  <data name="bnLight4.Location" type="System.Drawing.Point, System.Drawing">
+    <value>774, 129</value>
+  </data>
+  <data name="bnLight4.Size" type="System.Drawing.Size, System.Drawing">
+    <value>119, 29</value>
+  </data>
+  <data name="btnClear.Text" xml:space="preserve">
+    <value>Очистить журнал</value>
   </data>
   <data name="btnStartStop.Location" type="System.Drawing.Point, System.Drawing">
     <value>1024, 5</value>
@@ -145,11 +214,341 @@
   <data name="btnStartStop.Text" xml:space="preserve">
     <value>Запустить</value>
   </data>
-  <data name="lbLastMessage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>681, 18</value>
+  <data name="cBCloseMini.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 279</value>
+  </data>
+  <data name="cBCloseMini.Size" type="System.Drawing.Size, System.Drawing">
+    <value>200, 17</value>
+  </data>
+  <data name="cBCloseMini.Text" xml:space="preserve">
+    <value>При закрытии сворачивать в трей</value>
+  </data>
+  <data name="cBController1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>503, 35</value>
+  </data>
+  <data name="cBController2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>503, 67</value>
+  </data>
+  <data name="cBController3.Location" type="System.Drawing.Point, System.Drawing">
+    <value>503, 99</value>
+  </data>
+  <data name="cBController4.Location" type="System.Drawing.Point, System.Drawing">
+    <value>503, 133</value>
+  </data>
+  <data name="cBDisconnectBT.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 222</value>
+  </data>
+  <data name="cBDisconnectBT.Size" type="System.Drawing.Size, System.Drawing">
+    <value>249, 17</value>
+  </data>
+  <data name="cBDisconnectBT.Text" xml:space="preserve">
+    <value>Отключать от Bluetooth во время остановки</value>
+  </data>
+  <data name="cBDownloadLangauge.Location" type="System.Drawing.Point, System.Drawing">
+    <value>463, 10</value>
+  </data>
+  <data name="cBDownloadLangauge.Size" type="System.Drawing.Size, System.Drawing">
+    <value>264, 17</value>
+  </data>
+  <data name="cBDownloadLangauge.Text" xml:space="preserve">
+    <value>Загружать язык. пакет вместе с обновлением</value>
+  </data>
+  <data name="cBFlashWhenLate.Size" type="System.Drawing.Size, System.Drawing">
+    <value>281, 17</value>
+  </data>
+  <data name="cBFlashWhenLate.Text" xml:space="preserve">
+    <value>Мигать световой панелью при высокой задержке</value>
+  </data>
+  <data name="cBoxNotifications.Items" xml:space="preserve">
+    <value>никаких</value>
+  </data>
+  <data name="cBoxNotifications.Items1" xml:space="preserve">
+    <value>только предупреждения</value>
+  </data>
+  <data name="cBoxNotifications.Items2" xml:space="preserve">
+    <value>все</value>
+  </data>
+  <data name="cBoxNotifications.Location" type="System.Drawing.Point, System.Drawing">
+    <value>185, 1</value>
+  </data>
+  <data name="cBQuickCharge.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 302</value>
+  </data>
+  <data name="cBQuickCharge.Size" type="System.Drawing.Size, System.Drawing">
+    <value>115, 17</value>
+  </data>
+  <data name="cBQuickCharge.Text" xml:space="preserve">
+    <value>Быстрая зарядка</value>
+  </data>
+  <data name="cBSwipeProfiles.Size" type="System.Drawing.Size, System.Drawing">
+    <value>275, 17</value>
+  </data>
+  <data name="cBSwipeProfiles.Text" xml:space="preserve">
+    <value>Жест смахивания на тачпаде изменяет профиль</value>
+  </data>
+  <data name="cBUpdate.Location" type="System.Drawing.Point, System.Drawing">
+    <value>463, 33</value>
+  </data>
+  <data name="cBUpdate.Size" type="System.Drawing.Size, System.Drawing">
+    <value>209, 17</value>
+  </data>
+  <data name="cBUpdate.Text" xml:space="preserve">
+    <value>Проверять обновления при запуске</value>
+  </data>
+  <data name="cBUpdateTime.Items" xml:space="preserve">
+    <value>час.</value>
+  </data>
+  <data name="cBUpdateTime.Items1" xml:space="preserve">
+    <value>дн.</value>
+  </data>
+  <data name="cBUpdateTime.Location" type="System.Drawing.Point, System.Drawing">
+    <value>211, 0</value>
+  </data>
+  <data name="cBUseWhiteIcon.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 324</value>
+  </data>
+  <data name="chData.Text" xml:space="preserve">
+    <value>Дата</value>
+  </data>
+  <data name="chTime.Text" xml:space="preserve">
+    <value>Время</value>
+  </data>
+  <data name="cMCustomLed.Size" type="System.Drawing.Size, System.Drawing">
+    <value>232, 48</value>
+  </data>
+  <data name="cMProfile.Size" type="System.Drawing.Size, System.Drawing">
+    <value>239, 224</value>
   </data>
   <data name="cMTaskbar.Size" type="System.Drawing.Size, System.Drawing">
     <value>268, 164</value>
+  </data>
+  <data name="deleteToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>238, 22</value>
+  </data>
+  <data name="deleteToolStripMenuItem.Text" xml:space="preserve">
+    <value>Удалить (Del)</value>
+  </data>
+  <data name="duplicateToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>238, 22</value>
+  </data>
+  <data name="duplicateToolStripMenuItem.Text" xml:space="preserve">
+    <value>Дублировать (Ctrl+D)</value>
+  </data>
+  <data name="editProfileForController1ToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>267, 22</value>
+  </data>
+  <data name="editProfileForController1ToolStripMenuItem.Text" xml:space="preserve">
+    <value>Редакт. профиль 1-го контроллера</value>
+  </data>
+  <data name="editProfileForController2ToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>267, 22</value>
+  </data>
+  <data name="editProfileForController2ToolStripMenuItem.Text" xml:space="preserve">
+    <value>Редакт. профиль 2-го контроллера</value>
+  </data>
+  <data name="editProfileForController3ToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>267, 22</value>
+  </data>
+  <data name="editProfileForController3ToolStripMenuItem.Text" xml:space="preserve">
+    <value>Редакт. профиль 3-го контроллера</value>
+  </data>
+  <data name="editProfileForController4ToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>267, 22</value>
+  </data>
+  <data name="editProfileForController4ToolStripMenuItem.Text" xml:space="preserve">
+    <value>Редакт. профиль 4-го контроллера</value>
+  </data>
+  <data name="editToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>238, 22</value>
+  </data>
+  <data name="editToolStripMenuItem.Text" xml:space="preserve">
+    <value>Редактировать</value>
+  </data>
+  <data name="exitToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>267, 22</value>
+  </data>
+  <data name="exitToolStripMenuItem.Text" xml:space="preserve">
+    <value>Выход (ср. кнопка мыши)</value>
+  </data>
+  <data name="exportToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>238, 22</value>
+  </data>
+  <data name="exportToolStripMenuItem.Text" xml:space="preserve">
+    <value>Экспорт</value>
+  </data>
+  <data name="flowLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>463, 112</value>
+  </data>
+  <data name="flowLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>182, 65</value>
+  </data>
+  <data name="hideDS4CheckBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>159, 17</value>
+  </data>
+  <data name="hideDS4CheckBox.Text" xml:space="preserve">
+    <value>Спрятать контроллер DS4</value>
+  </data>
+  <data name="importToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>238, 22</value>
+  </data>
+  <data name="importToolStripMenuItem.Text" xml:space="preserve">
+    <value>Импорт</value>
+  </data>
+  <data name="languagePackComboBox1.InvariantCultureText" xml:space="preserve">
+    <value>Нет (английский интерфейс)</value>
+  </data>
+  <data name="languagePackComboBox1.LabelText" xml:space="preserve">
+    <value>Языковой пакет</value>
+  </data>
+  <data name="lbBatt1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>329, 38</value>
+  </data>
+  <data name="lbBatt2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>329, 70</value>
+  </data>
+  <data name="lbBatt3.Location" type="System.Drawing.Point, System.Drawing">
+    <value>329, 102</value>
+  </data>
+  <data name="lbBatt4.Location" type="System.Drawing.Point, System.Drawing">
+    <value>329, 136</value>
+  </data>
+  <data name="lbBattery.Location" type="System.Drawing.Point, System.Drawing">
+    <value>303, 7</value>
+  </data>
+  <data name="lbBattery.Size" type="System.Drawing.Size, System.Drawing">
+    <value>91, 15</value>
+  </data>
+  <data name="lbBattery.Text" xml:space="preserve">
+    <value>Аккумулятор</value>
+  </data>
+  <data name="lbCheckEvery.Size" type="System.Drawing.Size, System.Drawing">
+    <value>105, 13</value>
+  </data>
+  <data name="lbCheckEvery.Text" xml:space="preserve">
+    <value>Проверять каждые</value>
+  </data>
+  <data name="lbID.Size" type="System.Drawing.Size, System.Drawing">
+    <value>101, 15</value>
+  </data>
+  <data name="lbID.Text" xml:space="preserve">
+    <value>ID устройства</value>
+  </data>
+  <data name="lbLastMessage.Size" type="System.Drawing.Size, System.Drawing">
+    <value>681, 18</value>
+  </data>
+  <data name="lbLastXIPort.Location" type="System.Drawing.Point, System.Drawing">
+    <value>235, 3</value>
+  </data>
+  <data name="lbLinkProfile.Location" type="System.Drawing.Point, System.Drawing">
+    <value>408, 0</value>
+  </data>
+  <data name="lbMsLatency.Location" type="System.Drawing.Point, System.Drawing">
+    <value>418, 5</value>
+  </data>
+  <data name="lbNoControllers.Text" xml:space="preserve">
+    <value>Контроллеры не подключены (макс. не больше четырёх)</value>
+  </data>
+  <data name="lbNotifications.Size" type="System.Drawing.Size, System.Drawing">
+    <value>129, 13</value>
+  </data>
+  <data name="lbNotifications.Text" xml:space="preserve">
+    <value>Показать уведомления:</value>
+  </data>
+  <data name="lbPad1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 38</value>
+  </data>
+  <data name="lbPad2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 70</value>
+  </data>
+  <data name="lbPad3.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 102</value>
+  </data>
+  <data name="lbPad4.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 136</value>
+  </data>
+  <data name="lbSelectedProfile.Location" type="System.Drawing.Point, System.Drawing">
+    <value>485, 7</value>
+  </data>
+  <data name="lbSelectedProfile.Size" type="System.Drawing.Size, System.Drawing">
+    <value>148, 15</value>
+  </data>
+  <data name="lbSelectedProfile.Text" xml:space="preserve">
+    <value>Выбранный профиль</value>
+  </data>
+  <data name="lbStatus.Location" type="System.Drawing.Point, System.Drawing">
+    <value>194, 0</value>
+  </data>
+  <data name="lbStatus.Size" type="System.Drawing.Size, System.Drawing">
+    <value>95, 30</value>
+  </data>
+  <data name="lbStatus.Text" xml:space="preserve">
+    <value>Тип подключения</value>
+  </data>
+  <data name="lbTest.Location" type="System.Drawing.Point, System.Drawing">
+    <value>600, 8</value>
+  </data>
+  <data name="lbUseXIPorts.Size" type="System.Drawing.Size, System.Drawing">
+    <value>143, 13</value>
+  </data>
+  <data name="lbUseXIPorts.Text" xml:space="preserve">
+    <value>Использовать порт XInput:</value>
+  </data>
+  <data name="linkCB1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>434, 39</value>
+  </data>
+  <data name="linkCB2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>434, 71</value>
+  </data>
+  <data name="linkCB3.Location" type="System.Drawing.Point, System.Drawing">
+    <value>434, 103</value>
+  </data>
+  <data name="linkCB4.Location" type="System.Drawing.Point, System.Drawing">
+    <value>434, 136</value>
+  </data>
+  <data name="linkProfiles.Size" type="System.Drawing.Size, System.Drawing">
+    <value>153, 13</value>
+  </data>
+  <data name="linkProfiles.Text" xml:space="preserve">
+    <value>Открыть папку с профилями</value>
+  </data>
+  <data name="linkSetup.Size" type="System.Drawing.Size, System.Drawing">
+    <value>176, 13</value>
+  </data>
+  <data name="linkSetup.Text" xml:space="preserve">
+    <value>Установить контроллер/драйвер</value>
+  </data>
+  <data name="linkUninstall.Size" type="System.Drawing.Size, System.Drawing">
+    <value>123, 13</value>
+  </data>
+  <data name="linkUninstall.Text" xml:space="preserve">
+    <value>Удалить драйвер VBus</value>
+  </data>
+  <data name="llbHelp.Location" type="System.Drawing.Point, System.Drawing">
+    <value>718, 8</value>
+  </data>
+  <data name="llbHelp.Size" type="System.Drawing.Size, System.Drawing">
+    <value>174, 13</value>
+  </data>
+  <data name="llbHelp.Text" xml:space="preserve">
+    <value>Горячие клавиши / О программе</value>
+  </data>
+  <data name="lLBUpdate.Size" type="System.Drawing.Size, System.Drawing">
+    <value>169, 13</value>
+  </data>
+  <data name="lLBUpdate.Text" xml:space="preserve">
+    <value>Проверить наличие обновлений</value>
+  </data>
+  <data name="lnkControllers.Size" type="System.Drawing.Size, System.Drawing">
+    <value>107, 13</value>
+  </data>
+  <data name="lnkControllers.Text" xml:space="preserve">
+    <value>Панель управления</value>
+  </data>
+  <data name="newProfileToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>238, 22</value>
+  </data>
+  <data name="newProfileToolStripMenuItem.Text" xml:space="preserve">
+    <value>Новый профиль</value>
   </data>
   <data name="notifyIcon1.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
@@ -6323,38 +6722,14 @@
         AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
 </value>
   </data>
-  <data name="editProfileForController1ToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>267, 22</value>
+  <data name="nUDLatency.Location" type="System.Drawing.Point, System.Drawing">
+    <value>355, 2</value>
   </data>
-  <data name="editProfileForController1ToolStripMenuItem.Text" xml:space="preserve">
-    <value>Редакт. профиль 1-го контроллера</value>
+  <data name="nUDUpdateTime.Location" type="System.Drawing.Point, System.Drawing">
+    <value>150, 0</value>
   </data>
-  <data name="editProfileForController2ToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>267, 22</value>
-  </data>
-  <data name="editProfileForController2ToolStripMenuItem.Text" xml:space="preserve">
-    <value>Редакт. профиль 2-го контроллера</value>
-  </data>
-  <data name="editProfileForController3ToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>267, 22</value>
-  </data>
-  <data name="editProfileForController3ToolStripMenuItem.Text" xml:space="preserve">
-    <value>Редакт. профиль 3-го контроллера</value>
-  </data>
-  <data name="editProfileForController4ToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>267, 22</value>
-  </data>
-  <data name="editProfileForController4ToolStripMenuItem.Text" xml:space="preserve">
-    <value>Редакт. профиль 4-го контроллера</value>
-  </data>
-  <data name="toolStripSeparator1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>264, 6</value>
-  </data>
-  <data name="startToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>267, 22</value>
-  </data>
-  <data name="startToolStripMenuItem.Text" xml:space="preserve">
-    <value>Запустить</value>
+  <data name="nUDXIPorts.Location" type="System.Drawing.Point, System.Drawing">
+    <value>185, 1</value>
   </data>
   <data name="openToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>267, 22</value>
@@ -6362,131 +6737,17 @@
   <data name="openToolStripMenuItem.Text" xml:space="preserve">
     <value>Открыть</value>
   </data>
-  <data name="exitToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>267, 22</value>
+  <data name="panel1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>321, 28</value>
   </data>
-  <data name="exitToolStripMenuItem.Text" xml:space="preserve">
-    <value>Выход (ср. кнопка мыши)</value>
+  <data name="panel2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 245</value>
   </data>
-  <data name="tabControllers.Text" xml:space="preserve">
-    <value>Контроллеры</value>
-  </data>
-  <data name="tLPControllers.Size" type="System.Drawing.Size, System.Drawing">
-    <value>896, 161</value>
-  </data>
-  <data name="bnLight3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>774, 97</value>
-  </data>
-  <data name="bnLight3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>119, 26</value>
+  <data name="panel2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>447, 28</value>
   </data>
   <data name="pBStatus1.Location" type="System.Drawing.Point, System.Drawing">
     <value>222, 36</value>
-  </data>
-  <data name="lbPad1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 38</value>
-  </data>
-  <data name="lbPad2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 70</value>
-  </data>
-  <data name="bnEditC3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>639, 97</value>
-  </data>
-  <data name="bnEditC3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>129, 26</value>
-  </data>
-  <data name="bnEditC3.Text" xml:space="preserve">
-    <value>Редактировать</value>
-  </data>
-  <data name="bnEditC4.Location" type="System.Drawing.Point, System.Drawing">
-    <value>639, 129</value>
-  </data>
-  <data name="bnEditC4.Size" type="System.Drawing.Size, System.Drawing">
-    <value>129, 28</value>
-  </data>
-  <data name="bnEditC4.Text" xml:space="preserve">
-    <value>Редактировать</value>
-  </data>
-  <data name="lbPad3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 102</value>
-  </data>
-  <data name="lbPad4.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 136</value>
-  </data>
-  <data name="cBController1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>503, 35</value>
-  </data>
-  <data name="bnEditC2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>639, 65</value>
-  </data>
-  <data name="bnEditC2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>129, 26</value>
-  </data>
-  <data name="bnEditC2.Text" xml:space="preserve">
-    <value>Редактировать</value>
-  </data>
-  <data name="cBController2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>503, 67</value>
-  </data>
-  <data name="cBController3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>503, 99</value>
-  </data>
-  <data name="bnEditC1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>639, 33</value>
-  </data>
-  <data name="bnEditC1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>129, 26</value>
-  </data>
-  <data name="bnEditC1.Text" xml:space="preserve">
-    <value>Редактировать</value>
-  </data>
-  <data name="cBController4.Location" type="System.Drawing.Point, System.Drawing">
-    <value>503, 133</value>
-  </data>
-  <data name="lbSelectedProfile.Location" type="System.Drawing.Point, System.Drawing">
-    <value>485, 7</value>
-  </data>
-  <data name="lbSelectedProfile.Size" type="System.Drawing.Size, System.Drawing">
-    <value>148, 15</value>
-  </data>
-  <data name="lbSelectedProfile.Text" xml:space="preserve">
-    <value>Выбранный профиль</value>
-  </data>
-  <data name="lbID.Size" type="System.Drawing.Size, System.Drawing">
-    <value>101, 15</value>
-  </data>
-  <data name="lbID.Text" xml:space="preserve">
-    <value>ID устройства</value>
-  </data>
-  <data name="lbStatus.Location" type="System.Drawing.Point, System.Drawing">
-    <value>194, 0</value>
-  </data>
-  <data name="lbStatus.Size" type="System.Drawing.Size, System.Drawing">
-    <value>95, 30</value>
-  </data>
-  <data name="lbStatus.Text" xml:space="preserve">
-    <value>Тип подключения</value>
-  </data>
-  <data name="lbBattery.Location" type="System.Drawing.Point, System.Drawing">
-    <value>303, 7</value>
-  </data>
-  <data name="lbBattery.Size" type="System.Drawing.Size, System.Drawing">
-    <value>91, 15</value>
-  </data>
-  <data name="lbBattery.Text" xml:space="preserve">
-    <value>Аккумулятор</value>
-  </data>
-  <data name="lbBatt1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>329, 38</value>
-  </data>
-  <data name="lbBatt2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>329, 70</value>
-  </data>
-  <data name="lbBatt3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>329, 102</value>
-  </data>
-  <data name="lbBatt4.Location" type="System.Drawing.Point, System.Drawing">
-    <value>329, 136</value>
   </data>
   <data name="pBStatus2.Location" type="System.Drawing.Point, System.Drawing">
     <value>222, 68</value>
@@ -6497,110 +6758,53 @@
   <data name="pBStatus4.Location" type="System.Drawing.Point, System.Drawing">
     <value>222, 133</value>
   </data>
-  <data name="bnLight1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>774, 33</value>
+  <data name="pnlXIPorts.Location" type="System.Drawing.Point, System.Drawing">
+    <value>463, 84</value>
   </data>
-  <data name="bnLight1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>119, 26</value>
+  <data name="pnlXIPorts.Size" type="System.Drawing.Size, System.Drawing">
+    <value>262, 22</value>
   </data>
-  <data name="bnLight2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>774, 65</value>
+  <data name="pNUpdate.Location" type="System.Drawing.Point, System.Drawing">
+    <value>463, 56</value>
   </data>
-  <data name="bnLight2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>119, 26</value>
+  <data name="pNUpdate.Size" type="System.Drawing.Size, System.Drawing">
+    <value>281, 22</value>
   </data>
-  <data name="bnLight4.Location" type="System.Drawing.Point, System.Drawing">
-    <value>774, 129</value>
+  <data name="startMinimizedCheckBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>138, 17</value>
   </data>
-  <data name="bnLight4.Size" type="System.Drawing.Size, System.Drawing">
-    <value>119, 29</value>
+  <data name="startMinimizedCheckBox.Text" xml:space="preserve">
+    <value>Запускать свёрнутым</value>
   </data>
-  <data name="lbLinkProfile.Location" type="System.Drawing.Point, System.Drawing">
-    <value>408, 0</value>
+  <data name="startToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>267, 22</value>
   </data>
-  <data name="linkCB1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>434, 39</value>
+  <data name="startToolStripMenuItem.Text" xml:space="preserve">
+    <value>Запустить</value>
   </data>
-  <data name="linkCB2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>434, 71</value>
+  <data name="StartWindowsCheckBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>196, 17</value>
   </data>
-  <data name="linkCB3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>434, 103</value>
+  <data name="StartWindowsCheckBox.Text" xml:space="preserve">
+    <value>Запускать при загрузке Windows</value>
   </data>
-  <data name="linkCB4.Location" type="System.Drawing.Point, System.Drawing">
-    <value>434, 136</value>
+  <data name="tabAutoProfiles.Text" xml:space="preserve">
+    <value>Автоматические профили</value>
   </data>
-  <data name="lbNoControllers.Text" xml:space="preserve">
-    <value>Контроллеры не подключены (макс. не больше четырёх)</value>
+  <data name="tabControllers.Text" xml:space="preserve">
+    <value>Контроллеры</value>
+  </data>
+  <data name="tabLog.Text" xml:space="preserve">
+    <value>Журнал</value>
   </data>
   <data name="tabProfiles.Text" xml:space="preserve">
     <value>Профили</value>
   </data>
-  <data name="cMProfile.Size" type="System.Drawing.Size, System.Drawing">
-    <value>239, 224</value>
+  <data name="tabSettings.Text" xml:space="preserve">
+    <value>Настройки</value>
   </data>
-  <data name="editToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>238, 22</value>
-  </data>
-  <data name="editToolStripMenuItem.Text" xml:space="preserve">
-    <value>Редактировать</value>
-  </data>
-  <data name="assignToController1ToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>238, 22</value>
-  </data>
-  <data name="assignToController1ToolStripMenuItem.Text" xml:space="preserve">
-    <value>Присвоить 1-му контроллеру</value>
-  </data>
-  <data name="assignToController2ToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>238, 22</value>
-  </data>
-  <data name="assignToController2ToolStripMenuItem.Text" xml:space="preserve">
-    <value>Присвоить 2-му контроллеру</value>
-  </data>
-  <data name="assignToController3ToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>238, 22</value>
-  </data>
-  <data name="assignToController3ToolStripMenuItem.Text" xml:space="preserve">
-    <value>Присвоить 3-му контроллеру</value>
-  </data>
-  <data name="assignToController4ToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>238, 22</value>
-  </data>
-  <data name="assignToController4ToolStripMenuItem.Text" xml:space="preserve">
-    <value>Присвоить 4-му контроллеру</value>
-  </data>
-  <data name="deleteToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>238, 22</value>
-  </data>
-  <data name="deleteToolStripMenuItem.Text" xml:space="preserve">
-    <value>Удалить (Del)</value>
-  </data>
-  <data name="duplicateToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>238, 22</value>
-  </data>
-  <data name="duplicateToolStripMenuItem.Text" xml:space="preserve">
-    <value>Дублировать (Ctrl+D)</value>
-  </data>
-  <data name="newProfileToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>238, 22</value>
-  </data>
-  <data name="newProfileToolStripMenuItem.Text" xml:space="preserve">
-    <value>Новый профиль</value>
-  </data>
-  <data name="importToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>238, 22</value>
-  </data>
-  <data name="importToolStripMenuItem.Text" xml:space="preserve">
-    <value>Импорт</value>
-  </data>
-  <data name="exportToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>238, 22</value>
-  </data>
-  <data name="exportToolStripMenuItem.Text" xml:space="preserve">
-    <value>Экспорт</value>
-  </data>
-  <data name="tSOptions.Text" xml:space="preserve">
-    <value>Настройки профиля</value>
+  <data name="tLPControllers.Size" type="System.Drawing.Size, System.Drawing">
+    <value>896, 161</value>
   </data>
   <data name="toolStripLabel1.Size" type="System.Drawing.Size, System.Drawing">
     <value>87, 24</value>
@@ -6608,44 +6812,14 @@
   <data name="toolStripLabel1.Text" xml:space="preserve">
     <value>Имя профиля:</value>
   </data>
-  <data name="tSTBProfile.Text" xml:space="preserve">
-    <value>&lt;введите сюда имя профиля&gt;</value>
-  </data>
-  <data name="tSBSaveProfile.Size" type="System.Drawing.Size, System.Drawing">
-    <value>142, 24</value>
-  </data>
-  <data name="tSBSaveProfile.Text" xml:space="preserve">
-    <value>Сохранить профиль</value>
+  <data name="toolStripSeparator1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>264, 6</value>
   </data>
   <data name="tSBCancel.Size" type="System.Drawing.Size, System.Drawing">
     <value>73, 24</value>
   </data>
   <data name="tSBCancel.Text" xml:space="preserve">
     <value>Отмена</value>
-  </data>
-  <data name="tSBKeepSize.Size" type="System.Drawing.Size, System.Drawing">
-    <value>260, 24</value>
-  </data>
-  <data name="tSBKeepSize.Text" xml:space="preserve">
-    <value>Запоминать размер окна после закрытия</value>
-  </data>
-  <data name="tsBNewProfle.Size" type="System.Drawing.Size, System.Drawing">
-    <value>69, 24</value>
-  </data>
-  <data name="tsBNewProfle.Text" xml:space="preserve">
-    <value>Новый</value>
-  </data>
-  <data name="tsBNewProfle.ToolTipText" xml:space="preserve">
-    <value>Создать новый профиль</value>
-  </data>
-  <data name="tsBEditProfile.Size" type="System.Drawing.Size, System.Drawing">
-    <value>111, 24</value>
-  </data>
-  <data name="tsBEditProfile.Text" xml:space="preserve">
-    <value>Редактировать</value>
-  </data>
-  <data name="tsBEditProfile.ToolTipText" xml:space="preserve">
-    <value>Редактировать выбранный профиль (Enter)</value>
   </data>
   <data name="tsBDeleteProfile.Size" type="System.Drawing.Size, System.Drawing">
     <value>75, 24</value>
@@ -6665,14 +6839,14 @@
   <data name="tSBDupProfile.ToolTipText" xml:space="preserve">
     <value>Сделать копию выбранного профиля (Ctrl+D)</value>
   </data>
-  <data name="tSBImportProfile.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 24</value>
+  <data name="tsBEditProfile.Size" type="System.Drawing.Size, System.Drawing">
+    <value>111, 24</value>
   </data>
-  <data name="tSBImportProfile.Text" xml:space="preserve">
-    <value>Импорт</value>
+  <data name="tsBEditProfile.Text" xml:space="preserve">
+    <value>Редактировать</value>
   </data>
-  <data name="tSBImportProfile.ToolTipText" xml:space="preserve">
-    <value>Импорт профиля или профилей</value>
+  <data name="tsBEditProfile.ToolTipText" xml:space="preserve">
+    <value>Редактировать выбранный профиль (Enter)</value>
   </data>
   <data name="tSBExportProfile.Size" type="System.Drawing.Size, System.Drawing">
     <value>76, 24</value>
@@ -6683,220 +6857,52 @@
   <data name="tSBExportProfile.ToolTipText" xml:space="preserve">
     <value>Экспорт выбранного профиля</value>
   </data>
-  <data name="tabAutoProfiles.Text" xml:space="preserve">
-    <value>Автоматические профили</value>
+  <data name="tSBImportProfile.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 24</value>
   </data>
-  <data name="tabSettings.Text" xml:space="preserve">
-    <value>Настройки</value>
+  <data name="tSBImportProfile.Text" xml:space="preserve">
+    <value>Импорт</value>
   </data>
-  <data name="hideDS4CheckBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>159, 17</value>
+  <data name="tSBImportProfile.ToolTipText" xml:space="preserve">
+    <value>Импорт профиля или профилей</value>
   </data>
-  <data name="hideDS4CheckBox.Text" xml:space="preserve">
-    <value>Спрятать контроллер DS4</value>
+  <data name="tSBKeepSize.Size" type="System.Drawing.Size, System.Drawing">
+    <value>260, 24</value>
   </data>
-  <data name="cBSwipeProfiles.Size" type="System.Drawing.Size, System.Drawing">
-    <value>275, 17</value>
+  <data name="tSBKeepSize.Text" xml:space="preserve">
+    <value>Запоминать размер окна после закрытия</value>
   </data>
-  <data name="cBSwipeProfiles.Text" xml:space="preserve">
-    <value>Жест смахивания на тачпаде изменяет профиль</value>
+  <data name="tsBNewProfle.Size" type="System.Drawing.Size, System.Drawing">
+    <value>69, 24</value>
   </data>
-  <data name="StartWindowsCheckBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>196, 17</value>
+  <data name="tsBNewProfle.Text" xml:space="preserve">
+    <value>Новый</value>
   </data>
-  <data name="StartWindowsCheckBox.Text" xml:space="preserve">
-    <value>Запускать при загрузке Windows</value>
+  <data name="tsBNewProfle.ToolTipText" xml:space="preserve">
+    <value>Создать новый профиль</value>
   </data>
-  <data name="startMinimizedCheckBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>138, 17</value>
+  <data name="tSBSaveProfile.Size" type="System.Drawing.Size, System.Drawing">
+    <value>142, 24</value>
   </data>
-  <data name="startMinimizedCheckBox.Text" xml:space="preserve">
-    <value>Запускать свёрнутым</value>
+  <data name="tSBSaveProfile.Text" xml:space="preserve">
+    <value>Сохранить профиль</value>
   </data>
-  <data name="panel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>321, 28</value>
+  <data name="tSOptions.Text" xml:space="preserve">
+    <value>Настройки профиля</value>
   </data>
-  <data name="lbNotifications.Size" type="System.Drawing.Size, System.Drawing">
-    <value>129, 13</value>
-  </data>
-  <data name="lbNotifications.Text" xml:space="preserve">
-    <value>Показать уведомления:</value>
-  </data>
-  <data name="cBoxNotifications.Items" xml:space="preserve">
-    <value>никаких</value>
-  </data>
-  <data name="cBoxNotifications.Items1" xml:space="preserve">
-    <value>только предупреждения</value>
-  </data>
-  <data name="cBoxNotifications.Items2" xml:space="preserve">
-    <value>все</value>
-  </data>
-  <data name="cBoxNotifications.Location" type="System.Drawing.Point, System.Drawing">
-    <value>185, 1</value>
-  </data>
-  <data name="cBDisconnectBT.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 222</value>
-  </data>
-  <data name="cBDisconnectBT.Size" type="System.Drawing.Size, System.Drawing">
-    <value>249, 17</value>
-  </data>
-  <data name="cBDisconnectBT.Text" xml:space="preserve">
-    <value>Отключать от Bluetooth во время остановки</value>
-  </data>
-  <data name="panel2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 245</value>
-  </data>
-  <data name="panel2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>447, 28</value>
-  </data>
-  <data name="nUDLatency.Location" type="System.Drawing.Point, System.Drawing">
-    <value>355, 2</value>
-  </data>
-  <data name="lbMsLatency.Location" type="System.Drawing.Point, System.Drawing">
-    <value>418, 5</value>
-  </data>
-  <data name="cBFlashWhenLate.Size" type="System.Drawing.Size, System.Drawing">
-    <value>281, 17</value>
-  </data>
-  <data name="cBFlashWhenLate.Text" xml:space="preserve">
-    <value>Мигать световой панелью при высокой задержке</value>
-  </data>
-  <data name="cBCloseMini.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 279</value>
-  </data>
-  <data name="cBCloseMini.Size" type="System.Drawing.Size, System.Drawing">
-    <value>200, 17</value>
-  </data>
-  <data name="cBCloseMini.Text" xml:space="preserve">
-    <value>При закрытии сворачивать в трей</value>
-  </data>
-  <data name="cBQuickCharge.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 302</value>
-  </data>
-  <data name="cBQuickCharge.Size" type="System.Drawing.Size, System.Drawing">
-    <value>115, 17</value>
-  </data>
-  <data name="cBQuickCharge.Text" xml:space="preserve">
-    <value>Быстрая зарядка</value>
-  </data>
-  <data name="cBUseWhiteIcon.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 324</value>
-  </data>
-  <data name="cBDownloadLangauge.Location" type="System.Drawing.Point, System.Drawing">
-    <value>463, 10</value>
-  </data>
-  <data name="cBDownloadLangauge.Size" type="System.Drawing.Size, System.Drawing">
-    <value>264, 17</value>
-  </data>
-  <data name="cBDownloadLangauge.Text" xml:space="preserve">
-    <value>Загружать язык. пакет вместе с обновлением</value>
-  </data>
-  <data name="cBUpdate.Location" type="System.Drawing.Point, System.Drawing">
-    <value>463, 33</value>
-  </data>
-  <data name="cBUpdate.Size" type="System.Drawing.Size, System.Drawing">
-    <value>209, 17</value>
-  </data>
-  <data name="cBUpdate.Text" xml:space="preserve">
-    <value>Проверять обновления при запуске</value>
-  </data>
-  <data name="pNUpdate.Location" type="System.Drawing.Point, System.Drawing">
-    <value>463, 56</value>
-  </data>
-  <data name="pNUpdate.Size" type="System.Drawing.Size, System.Drawing">
-    <value>281, 22</value>
-  </data>
-  <data name="cBUpdateTime.Items" xml:space="preserve">
-    <value>час.</value>
-  </data>
-  <data name="cBUpdateTime.Items1" xml:space="preserve">
-    <value>дн.</value>
-  </data>
-  <data name="cBUpdateTime.Location" type="System.Drawing.Point, System.Drawing">
-    <value>211, 0</value>
-  </data>
-  <data name="lbCheckEvery.Size" type="System.Drawing.Size, System.Drawing">
-    <value>105, 13</value>
-  </data>
-  <data name="lbCheckEvery.Text" xml:space="preserve">
-    <value>Проверять каждые</value>
-  </data>
-  <data name="nUDUpdateTime.Location" type="System.Drawing.Point, System.Drawing">
-    <value>150, 0</value>
-  </data>
-  <data name="pnlXIPorts.Location" type="System.Drawing.Point, System.Drawing">
-    <value>463, 84</value>
-  </data>
-  <data name="pnlXIPorts.Size" type="System.Drawing.Size, System.Drawing">
-    <value>262, 22</value>
-  </data>
-  <data name="lbUseXIPorts.Size" type="System.Drawing.Size, System.Drawing">
-    <value>143, 13</value>
-  </data>
-  <data name="lbUseXIPorts.Text" xml:space="preserve">
-    <value>Использовать порт XInput:</value>
-  </data>
-  <data name="nUDXIPorts.Location" type="System.Drawing.Point, System.Drawing">
-    <value>185, 1</value>
-  </data>
-  <data name="lbLastXIPort.Location" type="System.Drawing.Point, System.Drawing">
-    <value>235, 3</value>
-  </data>
-  <data name="flowLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>463, 112</value>
-  </data>
-  <data name="flowLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>182, 65</value>
-  </data>
-  <data name="linkProfiles.Size" type="System.Drawing.Size, System.Drawing">
-    <value>153, 13</value>
-  </data>
-  <data name="linkProfiles.Text" xml:space="preserve">
-    <value>Открыть папку с профилями</value>
-  </data>
-  <data name="lnkControllers.Size" type="System.Drawing.Size, System.Drawing">
-    <value>107, 13</value>
-  </data>
-  <data name="lnkControllers.Text" xml:space="preserve">
-    <value>Панель управления</value>
-  </data>
-  <data name="linkUninstall.Size" type="System.Drawing.Size, System.Drawing">
-    <value>123, 13</value>
-  </data>
-  <data name="linkUninstall.Text" xml:space="preserve">
-    <value>Удалить драйвер VBus</value>
-  </data>
-  <data name="linkSetup.Size" type="System.Drawing.Size, System.Drawing">
-    <value>176, 13</value>
-  </data>
-  <data name="linkSetup.Text" xml:space="preserve">
-    <value>Установить контроллер/драйвер</value>
-  </data>
-  <data name="lLBUpdate.Size" type="System.Drawing.Size, System.Drawing">
-    <value>169, 13</value>
-  </data>
-  <data name="lLBUpdate.Text" xml:space="preserve">
-    <value>Проверить наличие обновлений</value>
-  </data>
-  <data name="tabLog.Text" xml:space="preserve">
-    <value>Журнал</value>
-  </data>
-  <data name="btnClear.Text" xml:space="preserve">
-    <value>Очистить журнал</value>
-  </data>
-  <data name="cMCustomLed.Size" type="System.Drawing.Size, System.Drawing">
-    <value>232, 48</value>
-  </data>
-  <data name="useProfileColorToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>231, 22</value>
-  </data>
-  <data name="useProfileColorToolStripMenuItem.Text" xml:space="preserve">
-    <value>Использовать цвет профиля</value>
+  <data name="tSTBProfile.Text" xml:space="preserve">
+    <value>&lt;введите сюда имя профиля&gt;</value>
   </data>
   <data name="useCustomColorToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>231, 22</value>
   </data>
   <data name="useCustomColorToolStripMenuItem.Text" xml:space="preserve">
     <value>Использовать свой цвет</value>
+  </data>
+  <data name="useProfileColorToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>231, 22</value>
+  </data>
+  <data name="useProfileColorToolStripMenuItem.Text" xml:space="preserve">
+    <value>Использовать цвет профиля</value>
   </data>
 </root>

--- a/DS4Windows/DS4Forms/LanguagePackComboBox.Designer.cs
+++ b/DS4Windows/DS4Forms/LanguagePackComboBox.Designer.cs
@@ -28,42 +28,33 @@
         /// </summary>
         private void InitializeComponent()
         {
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(LanguagePackComboBox));
             this.cbCulture = new System.Windows.Forms.ComboBox();
             this.label1 = new System.Windows.Forms.Label();
             this.SuspendLayout();
             // 
             // cbCulture
             // 
-            this.cbCulture.Anchor = System.Windows.Forms.AnchorStyles.Right;
+            resources.ApplyResources(this.cbCulture, "cbCulture");
             this.cbCulture.DisplayMember = "Value";
             this.cbCulture.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cbCulture.FormattingEnabled = true;
-            this.cbCulture.Location = new System.Drawing.Point(112, 3);
             this.cbCulture.Name = "cbCulture";
-            this.cbCulture.Size = new System.Drawing.Size(145, 21);
-            this.cbCulture.TabIndex = 61;
             this.cbCulture.ValueMember = "Key";
             // 
             // label1
             // 
-            this.label1.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(3, 6);
+            resources.ApplyResources(this.label1, "label1");
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(100, 13);
-            this.label1.TabIndex = 62;
-            this.label1.Text = "Use language pack";
-            this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.label1.SizeChanged += new System.EventHandler(this.LanguagePackComboBox_SizeChanged);
             // 
             // LanguagePackComboBox
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            resources.ApplyResources(this, "$this");
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.cbCulture);
             this.Controls.Add(this.label1);
             this.Name = "LanguagePackComboBox";
-            this.Size = new System.Drawing.Size(260, 27);
             this.SizeChanged += new System.EventHandler(this.LanguagePackComboBox_SizeChanged);
             this.Resize += new System.EventHandler(this.LanguagePackComboBox_SizeChanged);
             this.ResumeLayout(false);

--- a/DS4Windows/DS4Forms/LanguagePackComboBox.Designer.cs
+++ b/DS4Windows/DS4Forms/LanguagePackComboBox.Designer.cs
@@ -1,0 +1,79 @@
+﻿namespace DS4Windows.DS4Forms
+{
+    partial class LanguagePackComboBox
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Код, автоматически созданный конструктором компонентов
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.cbCulture = new System.Windows.Forms.ComboBox();
+            this.label1 = new System.Windows.Forms.Label();
+            this.SuspendLayout();
+            // 
+            // cbCulture
+            // 
+            this.cbCulture.Anchor = System.Windows.Forms.AnchorStyles.Right;
+            this.cbCulture.DisplayMember = "Value";
+            this.cbCulture.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cbCulture.FormattingEnabled = true;
+            this.cbCulture.Location = new System.Drawing.Point(112, 3);
+            this.cbCulture.Name = "cbCulture";
+            this.cbCulture.Size = new System.Drawing.Size(145, 21);
+            this.cbCulture.TabIndex = 61;
+            this.cbCulture.ValueMember = "Key";
+            // 
+            // label1
+            // 
+            this.label1.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(3, 6);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(100, 13);
+            this.label1.TabIndex = 62;
+            this.label1.Text = "Use language pack";
+            this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.label1.SizeChanged += new System.EventHandler(this.LanguagePackComboBox_SizeChanged);
+            // 
+            // LanguagePackComboBox
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.cbCulture);
+            this.Controls.Add(this.label1);
+            this.Name = "LanguagePackComboBox";
+            this.Size = new System.Drawing.Size(260, 27);
+            this.SizeChanged += new System.EventHandler(this.LanguagePackComboBox_SizeChanged);
+            this.Resize += new System.EventHandler(this.LanguagePackComboBox_SizeChanged);
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.ComboBox cbCulture;
+        private System.Windows.Forms.Label label1;
+    }
+}

--- a/DS4Windows/DS4Forms/LanguagePackComboBox.cs
+++ b/DS4Windows/DS4Forms/LanguagePackComboBox.cs
@@ -13,6 +13,7 @@ namespace DS4Windows.DS4Forms
     public partial class LanguagePackComboBox : UserControl
     {
         private string _probingPath = "";
+        private string _languageAssemblyName = "DS4Windows.resources.dll";
 
         [Category("Action")]
         [Description("Fires when the combo box selected index is changed.")]
@@ -41,6 +42,14 @@ namespace DS4Windows.DS4Forms
         {
             get { return this._probingPath; }
             set { this._probingPath = value; }
+        }
+
+        [Category("Data")]
+        [Description("Filter language assembly file names in order to ont include irrelevant assemblies to the combo box.")]
+        public string LanguageAssemblyName
+        {
+            get { return this._languageAssemblyName; }
+            set { this._languageAssemblyName = value; }
         }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
@@ -89,7 +98,7 @@ namespace DS4Windows.DS4Forms
 
             // Get all culture for which satellite folder found with culture code.
             Dictionary<string, string> cultures = CultureInfo.GetCultures(CultureTypes.AllCultures)
-                .Where(c => this.IsLanguageAssemblyAvailable(lookupPaths, c))
+                .Where(c => c.Equals(CultureInfo.InvariantCulture) || this.IsLanguageAssemblyAvailable(lookupPaths, c))
                 .ToDictionary(c => c.Name, c => c.Equals(CultureInfo.InvariantCulture) ? this.InvariantCultureText : c.NativeName);
 
             return new BindingSource(cultures, null);
@@ -97,8 +106,8 @@ namespace DS4Windows.DS4Forms
 
         private bool IsLanguageAssemblyAvailable(List<string> lookupPaths, CultureInfo culture)
         {
-            return lookupPaths.Select(path => Path.Combine(path, culture.Name))
-                .Where(path => Directory.Exists(path))
+            return lookupPaths.Select(path => Path.Combine(path, culture.Name, this.LanguageAssemblyName))
+                .Where(path => File.Exists(path))
                 .Count() > 0;
         }
 

--- a/DS4Windows/DS4Forms/LanguagePackComboBox.cs
+++ b/DS4Windows/DS4Forms/LanguagePackComboBox.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Windows.Forms;
+
+namespace DS4Windows.DS4Forms
+{
+    public partial class LanguagePackComboBox : UserControl
+    {
+        [Category("Action")]
+        [Description("Fires when the combo box selected index is changed.")]
+        public event EventHandler SelectedIndexChanged;
+
+        [Category("Action")]
+        [Description("Fires when the combo box selected value is changed.")]
+        public event EventHandler SelectedValueChanged;
+
+        [Category("Data")]
+        [Description("Text used for invariant culture name in the combo box.")]
+        [Localizable(true)]
+        public string InvariantCultureText { get; set; }
+
+        [Category("Data")]
+        [Description("Text for label before the combo box.")]
+        [Localizable(true)]
+        public string LabelText {
+            get { return label1.Text; }
+            set { label1.Text = value; }
+        }
+
+        public int SelectedIndex
+        {
+            get { return cbCulture.SelectedIndex; }
+            set { cbCulture.SelectedIndex = value; }
+        }
+
+        public string SelectedText
+        {
+            get { return cbCulture.SelectedText; }
+            set { cbCulture.SelectedText = value; }
+        }
+
+        public object SelectedValue
+        {
+            get { return cbCulture.SelectedValue; }
+            set { cbCulture.SelectedValue = value; }
+        }
+
+        public LanguagePackComboBox()
+        {
+            InitializeComponent();
+
+            // Find the location where application installed.
+            string exeLocation = Path.GetDirectoryName(Uri.UnescapeDataString(new UriBuilder(Assembly.GetExecutingAssembly().CodeBase).Path));
+
+            // Get all culture for which satellite folder found with culture code.
+            Dictionary<string, string> cultures = CultureInfo.GetCultures(CultureTypes.AllCultures)
+                .Where(c => Directory.Exists(Path.Combine(exeLocation, c.Name)))
+                .ToDictionary(c => c.Name, c => c.Equals(CultureInfo.InvariantCulture) ? this.InvariantCultureText : c.NativeName);
+
+            cbCulture.DataSource = new BindingSource(cultures, null);
+            cbCulture.SelectedValue = Thread.CurrentThread.CurrentUICulture.Name;
+
+            // This must be set here instead of Designer or event would fire at initial selected value setting above.
+            cbCulture.SelectedIndexChanged += new EventHandler(CbCulture_SelectedIndexChanged);
+            cbCulture.SelectedValueChanged += new EventHandler(CbCulture_SelectedValueChanged);
+        }
+
+        private void LanguagePackComboBox_SizeChanged(object sender, EventArgs e)
+        {
+            cbCulture.Left = label1.Margin.Left + label1.Width + label1.Margin.Right;
+            cbCulture.Width = this.Width - cbCulture.Left - cbCulture.Margin.Right - cbCulture.Margin.Left;
+        }
+
+        private void CbCulture_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            
+            this.SelectedIndexChanged?.Invoke(this, e);
+            
+        }
+
+        private void CbCulture_SelectedValueChanged(object sender, EventArgs e)
+        {
+            this.SelectedValueChanged?.Invoke(this, e);
+        }
+    }
+}

--- a/DS4Windows/DS4Forms/LanguagePackComboBox.cs
+++ b/DS4Windows/DS4Forms/LanguagePackComboBox.cs
@@ -13,10 +13,8 @@ namespace DS4Windows.DS4Forms
 {
     public partial class LanguagePackComboBox : UserControl
     {
-        private string _invariantCultureText = "No (English UI)";
-        private string _languageAssemblyName = "DS4Windows.resources.dll";
-        private TaskCompletionSource<bool> _languageListInitialized = new TaskCompletionSource<bool>();
-        private string _probingPath = "";
+        private string InvariantCultureTextValue = "No (English UI)";
+        private TaskCompletionSource<bool> LanguageListInitialized = new TaskCompletionSource<bool>();
 
         [Category("Action")]
         [Description("Fires when the combo box selected index is changed.")]
@@ -31,10 +29,10 @@ namespace DS4Windows.DS4Forms
         [Localizable(true)]
         public string InvariantCultureText
         {
-            get { return _invariantCultureText; }
+            get { return InvariantCultureTextValue; }
             [System.Diagnostics.CodeAnalysis.SuppressMessage("InvariantCultureText_Changed call will complete when ready, no need for a warning", "CS4014:Await.Warning")]
             set {
-                _invariantCultureText = value;
+                InvariantCultureTextValue = value;
                 InvariantCultureText_Changed(value);
             }
         }
@@ -49,19 +47,11 @@ namespace DS4Windows.DS4Forms
 
         [Category("Data")]
         [Description("If probing path has been changed in App.config, add the same string here.")]
-        public string ProbingPath
-        {
-            get { return _probingPath; }
-            set { _probingPath = value; }
-        }
+        public string ProbingPath { get; set; } = "";
 
         [Category("Data")]
         [Description("Filter language assembly file names in order to ont include irrelevant assemblies to the combo box.")]
-        public string LanguageAssemblyName
-        {
-            get { return _languageAssemblyName; }
-            set { _languageAssemblyName = value; }
-        }
+        public string LanguageAssemblyName { get; set; } = "DS4Windows.resources.dll";
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public int SelectedIndex
@@ -99,7 +89,7 @@ namespace DS4Windows.DS4Forms
                 cbCulture.SelectedValueChanged += new EventHandler(CbCulture_SelectedValueChanged);
 
                 cbCulture.Enabled = true;
-                _languageListInitialized.SetResult(true);
+                LanguageListInitialized.SetResult(true);
             });
         }
 
@@ -133,7 +123,7 @@ namespace DS4Windows.DS4Forms
         private async Task InvariantCultureText_Changed(string value)
         {
             // Normally the completion flag will be long set by the time this method is called.
-            await _languageListInitialized.Task;
+            await LanguageListInitialized.Task;
             BindingSource dataSource = ((BindingSource)cbCulture.DataSource);
             dataSource[0] = new KeyValuePair<string, string>("", value);
         }

--- a/DS4Windows/DS4Forms/LanguagePackComboBox.cs
+++ b/DS4Windows/DS4Forms/LanguagePackComboBox.cs
@@ -14,9 +14,9 @@ namespace DS4Windows.DS4Forms
     public partial class LanguagePackComboBox : UserControl
     {
         private string _invariantCultureText = "No (English UI)";
-        private string _probingPath = "";
         private string _languageAssemblyName = "DS4Windows.resources.dll";
         private TaskCompletionSource<bool> _languageListInitialized = new TaskCompletionSource<bool>();
+        private string _probingPath = "";
 
         [Category("Action")]
         [Description("Fires when the combo box selected index is changed.")]
@@ -51,16 +51,16 @@ namespace DS4Windows.DS4Forms
         [Description("If probing path has been changed in App.config, add the same string here.")]
         public string ProbingPath
         {
-            get { return this._probingPath; }
-            set { this._probingPath = value; }
+            get { return _probingPath; }
+            set { _probingPath = value; }
         }
 
         [Category("Data")]
         [Description("Filter language assembly file names in order to ont include irrelevant assemblies to the combo box.")]
         public string LanguageAssemblyName
         {
-            get { return this._languageAssemblyName; }
-            set { this._languageAssemblyName = value; }
+            get { return _languageAssemblyName; }
+            set { _languageAssemblyName = value; }
         }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
@@ -91,7 +91,7 @@ namespace DS4Windows.DS4Forms
 
             Task.Run(() => {
                 // Find available language assemblies and bind the list to the combo box.
-                cbCulture.DataSource = this.CreateLanguageAssembliesBindingSource();
+                cbCulture.DataSource = CreateLanguageAssembliesBindingSource();
                 cbCulture.SelectedValue = Thread.CurrentThread.CurrentUICulture.Name;
 
                 // This must be set here instead of Designer or event would fire at initial selected value setting above.
@@ -107,7 +107,7 @@ namespace DS4Windows.DS4Forms
         {
             // Find the location where application installed.
             string exeLocation = Path.GetDirectoryName(Uri.UnescapeDataString(new UriBuilder(Assembly.GetExecutingAssembly().CodeBase).Path));
-            List<string> lookupPaths = this.ProbingPath.Split(';')
+            List<string> lookupPaths = ProbingPath.Split(';')
                 .Select(path => Path.Combine(exeLocation, path))
                 .Where(path => path != exeLocation)
                 .ToList();
@@ -115,17 +115,17 @@ namespace DS4Windows.DS4Forms
 
             // Get all culture for which satellite folder found with culture code, then insert invariant culture at the beginning.
             List<KeyValuePair<string, string>> cultures = CultureInfo.GetCultures(CultureTypes.AllCultures)
-                .Where(c => this.IsLanguageAssemblyAvailable(lookupPaths, c))
+                .Where(c => IsLanguageAssemblyAvailable(lookupPaths, c))
                 .Select(c => new KeyValuePair<string, string>(c.Name, c.NativeName))
                 .ToList();
-            cultures.Insert(0, new KeyValuePair<string, string>("", this.InvariantCultureText));
+            cultures.Insert(0, new KeyValuePair<string, string>("", InvariantCultureText));
 
             return new BindingSource(cultures, null);
         }
 
         private bool IsLanguageAssemblyAvailable(List<string> lookupPaths, CultureInfo culture)
         {
-            return lookupPaths.Select(path => Path.Combine(path, culture.Name, this.LanguageAssemblyName))
+            return lookupPaths.Select(path => Path.Combine(path, culture.Name, LanguageAssemblyName))
                 .Where(path => File.Exists(path))
                 .Count() > 0;
         }
@@ -141,17 +141,17 @@ namespace DS4Windows.DS4Forms
         private void LanguagePackComboBox_SizeChanged(object sender, EventArgs e)
         {
             cbCulture.Left = label1.Margin.Left + label1.Width + label1.Margin.Right;
-            cbCulture.Width = this.Width - cbCulture.Left - cbCulture.Margin.Right - cbCulture.Margin.Left;
+            cbCulture.Width = Width - cbCulture.Left - cbCulture.Margin.Right - cbCulture.Margin.Left;
         }
 
         private void CbCulture_SelectedIndexChanged(object sender, EventArgs e)
         {
-            this.SelectedIndexChanged?.Invoke(this, e);
+            SelectedIndexChanged?.Invoke(this, e);
         }
 
         private void CbCulture_SelectedValueChanged(object sender, EventArgs e)
         {
-            this.SelectedValueChanged?.Invoke(this, e);
+            SelectedValueChanged?.Invoke(this, e);
         }
     }
 }

--- a/DS4Windows/DS4Forms/LanguagePackComboBox.cs
+++ b/DS4Windows/DS4Forms/LanguagePackComboBox.cs
@@ -33,18 +33,21 @@ namespace DS4Windows.DS4Forms
             set { label1.Text = value; }
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public int SelectedIndex
         {
             get { return cbCulture.SelectedIndex; }
             set { cbCulture.SelectedIndex = value; }
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public string SelectedText
         {
             get { return cbCulture.SelectedText; }
             set { cbCulture.SelectedText = value; }
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public object SelectedValue
         {
             get { return cbCulture.SelectedValue; }

--- a/DS4Windows/DS4Forms/LanguagePackComboBox.cs
+++ b/DS4Windows/DS4Forms/LanguagePackComboBox.cs
@@ -119,9 +119,7 @@ namespace DS4Windows.DS4Forms
 
         private void CbCulture_SelectedIndexChanged(object sender, EventArgs e)
         {
-            
             this.SelectedIndexChanged?.Invoke(this, e);
-            
         }
 
         private void CbCulture_SelectedValueChanged(object sender, EventArgs e)

--- a/DS4Windows/DS4Forms/LanguagePackComboBox.cs
+++ b/DS4Windows/DS4Forms/LanguagePackComboBox.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
+using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace DS4Windows.DS4Forms
@@ -76,14 +77,19 @@ namespace DS4Windows.DS4Forms
         public LanguagePackComboBox()
         {
             InitializeComponent();
+            cbCulture.Enabled = false;
 
-            // Find available language assemblies and bind the list to the combo box.
-            cbCulture.DataSource = this.CreateLanguageAssembliesBindingSource();
-            cbCulture.SelectedValue = Thread.CurrentThread.CurrentUICulture.Name;
+            Task.Run(() => {
+                // Find available language assemblies and bind the list to the combo box.
+                cbCulture.DataSource = this.CreateLanguageAssembliesBindingSource();
+                cbCulture.SelectedValue = Thread.CurrentThread.CurrentUICulture.Name;
 
-            // This must be set here instead of Designer or event would fire at initial selected value setting above.
-            cbCulture.SelectedIndexChanged += new EventHandler(CbCulture_SelectedIndexChanged);
-            cbCulture.SelectedValueChanged += new EventHandler(CbCulture_SelectedValueChanged);
+                // This must be set here instead of Designer or event would fire at initial selected value setting above.
+                cbCulture.SelectedIndexChanged += new EventHandler(CbCulture_SelectedIndexChanged);
+                cbCulture.SelectedValueChanged += new EventHandler(CbCulture_SelectedValueChanged);
+
+                cbCulture.Enabled = true;
+            });
         }
 
         private BindingSource CreateLanguageAssembliesBindingSource()

--- a/DS4Windows/DS4Forms/LanguagePackComboBox.resx
+++ b/DS4Windows/DS4Forms/LanguagePackComboBox.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/DS4Windows/DS4Forms/LanguagePackComboBox.resx
+++ b/DS4Windows/DS4Forms/LanguagePackComboBox.resx
@@ -117,4 +117,79 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="cbCulture.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Right</value>
+  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="cbCulture.Location" type="System.Drawing.Point, System.Drawing">
+    <value>112, 3</value>
+  </data>
+  <data name="cbCulture.Size" type="System.Drawing.Size, System.Drawing">
+    <value>145, 21</value>
+  </data>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="cbCulture.TabIndex" type="System.Int32, mscorlib">
+    <value>61</value>
+  </data>
+  <data name="&gt;&gt;cbCulture.Name" xml:space="preserve">
+    <value>cbCulture</value>
+  </data>
+  <data name="&gt;&gt;cbCulture.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbCulture.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;cbCulture.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="label1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="label1.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 6</value>
+  </data>
+  <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>100, 13</value>
+  </data>
+  <data name="label1.TabIndex" type="System.Int32, mscorlib">
+    <value>62</value>
+  </data>
+  <data name="label1.Text" xml:space="preserve">
+    <value>Use language pack</value>
+  </data>
+  <data name="label1.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
+  <data name="&gt;&gt;label1.Name" xml:space="preserve">
+    <value>label1</value>
+  </data>
+  <data name="&gt;&gt;label1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label1.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
+  </data>
+  <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
+    <value>260, 27</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>LanguagePackComboBox</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>System.Windows.Forms.UserControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
 </root>

--- a/DS4Windows/DS4Windows.csproj
+++ b/DS4Windows/DS4Windows.csproj
@@ -164,6 +164,12 @@
     <Compile Include="DS4Control\X360Device.designer.cs">
       <DependentUpon>X360Device.cs</DependentUpon>
     </Compile>
+    <Compile Include="DS4Forms\LanguagePackComboBox.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="DS4Forms\LanguagePackComboBox.Designer.cs">
+      <DependentUpon>LanguagePackComboBox.cs</DependentUpon>
+    </Compile>
     <Compile Include="DS4Library\DS4Audio.cs" />
     <Compile Include="DS4Library\DS4Device.cs" />
     <Compile Include="DS4Library\DS4Devices.cs" />
@@ -593,6 +599,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="DS4Forms\KBM360.zh-Hant.resx">
       <DependentUpon>KBM360.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="DS4Forms\LanguagePackComboBox.resx">
+      <DependentUpon>LanguagePackComboBox.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="DS4Forms\Options.ar.resx">
       <DependentUpon>Options.cs</DependentUpon>

--- a/DS4Windows/Program.cs
+++ b/DS4Windows/Program.cs
@@ -120,16 +120,6 @@ namespace DS4Windows
             threadComEvent.Close();
         }
 
-        public static void SetCulture(string culture)
-        {
-            try
-            {
-                Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo(culture);
-                CultureInfo.DefaultThreadCurrentUICulture = CultureInfo.GetCultureInfo(culture);
-            }
-            catch { /* Skip setting culture that we cannot set */ }
-        }
-
         private static void createControlService()
         {
             controlThread = new Thread(() => { rootHub = new ControlService(); });

--- a/DS4Windows/Program.cs
+++ b/DS4Windows/Program.cs
@@ -120,6 +120,18 @@ namespace DS4Windows
             threadComEvent.Close();
         }
 
+        public static void SetCulture(string culture)
+        {
+            foreach (Thread t in new Thread[] { Thread.CurrentThread, controlThread })
+            {
+                if (t != null && !t.CurrentUICulture.Equals(culture))
+                {
+                    try { t.CurrentUICulture = CultureInfo.GetCultureInfo(culture); }
+                    catch { /* Skip setting culture that we cannot set */ }
+                }
+            }
+        }
+
         private static void createControlService()
         {
             controlThread = new Thread(() => { rootHub = new ControlService(); });

--- a/DS4Windows/Program.cs
+++ b/DS4Windows/Program.cs
@@ -122,14 +122,12 @@ namespace DS4Windows
 
         public static void SetCulture(string culture)
         {
-            foreach (Thread t in new Thread[] { Thread.CurrentThread, controlThread })
+            try
             {
-                if (t != null && !t.CurrentUICulture.Equals(culture))
-                {
-                    try { t.CurrentUICulture = CultureInfo.GetCultureInfo(culture); }
-                    catch { /* Skip setting culture that we cannot set */ }
-                }
+                Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo(culture);
+                CultureInfo.DefaultThreadCurrentUICulture = CultureInfo.GetCultureInfo(culture);
             }
+            catch { /* Skip setting culture that we cannot set */ }
         }
 
         private static void createControlService()

--- a/DS4Windows/Properties/Resources.Designer.cs
+++ b/DS4Windows/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace DS4Windows.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -1087,6 +1087,15 @@ namespace DS4Windows.Properties {
         internal static string KeepThisSize {
             get {
                 return ResourceManager.GetString("KeepThisSize", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Language pack change will take effect after DS4Windows application is restarted..
+        /// </summary>
+        internal static string LanguagePackApplyRestartRequired {
+            get {
+                return ResourceManager.GetString("LanguagePackApplyRestartRequired", resourceCulture);
             }
         }
         

--- a/DS4Windows/Properties/Resources.cs.resx
+++ b/DS4Windows/Properties/Resources.cs.resx
@@ -126,6 +126,9 @@
   <data name="AddPrograms" xml:space="preserve">
     <value>Přidat programy</value>
   </data>
+  <data name="LanguagePackApplyRestartRequired" xml:space="preserve">
+    <value>Změna jazykového balíčku se projeví po restartu aplikace DS4Windows.</value>
+  </data>
   <data name="TestText" xml:space="preserve">
     <value>Test</value>
   </data>

--- a/DS4Windows/Properties/Resources.resx
+++ b/DS4Windows/Properties/Resources.resx
@@ -118,128 +118,20 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="mouse" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\mouse.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="rainbow" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\rainbow.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="rainbowC" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\rainbowC.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="DS4_Controller" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\DS4 Controller.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="Pairmode" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\Pairmode.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="copy" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\shell32_copy.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="edit" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\shell32_new.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="delete" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\delete.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="newprofile" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\imageres_new.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="BT" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\BT.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="none" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\none.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="USB" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\USB.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="export" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\export.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="import" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\imageres_import.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="saveprofile" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\saveprofile.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
   <data name="A" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\A.PNG;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
-  <data name="B" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\B.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  <data name="ActionExists" xml:space="preserve">
+    <value>Name of this action already exists</value>
   </data>
-  <data name="BACK" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\BACK.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  <data name="AddingToList" xml:space="preserve">
+    <value>Adding to list...</value>
   </data>
-  <data name="DOWN" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\DOWN.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  <data name="AddPrograms" xml:space="preserve">
+    <value>Add Programs</value>
   </data>
-  <data name="LB" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\LB.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="LEFT" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\LEFT.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="LS" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\LS.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="LSD" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\LSD.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="LSL" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\LSL.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="LSR" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\LSR.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="LSU" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\LSU.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="LT" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\LT.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="RB" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\RB.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="RIGHT" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\RIGHT.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="RS" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\RS.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="RSD" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\RSD.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="RSL" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\RSL.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="RSR" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\RSR.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="RSU" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\RSU.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="RT" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\RT.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="START" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\START.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="UP" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\UP.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="X" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\X.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="Y" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\Y.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="size" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\size.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="_checked" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\checked.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  <data name="ALocactionNeeded" xml:space="preserve">
+    <value>A location must be picked to continue</value>
   </data>
   <data name="AlwaysRainbow" xml:space="preserve">
     <value>Always Rainbow Mode</value>
@@ -247,14 +139,35 @@
   <data name="AssignProfile" xml:space="preserve">
     <value>Assign to Controller *number*</value>
   </data>
+  <data name="B" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\B.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="BACK" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\BACK.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
   <data name="Battery" xml:space="preserve">
     <value>Battery: *number*%</value>
   </data>
   <data name="BestUsedRightSide" xml:space="preserve">
     <value>Best used with right side as a mouse function</value>
   </data>
+  <data name="Browse" xml:space="preserve">
+    <value>Browse...</value>
+  </data>
+  <data name="BT" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\BT.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="BTPollRate" xml:space="preserve">
+    <value>Determines the poll rate used for the DS4 hardware when connected via Bluetooth</value>
+  </data>
+  <data name="CannotMoveFiles" xml:space="preserve">
+    <value>Cannot move files to new location, Please rename the DS4Tool folder to "DS4Windows"</value>
+  </data>
   <data name="CannotWriteHere" xml:space="preserve">
     <value>Cannot write at current location. Copy Settings to appdata?</value>
+  </data>
+  <data name="ChargeController" xml:space="preserve">
+    <value>Charge the battery</value>
   </data>
   <data name="Charged" xml:space="preserve">
     <value>Charged</value>
@@ -262,8 +175,26 @@
   <data name="Charging" xml:space="preserve">
     <value>Charging: *number*%</value>
   </data>
+  <data name="CheckBattery" xml:space="preserve">
+    <value>Check Battery</value>
+  </data>
+  <data name="CloseConfirm" xml:space="preserve">
+    <value>This will disconnect all your connected controllers. Proceed?</value>
+  </data>
+  <data name="CloseDS4W" xml:space="preserve">
+    <value>Close DS4Windows?</value>
+  </data>
+  <data name="CloseMinimize" xml:space="preserve">
+    <value>Close DS4Windows via the notification icon</value>
+  </data>
+  <data name="Color" xml:space="preserve">
+    <value>Color</value>
+  </data>
   <data name="ColorByBattery" xml:space="preserve">
     <value>Color by Battery %</value>
+  </data>
+  <data name="Confirm" xml:space="preserve">
+    <value>Confirm...</value>
   </data>
   <data name="Connecting" xml:space="preserve">
     <value>Connecting...</value>
@@ -276,6 +207,9 @@
   </data>
   <data name="ControllerWasRemoved" xml:space="preserve">
     <value>Controller *Mac address* was removed or lost connection</value>
+  </data>
+  <data name="copy" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\shell32_copy.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="CopyComplete" xml:space="preserve">
     <value>Copy complete, please relaunch DS4Windows and remove settings from Program Directory</value>
@@ -292,14 +226,26 @@
   <data name="Days" xml:space="preserve">
     <value>days</value>
   </data>
+  <data name="delete" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\delete.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
   <data name="DeleteProfile" xml:space="preserve">
     <value>Delete Profile?</value>
   </data>
   <data name="DimByBattery" xml:space="preserve">
     <value>Dim by Battery %</value>
   </data>
+  <data name="DinputOnly" xml:space="preserve">
+    <value>Turn off X360 input and only use the DS4's native input, hide ds4 must be off (Wired Only)</value>
+  </data>
+  <data name="DisconnectBT" xml:space="preserve">
+    <value>Disconnect BT</value>
+  </data>
   <data name="Disconnected" xml:space="preserve">
     <value>Disconnected</value>
+  </data>
+  <data name="DOWN" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\DOWN.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="Downloading" xml:space="preserve">
     <value>Downloading *number*%</value>
@@ -307,371 +253,23 @@
   <data name="DownloadVersion" xml:space="preserve">
     <value>Download Version *number* now?</value>
   </data>
-  <data name="DS4Update" xml:space="preserve">
-    <value>DS4Windows Update Available!</value>
-  </data>
-  <data name="DS4WindowsCannotEditHere" xml:space="preserve">
-    <value>DS4Windows cannot edit settings here, This will now close</value>
-  </data>
-  <data name="EditProfile" xml:space="preserve">
-    <value>Edit</value>
-  </data>
-  <data name="FifthMouseDown" xml:space="preserve">
-    <value>5th Mouse Button Down</value>
-  </data>
-  <data name="FifthMouseUp" xml:space="preserve">
-    <value>5th Mouse Button Up</value>
-  </data>
-  <data name="FlushHID" xml:space="preserve">
-    <value>Flush HID</value>
-  </data>
-  <data name="FoundController" xml:space="preserve">
-    <value>Found Controller:</value>
-  </data>
-  <data name="FourthMouseDown" xml:space="preserve">
-    <value>4th Mouse Button Down</value>
-  </data>
-  <data name="FourthMouseUp" xml:space="preserve">
-    <value>4th Mouse Button Up</value>
-  </data>
-  <data name="Full" xml:space="preserve">
-    <value>Full</value>
-  </data>
-  <data name="Hour" xml:space="preserve">
-    <value>hour</value>
-  </data>
-  <data name="Hours" xml:space="preserve">
-    <value>hours</value>
-  </data>
-  <data name="IfRemovingDS4Windows" xml:space="preserve">
-    <value>If removing DS4Windows, You can delete the settings following the profile folder link</value>
-  </data>
-  <data name="InstallComplete" xml:space="preserve">
-    <value>Install Complete</value>
-  </data>
-  <data name="Loading" xml:space="preserve">
-    <value>Loading...</value>
-  </data>
-  <data name="MakeNewProfile" xml:space="preserve">
-    <value>Make a New Profile</value>
-  </data>
-  <data name="NA" xml:space="preserve">
-    <value>N/A</value>
-  </data>
-  <data name="New" xml:space="preserve">
-    <value>New</value>
-  </data>
-  <data name="NoMacroRecorded" xml:space="preserve">
-    <value>No macro was recorded</value>
-  </data>
-  <data name="noneProfile" xml:space="preserve">
-    <value>(none)</value>
-  </data>
-  <data name="NoneText" xml:space="preserve">
-    <value>none</value>
-  </data>
-  <data name="NoProfileLoaded" xml:space="preserve">
-    <value>No Profile Loaded</value>
-  </data>
-  <data name="NotValid" xml:space="preserve">
-    <value>Not valid</value>
-  </data>
-  <data name="OpeningInstaller" xml:space="preserve">
-    <value>Opening Installer</value>
-  </data>
-  <data name="OpenScpDriver" xml:space="preserve">
-    <value>Please Open ScpDriver.exe</value>
-  </data>
-  <data name="PleaseDownloadUpdater" xml:space="preserve">
-    <value>Please Download the Updater now, and place it in the programs folder, then check for update again</value>
-  </data>
-  <data name="PleaseImport" xml:space="preserve">
-    <value>Please import or make a profile</value>
-  </data>
-  <data name="ProfileCannotRestore" xml:space="preserve">
-    <value>*Profile name* cannot be restored.</value>
-  </data>
-  <data name="ProfileFolderMoved" xml:space="preserve">
-    <value>Profile Folder Moved to program folder</value>
-  </data>
-  <data name="QuitOtherPrograms" xml:space="preserve">
-    <value>You must quit other applications like Steam, Uplay before activating the 'Hide DS4 Controller' option."</value>
-  </data>
-  <data name="SaveRecordedMacro" xml:space="preserve">
-    <value>Save Recorded Macro?</value>
-  </data>
-  <data name="SearchingController" xml:space="preserve">
-    <value>Searching for controllers...</value>
-  </data>
-  <data name="SelectActionTitle" xml:space="preserve">
-    <value>Select an action for *action*</value>
-  </data>
-  <data name="Starting" xml:space="preserve">
-    <value>Starting...</value>
-  </data>
-  <data name="StartText" xml:space="preserve">
-    <value>Start</value>
-  </data>
-  <data name="StoppingDS4" xml:space="preserve">
-    <value>Stopping DS4 Controllers</value>
-  </data>
-  <data name="StoppingX360" xml:space="preserve">
-    <value>Stopping X360 Controllers</value>
-  </data>
-  <data name="StopText" xml:space="preserve">
-    <value>Stop</value>
-  </data>
-  <data name="SwipeTouchpad" xml:space="preserve">
-    <value>Swipe Touchpad to change profiles</value>
-  </data>
-  <data name="TapAndHold" xml:space="preserve">
-    <value>Tap and hold to drag, slight delay with single taps</value>
-  </data>
-  <data name="TouchpadMovementOff" xml:space="preserve">
-    <value>Touchpad Movement is now Off</value>
-  </data>
-  <data name="TouchpadMovementOn" xml:space="preserve">
-    <value>Touchpad Movement is now On</value>
-  </data>
-  <data name="TypeNewName" xml:space="preserve">
-    <value>type new name here</value>
-  </data>
-  <data name="TypeProfileName" xml:space="preserve">
-    <value>type profile name here</value>
-  </data>
-  <data name="UseControllerForMapping" xml:space="preserve">
-    <value>You can also use your controller to change controls</value>
-  </data>
-  <data name="UsingExclusive" xml:space="preserve">
-    <value>Using Exclusive Mode</value>
-  </data>
-  <data name="UsingShared" xml:space="preserve">
-    <value>Using Shared Mode</value>
-  </data>
-  <data name="ValidName" xml:space="preserve">
-    <value>Please enter a valid name</value>
-  </data>
-  <data name="WaitMS" xml:space="preserve">
-    <value>Wait *number*ms</value>
-  </data>
-  <data name="WillKeep" xml:space="preserve">
-    <value>Will Keep</value>
-  </data>
-  <data name="TwoFingerSwipe" xml:space="preserve">
-    <value>2 finger touchpad swipe left or right</value>
-  </data>
-  <data name="UpToDate" xml:space="preserve">
-    <value>You are up to date</value>
-  </data>
-  <data name="AddingToList" xml:space="preserve">
-    <value>Adding to list...</value>
-  </data>
-  <data name="AddPrograms" xml:space="preserve">
-    <value>Add Programs</value>
-  </data>
-  <data name="Browse" xml:space="preserve">
-    <value>Browse...</value>
-  </data>
-  <data name="Color" xml:space="preserve">
-    <value>Color</value>
-  </data>
   <data name="DownText" xml:space="preserve">
     <value>Down</value>
-  </data>
-  <data name="InputDelay" xml:space="preserve">
-    <value>Input Delay: *number*ms</value>
-  </data>
-  <data name="KeepThisSize" xml:space="preserve">
-    <value>Keep this window size after closing</value>
-  </data>
-  <data name="RecordText" xml:space="preserve">
-    <value>Record</value>
-  </data>
-  <data name="Step1" xml:space="preserve">
-    <value>Step 1: Install the DS4 Driver</value>
-  </data>
-  <data name="UpText" xml:space="preserve">
-    <value>Up</value>
-  </data>
-  <data name="DinputOnly" xml:space="preserve">
-    <value>Turn off X360 input and only use the DS4's native input, hide ds4 must be off (Wired Only)</value>
-  </data>
-  <data name="InstallDriver" xml:space="preserve">
-    <value>Install Drivers here</value>
-  </data>
-  <data name="TiltDown" xml:space="preserve">
-    <value>Tilt Down</value>
-  </data>
-  <data name="TiltLeft" xml:space="preserve">
-    <value>Tilt Left</value>
-  </data>
-  <data name="TiltRight" xml:space="preserve">
-    <value>Tilt Right</value>
-  </data>
-  <data name="TiltUp" xml:space="preserve">
-    <value>Tilt Up</value>
-  </data>
-  <data name="Installing" xml:space="preserve">
-    <value>Installing...</value>
   </data>
   <data name="DS4" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\DS4.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
+  <data name="DS4Update" xml:space="preserve">
+    <value>DS4Windows Update Available!</value>
+  </data>
   <data name="DS4W" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\DS4W.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
-  <data name="InstallFailed" xml:space="preserve">
-    <value>Install Failed, Please Retry</value>
+  <data name="DS4WindowsCannotEditHere" xml:space="preserve">
+    <value>DS4Windows cannot edit settings here, This will now close</value>
   </data>
-  <data name="SwipeDown" xml:space="preserve">
-    <value>Swipe Down</value>
-  </data>
-  <data name="SwipeLeft" xml:space="preserve">
-    <value>Swipe Left</value>
-  </data>
-  <data name="SwipeRight" xml:space="preserve">
-    <value>Swipe Right</value>
-  </data>
-  <data name="SwipeUp" xml:space="preserve">
-    <value>Swipe Up</value>
-  </data>
-  <data name="StopHText" xml:space="preserve">
-    <value>Stop Heavy</value>
-  </data>
-  <data name="StopLText" xml:space="preserve">
-    <value>Stop Light</value>
-  </data>
-  <data name="TestHText" xml:space="preserve">
-    <value>Test Heavy</value>
-  </data>
-  <data name="TestLText" xml:space="preserve">
-    <value>Test Light</value>
-  </data>
-  <data name="QuickCharge" xml:space="preserve">
-    <value>EXPERIMENTAL: Auto-Disable BT when connecting to USB</value>
-  </data>
-  <data name="TestText" xml:space="preserve">
-    <value>Test</value>
-  </data>
-  <data name="CannotMoveFiles" xml:space="preserve">
-    <value>Cannot move files to new location, Please rename the DS4Tool folder to "DS4Windows"</value>
-  </data>
-  <data name="XinputPorts" xml:space="preserve">
-    <value>Use higher ports if you get conflicts in other emulating X360 programs, such as SCP's tool</value>
-  </data>
-  <data name="ActionExists" xml:space="preserve">
-    <value>Name of this action already exists</value>
-  </data>
-  <data name="LaunchProgram" xml:space="preserve">
-    <value>Launch *program*</value>
-  </data>
-  <data name="LoadProfile" xml:space="preserve">
-    <value>Load *profile*</value>
-  </data>
-  <data name="SetRegularTrigger" xml:space="preserve">
-    <value>Set Regular Trigger</value>
-  </data>
-  <data name="SetUnloadTrigger" xml:space="preserve">
-    <value>Set Unload Trigger</value>
-  </data>
-  <data name="CloseMinimize" xml:space="preserve">
-    <value>Close DS4Windows via the notification icon</value>
-  </data>
-  <data name="RightClickPresets" xml:space="preserve">
-    <value>Right Click to set presets for a set of controls</value>
-  </data>
-  <data name="DisconnectBT" xml:space="preserve">
-    <value>Disconnect BT</value>
-  </data>
-  <data name="PlusNewProfile" xml:space="preserve">
-    <value>New Profile</value>
-  </data>
-  <data name="FallBackTo" xml:space="preserve">
-    <value>Fall Back to *button*</value>
-  </data>
-  <data name="FlashAtTip" xml:space="preserve">
-    <value>Click to change flash color. Black = default color</value>
-  </data>
-  <data name="FlushHIDTip" xml:space="preserve">
-    <value>Flush HID Queue after each reading</value>
-  </data>
-  <data name="GyroReadout" xml:space="preserve">
-    <value>Click to see readout of Sixaxis Gyro</value>
-  </data>
-  <data name="GyroX" xml:space="preserve">
-    <value>GyroX, Left and Right Tilt</value>
-  </data>
-  <data name="GyroY" xml:space="preserve">
-    <value>GyroY, Forward and Back Tilt</value>
-  </data>
-  <data name="GyroZ" xml:space="preserve">
-    <value>GyroZ, Up and Down Tilt</value>
-  </data>
-  <data name="HoverOverItems" xml:space="preserve">
-    <value>Hover over items to see description or more about</value>
-  </data>
-  <data name="Jitter" xml:space="preserve">
-    <value>Use Sixaxis to help calculate touchpad movement</value>
-  </data>
-  <data name="LightByBatteryTip" xml:space="preserve">
-    <value>Also dim light by idle timeout if enabled when DS4 is fully charged</value>
-  </data>
-  <data name="Macro" xml:space="preserve">
-    <value>Macro</value>
-  </data>
-  <data name="Programs" xml:space="preserve">
-    <value>Programs</value>
-  </data>
-  <data name="ScanCode" xml:space="preserve">
-    <value>Scan Code</value>
-  </data>
-  <data name="Shortcuts" xml:space="preserve">
-    <value>Shortcuts</value>
-  </data>
-  <data name="SixAxisReading" xml:space="preserve">
-    <value>Click for advanced Sixaxis reading</value>
-  </data>
-  <data name="TouchpadOffTip" xml:space="preserve">
-    <value>Re-enable by pressing PS+Touchpad</value>
-  </data>
-  <data name="UsingTPSwipes" xml:space="preserve">
-    <value>This disables the Touchpad as a mouse</value>
-  </data>
-  <data name="FallBack" xml:space="preserve">
-    <value>Fall Back</value>
-  </data>
-  <data name="ALocactionNeeded" xml:space="preserve">
-    <value>A location must be picked to continue</value>
-  </data>
-  <data name="CloseDS4W" xml:space="preserve">
-    <value>Close DS4Windows?</value>
-  </data>
-  <data name="OtherFileLocation" xml:space="preserve">
-    <value>, other location files will be deleted</value>
-  </data>
-  <data name="EE" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\EE.wav;System.IO.MemoryStream, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="StoppedDS4Windows" xml:space="preserve">
-    <value>Stopped DS4Windows</value>
-  </data>
-  <data name="LatencyNotOverTen" xml:space="preserve">
-    <value>Controller *number*'s latency now under 10ms</value>
-  </data>
-  <data name="LatencyOverTen" xml:space="preserve">
-    <value>Controller *number*'s latency over 10ms</value>
-  </data>
-  <data name="NotUsingProfile" xml:space="preserve">
-    <value>Controller *number* is not using a profile</value>
-  </data>
-  <data name="CheckBattery" xml:space="preserve">
-    <value>Check Battery</value>
-  </data>
-  <data name="UsingProfile" xml:space="preserve">
-    <value>Controller *number* is using Profile “*Profile name*"</value>
-  </data>
-  <data name="ChargeController" xml:space="preserve">
-    <value>Charge the battery</value>
+  <data name="DS4W___White" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\DS4W - White.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="DS4_Config" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\DS4 Config.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
@@ -739,23 +337,455 @@
   <data name="DS4_Config_Up" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\DS4-Config_Up.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
+  <data name="DS4_Controller" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\DS4 Controller.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
   <data name="DS4_lightbar" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\DS4 lightbar.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
-  <data name="TextDocs" xml:space="preserve">
-    <value>Text Document (*.txt)</value>
+  <data name="edit" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\shell32_new.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
-  <data name="XMLFiles" xml:space="preserve">
-    <value>XML Files (*.xml)</value>
+  <data name="EditProfile" xml:space="preserve">
+    <value>Edit</value>
   </data>
-  <data name="Unassigned" xml:space="preserve">
-    <value>Unassigned</value>
+  <data name="EE" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\EE.wav;System.IO.MemoryStream, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="export" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\export.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="FallBack" xml:space="preserve">
+    <value>Fall Back</value>
+  </data>
+  <data name="FallBackTo" xml:space="preserve">
+    <value>Fall Back to *button*</value>
+  </data>
+  <data name="FifthMouseDown" xml:space="preserve">
+    <value>5th Mouse Button Down</value>
+  </data>
+  <data name="FifthMouseUp" xml:space="preserve">
+    <value>5th Mouse Button Up</value>
+  </data>
+  <data name="FlashAtTip" xml:space="preserve">
+    <value>Click to change flash color. Black = default color</value>
+  </data>
+  <data name="FlushHID" xml:space="preserve">
+    <value>Flush HID</value>
+  </data>
+  <data name="FlushHIDTip" xml:space="preserve">
+    <value>Flush HID Queue after each reading</value>
+  </data>
+  <data name="FoundController" xml:space="preserve">
+    <value>Found Controller:</value>
+  </data>
+  <data name="FourthMouseDown" xml:space="preserve">
+    <value>4th Mouse Button Down</value>
+  </data>
+  <data name="FourthMouseUp" xml:space="preserve">
+    <value>4th Mouse Button Up</value>
+  </data>
+  <data name="Full" xml:space="preserve">
+    <value>Full</value>
+  </data>
+  <data name="GyroReadout" xml:space="preserve">
+    <value>Click to see readout of Sixaxis Gyro</value>
+  </data>
+  <data name="GyroTriggerBehavior" xml:space="preserve">
+    <value>Check to have gyro active while trigger is active. Uncheck to disable gyro while trigger is active.</value>
+  </data>
+  <data name="GyroX" xml:space="preserve">
+    <value>GyroX, Left and Right Tilt</value>
+  </data>
+  <data name="GyroY" xml:space="preserve">
+    <value>GyroY, Forward and Back Tilt</value>
+  </data>
+  <data name="GyroZ" xml:space="preserve">
+    <value>GyroZ, Up and Down Tilt</value>
+  </data>
+  <data name="Hour" xml:space="preserve">
+    <value>hour</value>
+  </data>
+  <data name="Hours" xml:space="preserve">
+    <value>hours</value>
+  </data>
+  <data name="HoverOverItems" xml:space="preserve">
+    <value>Hover over items to see description or more about</value>
+  </data>
+  <data name="IfRemovingDS4Windows" xml:space="preserve">
+    <value>If removing DS4Windows, You can delete the settings following the profile folder link</value>
+  </data>
+  <data name="import" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\imageres_import.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="InputDelay" xml:space="preserve">
+    <value>Input Delay: *number*ms</value>
+  </data>
+  <data name="InstallComplete" xml:space="preserve">
+    <value>Install Complete</value>
+  </data>
+  <data name="InstallDriver" xml:space="preserve">
+    <value>Install Drivers here</value>
+  </data>
+  <data name="InstallFailed" xml:space="preserve">
+    <value>Install Failed, Please Retry</value>
+  </data>
+  <data name="Installing" xml:space="preserve">
+    <value>Installing...</value>
+  </data>
+  <data name="Jitter" xml:space="preserve">
+    <value>Use Sixaxis to help calculate touchpad movement</value>
+  </data>
+  <data name="KeepThisSize" xml:space="preserve">
+    <value>Keep this window size after closing</value>
+  </data>
+  <data name="LanguagePackApplyRestartRequired" xml:space="preserve">
+    <value>Language pack change will take effect after DS4Windows application is restarted.</value>
+  </data>
+  <data name="LatencyNotOverTen" xml:space="preserve">
+    <value>Controller *number*'s latency now under 10ms</value>
+  </data>
+  <data name="LatencyOverTen" xml:space="preserve">
+    <value>Controller *number*'s latency over 10ms</value>
+  </data>
+  <data name="LaunchProgram" xml:space="preserve">
+    <value>Launch *program*</value>
+  </data>
+  <data name="LB" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\LB.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="LEFT" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\LEFT.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="left_touch" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\left touch.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
+  <data name="LightByBatteryTip" xml:space="preserve">
+    <value>Also dim light by idle timeout if enabled when DS4 is fully charged</value>
+  </data>
+  <data name="Loading" xml:space="preserve">
+    <value>Loading...</value>
+  </data>
+  <data name="LoadProfile" xml:space="preserve">
+    <value>Load *profile*</value>
+  </data>
+  <data name="LS" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\LS.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="LSD" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\LSD.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="LSL" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\LSL.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="LSR" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\LSR.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="LSU" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\LSU.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="LT" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\LT.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="Macro" xml:space="preserve">
+    <value>Macro</value>
+  </data>
+  <data name="MacroRecorded" xml:space="preserve">
+    <value>Macro Recorded</value>
+  </data>
+  <data name="MakeNewProfile" xml:space="preserve">
+    <value>Make a New Profile</value>
+  </data>
+  <data name="mouse" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\mouse.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="MultiAction" xml:space="preserve">
+    <value>Mutli-Action Button</value>
+  </data>
+  <data name="NA" xml:space="preserve">
+    <value>N/A</value>
+  </data>
+  <data name="New" xml:space="preserve">
+    <value>New</value>
+  </data>
+  <data name="newprofile" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\imageres_new.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="NoMacroRecorded" xml:space="preserve">
+    <value>No macro was recorded</value>
+  </data>
+  <data name="none" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\none.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="noneProfile" xml:space="preserve">
+    <value>(none)</value>
+  </data>
+  <data name="NoneText" xml:space="preserve">
+    <value>none</value>
+  </data>
+  <data name="NoProfileLoaded" xml:space="preserve">
+    <value>No Profile Loaded</value>
+  </data>
+  <data name="NotUsingProfile" xml:space="preserve">
+    <value>Controller *number* is not using a profile</value>
+  </data>
+  <data name="NotValid" xml:space="preserve">
+    <value>Not valid</value>
+  </data>
+  <data name="OpeningInstaller" xml:space="preserve">
+    <value>Opening Installer</value>
+  </data>
+  <data name="OpenScpDriver" xml:space="preserve">
+    <value>Please Open ScpDriver.exe</value>
+  </data>
+  <data name="OtherFileLocation" xml:space="preserve">
+    <value>, other location files will be deleted</value>
+  </data>
+  <data name="Pairmode" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Pairmode.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="PleaseDownloadUpdater" xml:space="preserve">
+    <value>Please Download the Updater now, and place it in the programs folder, then check for update again</value>
+  </data>
+  <data name="PleaseImport" xml:space="preserve">
+    <value>Please import or make a profile</value>
+  </data>
+  <data name="PlusNewProfile" xml:space="preserve">
+    <value>New Profile</value>
+  </data>
+  <data name="ProfileCannotRestore" xml:space="preserve">
+    <value>*Profile name* cannot be restored.</value>
+  </data>
+  <data name="ProfileFolderMoved" xml:space="preserve">
+    <value>Profile Folder Moved to program folder</value>
+  </data>
+  <data name="Programs" xml:space="preserve">
+    <value>Programs</value>
+  </data>
+  <data name="QuickCharge" xml:space="preserve">
+    <value>EXPERIMENTAL: Auto-Disable BT when connecting to USB</value>
+  </data>
+  <data name="QuitOtherPrograms" xml:space="preserve">
+    <value>You must quit other applications like Steam, Uplay before activating the 'Hide DS4 Controller' option."</value>
+  </data>
+  <data name="rainbow" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\rainbow.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="rainbowC" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\rainbowC.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="RB" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\RB.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="RecordText" xml:space="preserve">
+    <value>Record</value>
+  </data>
+  <data name="RIGHT" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\RIGHT.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="RightClickPresets" xml:space="preserve">
+    <value>Right Click to set presets for a set of controls</value>
+  </data>
   <data name="right_touch" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\right touch.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="RS" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\RS.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="RSD" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\RSD.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="RSL" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\RSL.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="RSR" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\RSR.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="RSU" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\RSU.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="RT" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\RT.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="RunAtStartup" xml:space="preserve">
+    <value>Tells Windows to start DS4Windows after login</value>
+  </data>
+  <data name="saveprofile" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\saveprofile.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="SaveRecordedMacro" xml:space="preserve">
+    <value>Save Recorded Macro?</value>
+  </data>
+  <data name="ScanCode" xml:space="preserve">
+    <value>Scan Code</value>
+  </data>
+  <data name="SearchingController" xml:space="preserve">
+    <value>Searching for controllers...</value>
+  </data>
+  <data name="SelectActionTitle" xml:space="preserve">
+    <value>Select an action for *action*</value>
+  </data>
+  <data name="SelectMacro" xml:space="preserve">
+    <value>Select a macro</value>
+  </data>
+  <data name="SetRegularTrigger" xml:space="preserve">
+    <value>Set Regular Trigger</value>
+  </data>
+  <data name="SetUnloadTrigger" xml:space="preserve">
+    <value>Set Unload Trigger</value>
+  </data>
+  <data name="Shortcuts" xml:space="preserve">
+    <value>Shortcuts</value>
+  </data>
+  <data name="SixAxisReading" xml:space="preserve">
+    <value>Click for advanced Sixaxis reading</value>
+  </data>
+  <data name="size" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\size.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="START" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\START.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="Starting" xml:space="preserve">
+    <value>Starting...</value>
+  </data>
+  <data name="StartText" xml:space="preserve">
+    <value>Start</value>
+  </data>
+  <data name="Step1" xml:space="preserve">
+    <value>Step 1: Install the DS4 Driver</value>
+  </data>
+  <data name="StopHText" xml:space="preserve">
+    <value>Stop Heavy</value>
+  </data>
+  <data name="StopLText" xml:space="preserve">
+    <value>Stop Light</value>
+  </data>
+  <data name="StoppedDS4Windows" xml:space="preserve">
+    <value>Stopped DS4Windows</value>
+  </data>
+  <data name="StoppingDS4" xml:space="preserve">
+    <value>Stopping DS4 Controllers</value>
+  </data>
+  <data name="StoppingX360" xml:space="preserve">
+    <value>Stopping X360 Controllers</value>
+  </data>
+  <data name="StopText" xml:space="preserve">
+    <value>Stop</value>
+  </data>
+  <data name="SwipeDown" xml:space="preserve">
+    <value>Swipe Down</value>
+  </data>
+  <data name="SwipeLeft" xml:space="preserve">
+    <value>Swipe Left</value>
+  </data>
+  <data name="SwipeRight" xml:space="preserve">
+    <value>Swipe Right</value>
+  </data>
+  <data name="SwipeTouchpad" xml:space="preserve">
+    <value>Swipe Touchpad to change profiles</value>
+  </data>
+  <data name="SwipeUp" xml:space="preserve">
+    <value>Swipe Up</value>
+  </data>
+  <data name="TapAndHold" xml:space="preserve">
+    <value>Tap and hold to drag, slight delay with single taps</value>
+  </data>
+  <data name="TestHText" xml:space="preserve">
+    <value>Test Heavy</value>
+  </data>
+  <data name="TestLText" xml:space="preserve">
+    <value>Test Light</value>
+  </data>
+  <data name="TestText" xml:space="preserve">
+    <value>Test</value>
+  </data>
+  <data name="TextDocs" xml:space="preserve">
+    <value>Text Document (*.txt)</value>
+  </data>
+  <data name="TiltDown" xml:space="preserve">
+    <value>Tilt Down</value>
+  </data>
+  <data name="TiltLeft" xml:space="preserve">
+    <value>Tilt Left</value>
+  </data>
+  <data name="TiltRight" xml:space="preserve">
+    <value>Tilt Right</value>
+  </data>
+  <data name="TiltUp" xml:space="preserve">
+    <value>Tilt Up</value>
+  </data>
+  <data name="TouchpadMovementOff" xml:space="preserve">
+    <value>Touchpad Movement is now Off</value>
+  </data>
+  <data name="TouchpadMovementOn" xml:space="preserve">
+    <value>Touchpad Movement is now On</value>
+  </data>
+  <data name="TouchpadOffTip" xml:space="preserve">
+    <value>Re-enable by pressing PS+Touchpad</value>
+  </data>
+  <data name="TwoFingerSwipe" xml:space="preserve">
+    <value>2 finger touchpad swipe left or right</value>
+  </data>
+  <data name="TypeNewName" xml:space="preserve">
+    <value>type new name here</value>
+  </data>
+  <data name="TypeProfileName" xml:space="preserve">
+    <value>type profile name here</value>
+  </data>
+  <data name="UACTask" xml:space="preserve">
+    <value>You need to run DS4Windows as the Administrator in order to activate this mode.</value>
+  </data>
+  <data name="Unassigned" xml:space="preserve">
+    <value>Unassigned</value>
+  </data>
+  <data name="UP" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\UP.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="UpText" xml:space="preserve">
+    <value>Up</value>
+  </data>
+  <data name="UpToDate" xml:space="preserve">
+    <value>You are up to date</value>
+  </data>
+  <data name="USB" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\USB.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="UseControllerForMapping" xml:space="preserve">
+    <value>You can also use your controller to change controls</value>
+  </data>
+  <data name="UsingExclusive" xml:space="preserve">
+    <value>Using Exclusive Mode</value>
+  </data>
+  <data name="UsingProfile" xml:space="preserve">
+    <value>Controller *number* is using Profile “*Profile name*"</value>
+  </data>
+  <data name="UsingShared" xml:space="preserve">
+    <value>Using Shared Mode</value>
+  </data>
+  <data name="UsingTPSwipes" xml:space="preserve">
+    <value>This disables the Touchpad as a mouse</value>
+  </data>
+  <data name="ValidName" xml:space="preserve">
+    <value>Please enter a valid name</value>
+  </data>
+  <data name="WaitMS" xml:space="preserve">
+    <value>Wait *number*ms</value>
+  </data>
+  <data name="WillKeep" xml:space="preserve">
+    <value>Will Keep</value>
+  </data>
+  <data name="X" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\X.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="XinputPorts" xml:space="preserve">
+    <value>Use higher ports if you get conflicts in other emulating X360 programs, such as SCP's tool</value>
+  </data>
+  <data name="XMLFiles" xml:space="preserve">
+    <value>XML Files (*.xml)</value>
+  </data>
+  <data name="Y" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Y.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="_360_highlight" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\360 highlight.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
@@ -763,34 +793,7 @@
   <data name="_360_map" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\360 map.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
-  <data name="DS4W___White" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\DS4W - White.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="MultiAction" xml:space="preserve">
-    <value>Mutli-Action Button</value>
-  </data>
-  <data name="MacroRecorded" xml:space="preserve">
-    <value>Macro Recorded</value>
-  </data>
-  <data name="SelectMacro" xml:space="preserve">
-    <value>Select a macro</value>
-  </data>
-  <data name="RunAtStartup" xml:space="preserve">
-    <value>Tells Windows to start DS4Windows after login</value>
-  </data>
-  <data name="UACTask" xml:space="preserve">
-    <value>You need to run DS4Windows as the Administrator in order to activate this mode.</value>
-  </data>
-  <data name="BTPollRate" xml:space="preserve">
-    <value>Determines the poll rate used for the DS4 hardware when connected via Bluetooth</value>
-  </data>
-  <data name="GyroTriggerBehavior" xml:space="preserve">
-    <value>Check to have gyro active while trigger is active. Uncheck to disable gyro while trigger is active.</value>
-  </data>
-  <data name="CloseConfirm" xml:space="preserve">
-    <value>This will disconnect all your connected controllers. Proceed?</value>
-  </data>
-  <data name="Confirm" xml:space="preserve">
-    <value>Confirm...</value>
+  <data name="_checked" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\checked.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
 </root>

--- a/DS4Windows/Properties/Resources.ru-RU.resx
+++ b/DS4Windows/Properties/Resources.ru-RU.resx
@@ -144,8 +144,14 @@
   <data name="Browse" xml:space="preserve">
     <value>Обзор…</value>
   </data>
+  <data name="CannotMoveFiles" xml:space="preserve">
+    <value>Невозможно переместить файлы в новое место. Пожалуйста переименуйте папку с DS4Tool в "DS4Windows"</value>
+  </data>
   <data name="CannotWriteHere" xml:space="preserve">
     <value>Невозможно записать в текущее местоположение. Скопировать настройки в AppData?</value>
+  </data>
+  <data name="ChargeController" xml:space="preserve">
+    <value>Зарядите батарею</value>
   </data>
   <data name="Charged" xml:space="preserve">
     <value>Заряжено</value>
@@ -231,6 +237,9 @@
   <data name="FallBack" xml:space="preserve">
     <value>Вернуть</value>
   </data>
+  <data name="FallBackTo" xml:space="preserve">
+    <value>Вернуть на *button*</value>
+  </data>
   <data name="FifthMouseDown" xml:space="preserve">
     <value>5-я кнопка мыши Вниз</value>
   </data>
@@ -291,6 +300,9 @@
   <data name="InstallDriver" xml:space="preserve">
     <value>Установите этот драйвер</value>
   </data>
+  <data name="InstallFailed" xml:space="preserve">
+    <value>Установка не удалась. Пожалуйста повторите</value>
+  </data>
   <data name="Installing" xml:space="preserve">
     <value>Установка...</value>
   </data>
@@ -299,6 +311,9 @@
   </data>
   <data name="KeepThisSize" xml:space="preserve">
     <value>Запоминать размер окна после закрытия</value>
+  </data>
+  <data name="LanguagePackApplyRestartRequired" xml:space="preserve">
+    <value>Выбранный языковой пакет будет применен после перезапуска приложения DS4Windows.</value>
   </data>
   <data name="LatencyNotOverTen" xml:space="preserve">
     <value>Задержка *number*-го контроллера сейчас меньше 10 мс</value>
@@ -426,6 +441,9 @@
   <data name="StopLText" xml:space="preserve">
     <value>Ост. лёгкий</value>
   </data>
+  <data name="StoppedDS4Tool" xml:space="preserve">
+    <value>Остановлена работа DS4Windows</value>
+  </data>
   <data name="StoppedDS4Windows" xml:space="preserve">
     <value>Остановлена работа DS4Windows</value>
   </data>
@@ -462,6 +480,12 @@
   <data name="TestLText" xml:space="preserve">
     <value>Тест. лёгкого</value>
   </data>
+  <data name="TestText" xml:space="preserve">
+    <value>Проверка</value>
+  </data>
+  <data name="TextDocs" xml:space="preserve">
+    <value>Текстовый документ (*.txt)</value>
+  </data>
   <data name="TiltDown" xml:space="preserve">
     <value>Накл. вниз</value>
   </data>
@@ -491,6 +515,9 @@
   </data>
   <data name="TypeProfileName" xml:space="preserve">
     <value>введите сюда имя профиля</value>
+  </data>
+  <data name="Unassigned" xml:space="preserve">
+    <value>Не назначено</value>
   </data>
   <data name="UpText" xml:space="preserve">
     <value>Вверх</value>
@@ -525,31 +552,7 @@
   <data name="XinputPorts" xml:space="preserve">
     <value>Используйте иной порт, если у вас возникла проблема с другой программой эмулятора контроллера X360, такой как SCP's tool</value>
   </data>
-  <data name="StoppedDS4Tool" xml:space="preserve">
-    <value>Остановлена работа DS4Windows</value>
-  </data>
-  <data name="TextDocs" xml:space="preserve">
-    <value>Текстовый документ (*.txt)</value>
-  </data>
-  <data name="CannotMoveFiles" xml:space="preserve">
-    <value>Невозможно переместить файлы в новое место. Пожалуйста переименуйте папку с DS4Tool в "DS4Windows"</value>
-  </data>
-  <data name="ChargeController" xml:space="preserve">
-    <value>Зарядите батарею</value>
-  </data>
-  <data name="FallBackTo" xml:space="preserve">
-    <value>Вернуть на *button*</value>
-  </data>
-  <data name="InstallFailed" xml:space="preserve">
-    <value>Установка не удалась. Пожалуйста повторите</value>
-  </data>
-  <data name="Unassigned" xml:space="preserve">
-    <value>Не назначено</value>
-  </data>
   <data name="XMLFiles" xml:space="preserve">
     <value>XML-файлы (*.xml)</value>
-  </data>
-  <data name="TestText" xml:space="preserve">
-    <value>Проверка</value>
   </data>
 </root>


### PR DESCRIPTION
Hi, I think I'm now ready to submit the language switcher (continued from feature request #169).

From the notable changes since then:

I haven't found a built-in way to find all available language assemblies without actually loading them all, nor getting the probing path from the runtime config section as it is apparently hidden. So I implemented a functionality for looking them up in the specified directories as well as exe directory in a similar fashion (the same string as in `probingPath` config must be set to the language picker control property - d0ad9d8) and it will additionally filter dlls by a specified name (ie `DS4Windows.resources.dll`) in order to skip assemblies for Task Scheduler - 300e842. Assemblies lookup will run asynchronously in order not to block other form elements from loading - acfb9b2.

One thing I kind of worry about are huge diffs to resx files even though I've added only 2 new keys to `DS4Form.resx` and one to `Properties.resx`. I think if you had made your changes to the resx files in the mean time, the changes would not merge...