### PR TITLE
Postpone language packs list population until control Load event

### DIFF
--- a/DS4Windows/DS4Forms/LanguagePackComboBox.Designer.cs
+++ b/DS4Windows/DS4Forms/LanguagePackComboBox.Designer.cs
@@ -55,7 +55,6 @@
             this.Controls.Add(this.cbCulture);
             this.Controls.Add(this.label1);
             this.Name = "LanguagePackComboBox";
-            this.Load += new System.EventHandler(this.LanguagePackComboBox_Load);
             this.SizeChanged += new System.EventHandler(this.LanguagePackComboBox_SizeChanged);
             this.Resize += new System.EventHandler(this.LanguagePackComboBox_SizeChanged);
             this.ResumeLayout(false);

--- a/DS4Windows/DS4Forms/LanguagePackComboBox.Designer.cs
+++ b/DS4Windows/DS4Forms/LanguagePackComboBox.Designer.cs
@@ -55,6 +55,7 @@
             this.Controls.Add(this.cbCulture);
             this.Controls.Add(this.label1);
             this.Name = "LanguagePackComboBox";
+            this.Load += new System.EventHandler(this.LanguagePackComboBox_Load);
             this.SizeChanged += new System.EventHandler(this.LanguagePackComboBox_SizeChanged);
             this.Resize += new System.EventHandler(this.LanguagePackComboBox_SizeChanged);
             this.ResumeLayout(false);

--- a/DS4Windows/DS4Forms/LanguagePackComboBox.cs
+++ b/DS4Windows/DS4Forms/LanguagePackComboBox.cs
@@ -78,19 +78,6 @@ namespace DS4Windows.DS4Forms
         {
             InitializeComponent();
             cbCulture.Enabled = false;
-
-            Task.Run(() => {
-                // Find available language assemblies and bind the list to the combo box.
-                cbCulture.DataSource = CreateLanguageAssembliesBindingSource();
-                cbCulture.SelectedValue = Thread.CurrentThread.CurrentUICulture.Name;
-
-                // This must be set here instead of Designer or event would fire at initial selected value setting above.
-                cbCulture.SelectedIndexChanged += new EventHandler(CbCulture_SelectedIndexChanged);
-                cbCulture.SelectedValueChanged += new EventHandler(CbCulture_SelectedValueChanged);
-
-                cbCulture.Enabled = true;
-                LanguageListInitialized.SetResult(true);
-            });
         }
 
         private BindingSource CreateLanguageAssembliesBindingSource()
@@ -142,6 +129,22 @@ namespace DS4Windows.DS4Forms
         private void CbCulture_SelectedValueChanged(object sender, EventArgs e)
         {
             SelectedValueChanged?.Invoke(this, e);
+        }
+
+        private void LanguagePackComboBox_Load(object sender, EventArgs e)
+        {
+            Invoke(new Action(() => {
+                // Find available language assemblies and bind the list to the combo box.
+                cbCulture.DataSource = CreateLanguageAssembliesBindingSource();
+                cbCulture.SelectedValue = Thread.CurrentThread.CurrentUICulture.Name;
+
+                // This must be set here instead of Designer or event would fire at initial selected value setting above.
+                cbCulture.SelectedIndexChanged += new EventHandler(CbCulture_SelectedIndexChanged);
+                cbCulture.SelectedValueChanged += new EventHandler(CbCulture_SelectedValueChanged);
+
+                cbCulture.Enabled = true;
+                LanguageListInitialized.SetResult(true);
+            }));
         }
     }
 }

--- a/DS4Windows/DS4Forms/LanguagePackComboBox.cs
+++ b/DS4Windows/DS4Forms/LanguagePackComboBox.cs
@@ -78,6 +78,19 @@ namespace DS4Windows.DS4Forms
         {
             InitializeComponent();
             cbCulture.Enabled = false;
+
+            Task.Run(() => {
+                // Find available language assemblies and bind the list to the combo box.
+                cbCulture.DataSource = CreateLanguageAssembliesBindingSource();
+                cbCulture.SelectedValue = Thread.CurrentThread.CurrentUICulture.Name;
+
+                // This must be set here instead of Designer or event would fire at initial selected value setting above.
+                cbCulture.SelectedIndexChanged += new EventHandler(CbCulture_SelectedIndexChanged);
+                cbCulture.SelectedValueChanged += new EventHandler(CbCulture_SelectedValueChanged);
+
+                cbCulture.Enabled = true;
+                LanguageListInitialized.SetResult(true);
+            });
         }
 
         private BindingSource CreateLanguageAssembliesBindingSource()
@@ -129,22 +142,6 @@ namespace DS4Windows.DS4Forms
         private void CbCulture_SelectedValueChanged(object sender, EventArgs e)
         {
             SelectedValueChanged?.Invoke(this, e);
-        }
-
-        private void LanguagePackComboBox_Load(object sender, EventArgs e)
-        {
-            Invoke(new Action(() => {
-                // Find available language assemblies and bind the list to the combo box.
-                cbCulture.DataSource = CreateLanguageAssembliesBindingSource();
-                cbCulture.SelectedValue = Thread.CurrentThread.CurrentUICulture.Name;
-
-                // This must be set here instead of Designer or event would fire at initial selected value setting above.
-                cbCulture.SelectedIndexChanged += new EventHandler(CbCulture_SelectedIndexChanged);
-                cbCulture.SelectedValueChanged += new EventHandler(CbCulture_SelectedValueChanged);
-
-                cbCulture.Enabled = true;
-                LanguageListInitialized.SetResult(true);
-            }));
         }
     }
 }

--- a/DS4Windows/DS4Forms/LanguagePackComboBox.cs
+++ b/DS4Windows/DS4Forms/LanguagePackComboBox.cs
@@ -16,6 +16,12 @@ namespace DS4Windows.DS4Forms
         private string InvariantCultureTextValue = "No (English UI)";
         private TaskCompletionSource<bool> LanguageListInitialized = new TaskCompletionSource<bool>();
 
+        // If probing path has been changed in App.config, add the same string here.
+        public string ProbingPath = "Lang";
+
+        // Filter language assembly file names in order to ont include irrelevant assemblies to the combo box.
+        public string LanguageAssemblyName { get; set; } = "DS4Windows.resources.dll";
+
         [Category("Action")]
         [Description("Fires when the combo box selected index is changed.")]
         public event EventHandler SelectedIndexChanged;
@@ -44,14 +50,6 @@ namespace DS4Windows.DS4Forms
             get { return label1.Text; }
             set { label1.Text = value; }
         }
-
-        [Category("Data")]
-        [Description("If probing path has been changed in App.config, add the same string here.")]
-        public string ProbingPath { get; set; } = "Lang";
-
-        [Category("Data")]
-        [Description("Filter language assembly file names in order to ont include irrelevant assemblies to the combo box.")]
-        public string LanguageAssemblyName { get; set; } = "DS4Windows.resources.dll";
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public int SelectedIndex

--- a/DS4Windows/DS4Forms/LanguagePackComboBox.cs
+++ b/DS4Windows/DS4Forms/LanguagePackComboBox.cs
@@ -20,7 +20,7 @@ namespace DS4Windows.DS4Forms
         public string ProbingPath = "Lang";
 
         // Filter language assembly file names in order to ont include irrelevant assemblies to the combo box.
-        public string LanguageAssemblyName { get; set; } = "DS4Windows.resources.dll";
+        public string LanguageAssemblyName = "DS4Windows.resources.dll";
 
         [Category("Action")]
         [Description("Fires when the combo box selected index is changed.")]


### PR DESCRIPTION
I moved the code that populates the list to the control's Load event handler. It executes the first time the control appears on screen (when the Settings tab is opened).

It wouldn't work in `Task.Run(() => {...})`, so I had to change it to `Invoke(new Action(() => {...})` (found in [this SO thread](https://stackoverflow.com/questions/142003/cross-thread-operation-not-valid-control-accessed-from-a-thread-other-than-the)), however now I'm not sure it even uses a separate thread now. Please see if there are any performance issues with this approach.

The alternative way could be to tie the list population on DS4Form's Load event, which is triggered just before the form is first shown (the property is already set up by that time too), but I'd rather let the user control handle its state and not create complicated dependencies.