### PR TITLE
Add VID + PID for Hori PS4 Mini

### DIFF
--- a/DS4Windows/DS4Library/DS4Devices.cs
+++ b/DS4Windows/DS4Library/DS4Devices.cs
@@ -31,12 +31,16 @@ namespace DS4Windows
         internal const int SONY_VID = 0x054C;
         internal const int RAZER_VID = 0x1532;
         internal const int NACON_VID = 0x146B;
+        internal const int HORI_VID = 0x0F0D;
 
         private static VidPidInfo[] knownDevices =
         {
-            new VidPidInfo(SONY_VID, 0xBA0), new VidPidInfo(SONY_VID, 0x5C4),
-            new VidPidInfo(SONY_VID, 0x09CC), new VidPidInfo(RAZER_VID, 0x1000),
-            new VidPidInfo(NACON_VID, 0x0D01)
+            new VidPidInfo(SONY_VID, 0xBA0),
+            new VidPidInfo(SONY_VID, 0x5C4),
+            new VidPidInfo(SONY_VID, 0x09CC),
+            new VidPidInfo(RAZER_VID, 0x1000),
+            new VidPidInfo(NACON_VID, 0x0D01),
+            new VidPidInfo(HORI_VID, 0x00EE)    // Hori PS4 Mini Wired Gamepad
         };
 
         private static string devicePathToInstanceId(string devicePath)


### PR DESCRIPTION
Hello!

I'd like to make a small change to allow DS4Windows to recognize the Hori Playstation 4 Mini Wired Gamepad (https://www.amazon.com/PlayStation-4-Mini-Wired-Gamepad/dp/B076MQ34PQ?)  please.

I've verified locally that it works (or at least DS4Windows is able to recognize the controller, and Witcher 3 was able to pick it up with this change.) 

The change adds the Hori Mini VID + PID to the list of known devices.

Thank you very much!