### PR TITLE
Move URL definition

### DIFF
--- a/DS4Windows/DS4Forms/DS4Form.cs
+++ b/DS4Windows/DS4Forms/DS4Form.cs
@@ -353,10 +353,9 @@ namespace DS4Windows
                 nUDUpdateTime.Value = checkwhen;
             }
 
-            Uri url = new Uri("http://23.239.26.40/ds4windows/files/builds/newest.txt"); // Sorry other devs, gonna have to find your own server
-
             if (checkwhen > 0 && DateTime.Now >= LastChecked + TimeSpan.FromHours(checkwhen))
             {
+                Uri url = new Uri("http://23.239.26.40/ds4windows/files/builds/newest.txt"); // Sorry other devs, gonna have to find your own server
                 wc.DownloadFileAsync(url, appdatapath + "\\version.txt");
                 wc.DownloadFileCompleted += Check_Version;
                 LastChecked = DateTime.Now;


### PR DESCRIPTION
I'm a non-updater user myself. I don't see a reason to define `url` when it's not used so I moved it slightly down the code. :)