### PR TITLE
Tray tooltip changes

### DIFF
--- a/DS4Windows/DS4Forms/DS4Form.cs
+++ b/DS4Windows/DS4Forms/DS4Form.cs
@@ -183,6 +183,7 @@ namespace DS4Windows
             cBUseWhiteIcon.Checked = UseWhiteIcon;
             Icon = Properties.Resources.DS4W;
             notifyIcon1.Icon = UseWhiteIcon ? Properties.Resources.DS4W___White : Properties.Resources.DS4W;
+            populateNotifyText();
             foreach (ToolStripMenuItem t in shortcuts)
                 t.DropDownItemClicked += Profile_Changed_Menu;
 

--- a/DS4Windows/DS4Forms/DS4Form.cs
+++ b/DS4Windows/DS4Forms/DS4Form.cs
@@ -1163,7 +1163,7 @@ Properties.Resources.DS4Update, MessageBoxButtons.YesNo, MessageBoxIcon.Question
                 string temp = Program.rootHub.getShortDS4ControllerInfo(i);
                 if (temp != Properties.Resources.NoneText)
                 {
-                    notifyText[i + 1] = (i + 1) + ": " + temp; // Carefully stay under the 63 character limit.
+                    notifyText[i + 1] = (i + 1) + ": " + temp;
                 }
                 else
                 {
@@ -1179,7 +1179,7 @@ Properties.Resources.DS4Update, MessageBoxButtons.YesNo, MessageBoxIcon.Question
             string temp = Program.rootHub.getShortDS4ControllerInfo(index);
             if (temp != Properties.Resources.NoneText)
             {
-                notifyText[index + 1] = (index + 1) + ": " + temp; // Carefully stay under the 63 character limit.
+                notifyText[index + 1] = (index + 1) + ": " + temp;
             }
             else
             {
@@ -1195,14 +1195,11 @@ Properties.Resources.DS4Update, MessageBoxButtons.YesNo, MessageBoxIcon.Question
                 string temp = notifyText[i];
                 if (!string.IsNullOrEmpty(temp))
                 {
-                    tooltip += "\n" + notifyText[i]; // Carefully stay under the 63 character limit.
+                    tooltip += "\n" + notifyText[i];
                 }
             }
 
-            if (tooltip.Length > 63)
-                notifyIcon1.Text = tooltip.Substring(0, 63);
-            else
-                notifyIcon1.Text = tooltip;
+            notifyIcon1.Text = tooltip.Length > 63 ? tooltip.Substring(0, 63) : tooltip; // Carefully stay under the 63 character limit.
         }
 
         protected void DeviceSerialChanged(object sender, SerialChangeArgs args)

--- a/DS4Windows/DS4Forms/DS4Form.resx
+++ b/DS4Windows/DS4Forms/DS4Form.resx
@@ -418,7 +418,7 @@
     <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="notifyIcon1.Text" xml:space="preserve">
-    <value>DS4 Xinput Tool</value>
+    <value>DS4Windows</value>
   </data>
   <data name="notifyIcon1.Visible" type="System.Boolean, mscorlib">
     <value>True</value>


### PR DESCRIPTION
- Change initial text defined in resource
- Populate tray icon text properly when app starts. This adds version info when having no controllers connected on app start.
- Shortened tray character limit code