### PR TITLE
Prevent DS4Update prompt from displaying when offline

### DIFF
--- a/DS4Windows/DS4Forms/DS4Form.cs
+++ b/DS4Windows/DS4Forms/DS4Form.cs
@@ -789,6 +789,7 @@ namespace DS4Windows
 
             if (string.IsNullOrWhiteSpace(newversion))
             {
+                File.Delete(appdatapath + "\\version.txt");
                 return;
             }
 
@@ -2106,6 +2107,7 @@ Properties.Resources.DS4Update, MessageBoxButtons.YesNo, MessageBoxIcon.Question
 
             if (string.IsNullOrWhiteSpace(newversion2))
             {
+                File.Delete(appdatapath + "\\version.txt");
                 this.BeginInvoke((System.Action)(() => MessageBox.Show(Properties.Resources.CouldNotContactUpdateServer, "DS4Windows Updater")));
                 return;
             }

--- a/DS4Windows/DS4Forms/DS4Form.cs
+++ b/DS4Windows/DS4Forms/DS4Form.cs
@@ -786,6 +786,12 @@ namespace DS4Windows
             FileVersionInfo fvi = FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location);
             string version = fvi.FileVersion;
             string newversion = File.ReadAllText(appdatapath + "\\version.txt").Trim();
+
+            if (string.IsNullOrWhiteSpace(newversion))
+            {
+                return;
+            }
+
             if (version.Replace(',', '.').CompareTo(newversion) != 0)
             {
                 if ((DialogResult)this.Invoke(new Func<DialogResult>(() => {
@@ -2097,6 +2103,13 @@ Properties.Resources.DS4Update, MessageBoxButtons.YesNo, MessageBoxIcon.Question
             FileVersionInfo fvi = FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location);
             string version2 = fvi.FileVersion;
             string newversion2 = File.ReadAllText(appdatapath + "\\version.txt").Trim();
+
+            if (string.IsNullOrWhiteSpace(newversion2))
+            {
+                this.BeginInvoke((System.Action)(() => MessageBox.Show(Properties.Resources.CouldNotContactUpdateServer, "DS4Windows Updater")));
+                return;
+            }
+
             if (version2.Replace(',', '.').CompareTo(newversion2) != 0)
             {
                 if ((DialogResult)this.Invoke(new Func<DialogResult>(() =>

--- a/DS4Windows/Properties/Resources.Designer.cs
+++ b/DS4Windows/Properties/Resources.Designer.cs
@@ -393,6 +393,15 @@ namespace DS4Windows.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Could not contact the update server. Please check your internet connection and try again..
+        /// </summary>
+        public static string CouldNotContactUpdateServer {
+            get {
+                return ResourceManager.GetString("CouldNotContactUpdateServer", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Warning: Could not open DS4 *Mac address* exclusively..
         /// </summary>
         public static string CouldNotOpenDS4 {

--- a/DS4Windows/Properties/Resources.resx
+++ b/DS4Windows/Properties/Resources.resx
@@ -796,4 +796,7 @@
   <data name="_checked" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\checked.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
+  <data name="CouldNotContactUpdateServer" xml:space="preserve">
+    <value>Could not contact the update server. Please check your internet connection and try again.</value>
+  </data>
 </root>


### PR DESCRIPTION
Hi!

Just fixing a small (most likely unintended?) behaviour I noticed while my internet was out.

When offline, opening DS4Windows could cause the DS4Update prompt to appear with a blank version number.

Similarly, clicking "Check for Update Now" would cause the same behaviour.

This fix introduces a check using `string.IsNullOrWhiteSpace` against the new version number. If true, abort version comparison and update procedure.

I have also added a message box notifying when the update has failed upon clicking "Check for Update Now".