### PR TITLE
Workaround fix to ViGem "stuck rumble motor" bug and allow saving a loadProfile spec action without unload trigger

### DIFF
--- a/DS4Windows/DS4Control/ControlService.cs
+++ b/DS4Windows/DS4Control/ControlService.cs
@@ -426,11 +426,11 @@ namespace DS4Windows
                             useDInputOnly[i] = false;
                             x360controls[i] = new Xbox360Controller(vigemTestClient);
                             int devIndex = i;
-                            /*x360controls[i].FeedbackReceived += (sender, args) =>
+                            x360controls[i].FeedbackReceived += (sender, args) =>
                             {
                                 SetDevRumble(device, args.LargeMotor, args.SmallMotor, devIndex);
                             };
-                            */
+                            
                             x360controls[i].Connect();
                             LogDebug("X360 Controller #" + (i + 1) + " connected");
                         }
@@ -683,11 +683,11 @@ namespace DS4Windows
                                 useDInputOnly[Index] = false;
                                 x360controls[Index] = new Xbox360Controller(vigemTestClient);
                                 int devIndex = Index;
-                                /*x360controls[Index].FeedbackReceived += (sender, args) =>
+                                x360controls[Index].FeedbackReceived += (sender, args) =>
                                 {
                                     SetDevRumble(device, args.LargeMotor, args.SmallMotor, devIndex);
                                 };
-                                */
+                                
                                 x360controls[Index].Connect();
                                 LogDebug("X360 Controller #" + (Index + 1) + " connected");
                             }
@@ -1060,11 +1060,11 @@ namespace DS4Windows
                     {
                         LogDebug("Plugging in X360 Controller #" + (ind + 1));
                         x360controls[ind] = new Xbox360Controller(vigemTestClient);
-                        /*x360controls[ind].FeedbackReceived += (eventsender, args) =>
+                        x360controls[ind].FeedbackReceived += (eventsender, args) =>
                         {
                             SetDevRumble(device, args.LargeMotor, args.SmallMotor, ind);
                         };
-                        */
+                        
                         x360controls[ind].Connect();
                         useDInputOnly[ind] = false;
                         LogDebug("X360 Controller #" + (ind + 1) + " connected");

--- a/DS4Windows/DS4Control/Mapping.cs
+++ b/DS4Windows/DS4Control/Mapping.cs
@@ -1896,11 +1896,15 @@ namespace DS4Windows
                             {
                                 actionFound = true;
 
-                                if (!actionDone[index].dev[device] && !useTempProfile[device])
+                                if (!actionDone[index].dev[device] && (!useTempProfile[device] || untriggeraction[device] == null || untriggeraction[device].typeID != SpecialAction.ActionTypeId.Profile) )
                                 {
                                     actionDone[index].dev[device] = true;
-                                    untriggeraction[device] = action;
-                                    untriggerindex[device] = index;
+                                    // If Loadprofile special action doesn't have unload trigger then don't set untrigger status. This way the new loaded profile allows yet another loadProfile action key events)
+                                    if (action.uTrigger.Count > 0)
+                                    {
+                                        untriggeraction[device] = action;
+                                        untriggerindex[device] = index;
+                                    }
                                     //foreach (DS4Controls dc in action.trigger)
                                     for (int i = 0, arlen = action.trigger.Count; i < arlen; i++)
                                     {

--- a/DS4Windows/DS4Control/ScpUtil.cs
+++ b/DS4Windows/DS4Control/ScpUtil.cs
@@ -3064,11 +3064,11 @@ namespace DS4Windows
                         if (xinputStatus && xinputPlug)
                         {
                             control.x360controls[device] = new Nefarius.ViGEm.Client.Targets.Xbox360Controller(control.vigemTestClient);
-                            /*control.x360controls[device].FeedbackReceived += (eventsender, args) =>
+                            control.x360controls[device].FeedbackReceived += (eventsender, args) =>
                             {
                                 control.SetDevRumble(tempDev, args.LargeMotor, args.SmallMotor, device);
                             };
-                            */
+                            
                             control.x360controls[device].Connect();
                             Global.useDInputOnly[device] = false;
                             AppLogger.LogToGui("X360 Controller #" + (device + 1) + " connected", false);

--- a/DS4Windows/DS4Forms/SpecActions.cs
+++ b/DS4Windows/DS4Forms/SpecActions.cs
@@ -92,13 +92,16 @@ namespace DS4Windows
                 case "Profile": 
                     cBActions.SelectedIndex = 3;
                     cBProfiles.Text = act.details;
-                    foreach (string s in act.ucontrols.Split('/'))
-                        foreach (ListViewItem lvi in lVUnloadTrigger.Items)
-                            if (lvi.Text == s)
-                            {
-                                lvi.Checked = true;
-                                break;
-                            }
+                    if (act.ucontrols != null)
+                    {
+                        foreach (string s in act.ucontrols.Split('/'))
+                            foreach (ListViewItem lvi in lVUnloadTrigger.Items)
+                                if (lvi.Text == s)
+                                {
+                                    lvi.Checked = true;
+                                    break;
+                                }
+                    }
                     break;
                 case "Key":
                     cBActions.SelectedIndex = 4;
@@ -261,7 +264,7 @@ namespace DS4Windows
                         }
                         break;
                     case 3:
-                        if (cBProfiles.SelectedIndex > 0 && ucontrols.Count > 0)
+                        if (cBProfiles.SelectedIndex > 0 /*&& ucontrols.Count > 0*/)
                         {
                             action = Properties.Resources.LoadProfile.Replace("*profile*", cBProfiles.Text);
                             actRe = true;


### PR DESCRIPTION
Brute force timer fix to the "stuck rumble motor" bug in ViGem virtual gamepad driver. This rumble autostop timer should be removed when a signed ViGem driver has a fix to this issue. Existing autostop timer is 2 secs, so this assumes that game keeps on updating a rumble values at least once in 2 secs. If rumble-0 event is lost or game doesn't send a new rumble value within 2 secs then rumble motor is automagically stopped (=assumed it is stuck). Usually games keep on sending rumble values as long an effect needs it, so this autostop timer works reasonable good in most games.