### PR TITLE
New feature: Unload a profile on regular trigger key release (ie. automatic untrigger for profiles).  Bug fix: Gyro mouse toggle option wrong after Startup and Hotplug LoadProfile call.

### DIFF
--- a/DS4Windows/DS4Control/ControlService.cs
+++ b/DS4Windows/DS4Control/ControlService.cs
@@ -403,6 +403,9 @@ namespace DS4Windows
                         device.SyncChange += this.On_SyncChange;
                         device.SyncChange += DS4Devices.UpdateSerial;
                         device.SerialChange += this.On_SerialChange;
+
+                        touchPad[i] = new Mouse(i, device);
+
                         if (!useTempProfile[i])
                         {
                             if (device.isValidSerial() && containsLinkedProfile(device.getMacAddress()))
@@ -417,7 +420,6 @@ namespace DS4Windows
                             LoadProfile(i, false, this, false, false);
                         }
 
-                        touchPad[i] = new Mouse(i, device);
                         device.LightBarColor = getMainColor(i);
 
                         if (!getDInputOnly(i) && device.isSynced())
@@ -641,6 +643,9 @@ namespace DS4Windows
                             device.SyncChange += this.On_SyncChange;
                             device.SyncChange += DS4Devices.UpdateSerial;
                             device.SerialChange += this.On_SerialChange;
+
+                            touchPad[Index] = new Mouse(Index, device);
+
                             if (!useTempProfile[Index])
                             {
                                 if (device.isValidSerial() && containsLinkedProfile(device.getMacAddress()))
@@ -655,7 +660,6 @@ namespace DS4Windows
                                 LoadProfile(Index, false, this, false, false);
                             }
 
-                            touchPad[Index] = new Mouse(Index, device);
                             device.LightBarColor = getMainColor(Index);
 
                             int tempIdx = Index;

--- a/DS4Windows/DS4Control/ScpUtil.cs
+++ b/DS4Windows/DS4Control/ScpUtil.cs
@@ -4072,6 +4072,8 @@ namespace DS4Windows
         public DateTime pastTime;
         public DateTime firstTap;
         public DateTime TimeofEnd;
+        public bool automaticUntrigger = false;
+        public string prevProfileName;  // Name of the previous profile where automaticUntrigger would jump back to (could be regular or temporary profile. Empty name is the same as regular profile)
 
         public SpecialAction(string name, string controls, string type, string details, double delay = 0, string extras = "")
         {
@@ -4181,7 +4183,10 @@ namespace DS4Windows
                 this.ucontrols = extras;
                 string[] uctrls = extras.Split('/');
                 foreach (string s in uctrls)
-                    uTrigger.Add(getDS4ControlsByName(s));
+                {
+                    if (s == "AutomaticUntrigger") this.automaticUntrigger = true;
+                    else uTrigger.Add(getDS4ControlsByName(s));
+                }
             }
         }
 

--- a/DS4Windows/DS4Forms/SpecActions.Designer.cs
+++ b/DS4Windows/DS4Forms/SpecActions.Designer.cs
@@ -86,6 +86,7 @@
             this.lbDTapDVR = new System.Windows.Forms.Label();
             this.lbHoldDVR = new System.Windows.Forms.Label();
             this.lbTapDVR = new System.Windows.Forms.Label();
+            this.cbProfileAutoUntrigger = new System.Windows.Forms.CheckBox();
             ((System.ComponentModel.ISupportInitialize)(this.pBProgram)).BeginInit();
             this.pnlProgram.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.nUDProg)).BeginInit();
@@ -383,6 +384,7 @@
             // 
             // pnlProfile
             // 
+            this.pnlProfile.Controls.Add(this.cbProfileAutoUntrigger);
             this.pnlProfile.Controls.Add(this.lbUnloadTipProfile);
             this.pnlProfile.Controls.Add(this.cBProfiles);
             this.pnlProfile.Controls.Add(this.btnSetUTriggerProfile);
@@ -596,6 +598,12 @@
             resources.ApplyResources(this.lbTapDVR, "lbTapDVR");
             this.lbTapDVR.Name = "lbTapDVR";
             // 
+            // cbProfileAutoUntrigger
+            // 
+            resources.ApplyResources(this.cbProfileAutoUntrigger, "cbProfileAutoUntrigger");
+            this.cbProfileAutoUntrigger.Name = "cbProfileAutoUntrigger";
+            this.cbProfileAutoUntrigger.UseVisualStyleBackColor = true;
+            // 
             // SpecActions
             // 
             resources.ApplyResources(this, "$this");
@@ -698,5 +706,6 @@
         public System.Windows.Forms.Button btnDTapT;
         public System.Windows.Forms.Button btnHoldT;
         public System.Windows.Forms.Button btnSTapT;
+        private System.Windows.Forms.CheckBox cbProfileAutoUntrigger;
     }
 }

--- a/DS4Windows/DS4Forms/SpecActions.cs
+++ b/DS4Windows/DS4Forms/SpecActions.cs
@@ -270,7 +270,7 @@ namespace DS4Windows
                             actRe = true;
                             if (!string.IsNullOrEmpty(oldprofilename) && oldprofilename != tBName.Text)
                                 Global.RemoveAction(oldprofilename);
-                            Global.SaveAction(tBName.Text, String.Join("/", controls), cBActions.SelectedIndex, cBProfiles.Text, edit, String.Join("/", ucontrols));
+                            Global.SaveAction(tBName.Text, String.Join("/", controls), cBActions.SelectedIndex, cBProfiles.Text, edit, String.Join("/", ucontrols) + (/* TODO: Is automaticUntrigger set */ true ? (ucontrols.Count > 0 ? "/" : "") + "AutomaticUntrigger" : "") );
                         }
                         else
                             btnSetUTriggerProfile.ForeColor = Color.Red;

--- a/DS4Windows/DS4Forms/SpecActions.cs
+++ b/DS4Windows/DS4Forms/SpecActions.cs
@@ -102,6 +102,7 @@ namespace DS4Windows
                                     break;
                                 }
                     }
+                    cbProfileAutoUntrigger.Checked = act.automaticUntrigger;
                     break;
                 case "Key":
                     cBActions.SelectedIndex = 4;
@@ -270,7 +271,7 @@ namespace DS4Windows
                             actRe = true;
                             if (!string.IsNullOrEmpty(oldprofilename) && oldprofilename != tBName.Text)
                                 Global.RemoveAction(oldprofilename);
-                            Global.SaveAction(tBName.Text, String.Join("/", controls), cBActions.SelectedIndex, cBProfiles.Text, edit, String.Join("/", ucontrols) + (/* TODO: Is automaticUntrigger set */ true ? (ucontrols.Count > 0 ? "/" : "") + "AutomaticUntrigger" : "") );
+                            Global.SaveAction(tBName.Text, String.Join("/", controls), cBActions.SelectedIndex, cBProfiles.Text, edit, String.Join("/", ucontrols) + (cbProfileAutoUntrigger.Checked ? (ucontrols.Count > 0 ? "/" : "") + "AutomaticUntrigger" : "") );
                         }
                         else
                             btnSetUTriggerProfile.ForeColor = Color.Red;

--- a/DS4Windows/DS4Forms/SpecActions.resx
+++ b/DS4Windows/DS4Forms/SpecActions.resx
@@ -2116,7 +2116,7 @@
     <value>NoControl</value>
   </data>
   <data name="lbUnloadTipProfile.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 55</value>
+    <value>0, 95</value>
   </data>
   <data name="lbUnloadTipProfile.Size" type="System.Drawing.Size, System.Drawing">
     <value>100, 23</value>
@@ -2140,7 +2140,7 @@
     <value>206, 58</value>
   </data>
   <data name="pnlProfile.Size" type="System.Drawing.Size, System.Drawing">
-    <value>161, 94</value>
+    <value>161, 121</value>
   </data>
   <data name="pnlProfile.TabIndex" type="System.Int32, mscorlib">
     <value>262</value>
@@ -2159,6 +2159,45 @@
   </data>
   <data name="&gt;&gt;pnlProfile.ZOrder" xml:space="preserve">
     <value>11</value>
+  </data>
+  <data name="&gt;&gt;cbProfileAutoUntrigger.Name" xml:space="preserve">
+    <value>cbProfileAutoUntrigger</value>
+  </data>
+  <data name="&gt;&gt;cbProfileAutoUntrigger.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbProfileAutoUntrigger.Parent" xml:space="preserve">
+    <value>pnlProfile</value>
+  </data>
+  <data name="&gt;&gt;cbProfileAutoUntrigger.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="cbProfileAutoUntrigger.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cbProfileAutoUntrigger.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 61</value>
+  </data>
+  <data name="cbProfileAutoUntrigger.Size" type="System.Drawing.Size, System.Drawing">
+    <value>144, 17</value>
+  </data>
+  <data name="cbProfileAutoUntrigger.TabIndex" type="System.Int32, mscorlib">
+    <value>260</value>
+  </data>
+  <data name="cbProfileAutoUntrigger.Text" xml:space="preserve">
+    <value>Unload on trigger release</value>
+  </data>
+  <data name="&gt;&gt;cbProfileAutoUntrigger.Name" xml:space="preserve">
+    <value>cbProfileAutoUntrigger</value>
+  </data>
+  <data name="&gt;&gt;cbProfileAutoUntrigger.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbProfileAutoUntrigger.Parent" xml:space="preserve">
+    <value>pnlProfile</value>
+  </data>
+  <data name="&gt;&gt;cbProfileAutoUntrigger.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="nUDDCBT.Location" type="System.Drawing.Point, System.Drawing">
     <value>56, 3</value>


### PR DESCRIPTION
New feature:
- Special action "Load profile" has a new "Unload on trigger release" option. If this option is set then the loaded temporary profile is automatically unloaded (=untriggered and goes back to previous profile) when a regular trigger key is released. This makes it possible to define sort of "shift key for a whole profile" type of functionality. Related to #658 issue and feature suggestion.

Bug fix:
- Issue #664 bug fix. Gyro mouse "toggle" option is wrong right after an initial Startup and Hotplug LoadProfile call because the touchpad[idx} Mouse object was created after the profile was loaded. LoadProfile method tried to set the option but failed because the Mouse obj was missing at this point. LoadProfile worked when a profile was switched after the initial Startup and Hotplug events. Fixed this bug in Startup and Hotplug methods by creating the Mouse object before calling LoadProfile method.
