### PR TITLE
Support for Razer Raiju Ultimate (USB) and CronusMax (PS4OutputMode) devices

### DIFF
--- a/DS4Windows/DS4Library/DS4Devices.cs
+++ b/DS4Windows/DS4Library/DS4Devices.cs
@@ -46,6 +46,9 @@ namespace DS4Windows
             new VidPidInfo(0x2E95, 0x7725), // Scuf Vantage gamepad
             new VidPidInfo(0x11C0, 0x4001), // PS4 Fun Controller
             new VidPidInfo(RAZER_VID, 0x1007), // Razer Raiju Tournament Edition
+            new VidPidInfo(RAZER_VID, 0x1004), // Razer Raiju Ultimate Edition (wired)
+            new VidPidInfo(RAZER_VID, 0x1009), // Razer Raiju Ultimate Edition (BT). Doesn't work yet for some reason even when non-steam Razer driver lists the BT Razer Ultimate with this ID.
+            new VidPidInfo(SONY_VID, 0x05C5), // CronusMax (PS4 Output Mode)
         };
 
         private static string devicePathToInstanceId(string devicePath)

--- a/DS4Windows/HidLibrary/HidDevices.cs
+++ b/DS4Windows/HidLibrary/HidDevices.cs
@@ -43,6 +43,7 @@ namespace DS4Windows
 
         public static IEnumerable<HidDevice> EnumerateDS4(VidPidInfo[] devInfo)
         {
+            //int iDebugDevCount = 0;
             List<HidDevice> foundDevs = new List<HidDevice>();
             int devInfoLen = devInfo.Length;
             IEnumerable<DeviceInfo> temp = EnumerateDevices();
@@ -50,8 +51,10 @@ namespace DS4Windows
             //for (int i = 0, len = temp.Count(); i < len; i++)
             {
                 DeviceInfo x = devEnum.Current;
-                //DeviceInfo x = temp.ElementAt(i);
+                //DeviceInfo x = temp.ElementAt(i);               
                 HidDevice tempDev = new HidDevice(x.Path, x.Description);
+                //iDebugDevCount++;
+                //AppLogger.LogToGui($"DEBUG: HID#{iDebugDevCount} Path={x.Path}  Description={x.Description}  VID={tempDev.Attributes.VendorHexId}  PID={tempDev.Attributes.ProductHexId}  Usage=0x{tempDev.Capabilities.Usage.ToString("X")}  Version=0x{tempDev.Attributes.Version.ToString("X")}", false);
                 bool found = false;
                 for (int j = 0; !found && j < devInfoLen; j++)
                 {


### PR DESCRIPTION
Support for Razer Raiju Ultimate (USB wired connection only at the moment). #689. VID/PID provided by Neodraon and Voovoodoo.

Support for CronusMax PS4OutputMode. #702. VID/PID provided by Aidolii.