### PR TITLE
Implemented square stick roundness selectability

### DIFF
--- a/DS4Windows/DS4Control/Mapping.cs
+++ b/DS4Windows/DS4Control/Mapping.cs
@@ -102,10 +102,9 @@ namespace DS4Windows
                 squared = new DS4Vector2(0.0, 0.0);
             }
 
-            public void CircleToSquare()
+            public void CircleToSquare(double roundness)
             {
                 const double PiOverFour = Math.PI / 4.0;
-                const double roundness = 5.0;
 
                 // Determine the theta angle
                 double angle = Math.Atan2(current.y, -current.x);
@@ -876,9 +875,10 @@ namespace DS4Windows
                 double capY = dState.LY >= 128 ? 127.0 : 128.0;
                 double tempX = (dState.LX - 128.0) / capX;
                 double tempY = (dState.LY - 128.0) / capY;
+                double roundness = getSquareStickRoundness(device);
                 DS4SquareStick sqstick = outSqrStk[device];
                 sqstick.current.x = tempX; sqstick.current.y = tempY;
-                sqstick.CircleToSquare();
+                sqstick.CircleToSquare(roundness);
                 //Console.WriteLine("Input ({0}) | Output ({1})", tempY, sqstick.current.y);
                 tempX = sqstick.current.x < -1.0 ? -1.0 : sqstick.current.x > 1.0
                     ? 1.0 : sqstick.current.x;
@@ -974,9 +974,10 @@ namespace DS4Windows
                 double capY = dState.RY >= 128 ? 127.0 : 128.0;
                 double tempX = (dState.RX - 128.0) / capX;
                 double tempY = (dState.RY - 128.0) / capY;
+                double roundness = getSquareStickRoundness(device);
                 DS4SquareStick sqstick = outSqrStk[device];
                 sqstick.current.x = tempX; sqstick.current.y = tempY;
-                sqstick.CircleToSquare();
+                sqstick.CircleToSquare(roundness);
                 tempX = sqstick.current.x < -1.0 ? -1.0 : sqstick.current.x > 1.0
                     ? 1.0 : sqstick.current.x;
                 tempY = sqstick.current.y < -1.0 ? -1.0 : sqstick.current.y > 1.0

--- a/DS4Windows/DS4Control/ScpUtil.cs
+++ b/DS4Windows/DS4Control/ScpUtil.cs
@@ -1184,6 +1184,12 @@ namespace DS4Windows
             return m_Config.sqRSStickMode[device];
         }
 
+        public static double[] squareStickRoundness => m_Config.sqStickRoundness;
+        public static double getSquareStickRoundness(int device) 
+        {
+            return m_Config.sqStickRoundness[device];
+        }
+
         public static int[] lsOutCurveMode => m_Config.lsOutCurveMode;
         public static int getLsOutCurveMode(int index)
         {
@@ -1630,6 +1636,7 @@ namespace DS4Windows
             false, false };
         public bool[] sqLSStickMode = new bool[5] { false, false, false, false, false };
         public bool[] sqRSStickMode = new bool[5] { false, false, false, false, false };
+        public double[] sqStickRoundness = new double[5] { 5.0, 5.0, 5.0, 5.0, 5.0 };
         public int[] lsOutCurveMode = new int[5] { 0, 0, 0, 0, 0 };
         public int[] rsOutCurveMode = new int[5] { 0, 0, 0, 0, 0 };
         public int[] l2OutCurveMode = new int[5] { 0, 0, 0, 0, 0 };
@@ -2016,6 +2023,8 @@ namespace DS4Windows
 
                 XmlNode xmlLsSquareStickMode = m_Xdoc.CreateNode(XmlNodeType.Element, "LSSquareStick", null); xmlLsSquareStickMode.InnerText = sqLSStickMode[device].ToString(); Node.AppendChild(xmlLsSquareStickMode);
                 XmlNode xmlRsSquareStickMode = m_Xdoc.CreateNode(XmlNodeType.Element, "RSSquareStick", null); xmlRsSquareStickMode.InnerText = sqRSStickMode[device].ToString(); Node.AppendChild(xmlRsSquareStickMode);
+
+                XmlNode xmlSquareStickRoundness = m_Xdoc.CreateNode(XmlNodeType.Element, "SquareStickRoundness", null); xmlSquareStickRoundness.InnerText = sqStickRoundness[device].ToString(); Node.AppendChild(xmlSquareStickRoundness);
 
                 XmlNode xmlL2OutputCurveMode = m_Xdoc.CreateNode(XmlNodeType.Element, "L2OutputCurveMode", null); xmlL2OutputCurveMode.InnerText = axisOutputCurveString(l2OutCurveMode[device]); Node.AppendChild(xmlL2OutputCurveMode);
                 XmlNode xmlR2OutputCurveMode = m_Xdoc.CreateNode(XmlNodeType.Element, "R2OutputCurveMode", null); xmlR2OutputCurveMode.InnerText = axisOutputCurveString(r2OutCurveMode[device]); Node.AppendChild(xmlR2OutputCurveMode);
@@ -2920,6 +2929,9 @@ namespace DS4Windows
 
                 try { Item = m_Xdoc.SelectSingleNode("/" + rootname + "/LSSquareStick"); bool.TryParse(Item.InnerText, out sqLSStickMode[device]); }
                 catch { sqLSStickMode[device] = false; missingSetting = true; }
+
+                try { Item = m_Xdoc.SelectSingleNode("/" + rootname + "/SquareStickRoundness"); double.TryParse(Item.InnerText, out sqStickRoundness[device]); }
+                catch { sqStickRoundness[device] = 5.0; missingSetting = true; }
 
                 try { Item = m_Xdoc.SelectSingleNode("/" + rootname + "/RSSquareStick"); bool.TryParse(Item.InnerText, out sqRSStickMode[device]); }
                 catch { sqRSStickMode[device] = false; missingSetting = true; }
@@ -4220,6 +4232,7 @@ namespace DS4Windows
             gyroMouseHorizontalAxis[device] = 0;
             sqLSStickMode[device] = false;
             sqRSStickMode[device] = false;
+            sqStickRoundness[device] = 5;
             lsOutCurveMode[device] = 0;
             rsOutCurveMode[device] = 0;
             l2OutCurveMode[device] = 0;

--- a/DS4Windows/DS4Forms/Options.Designer.cs
+++ b/DS4Windows/DS4Forms/Options.Designer.cs
@@ -28,1060 +28,1063 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.components = new System.ComponentModel.Container();
-            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Options));
-            this.lowColorChooserButton = new System.Windows.Forms.Button();
-            this.nUDRainbow = new System.Windows.Forms.NumericUpDown();
-            this.tBBlueBar = new System.Windows.Forms.TrackBar();
-            this.tBGreenBar = new System.Windows.Forms.TrackBar();
-            this.tBRedBar = new System.Windows.Forms.TrackBar();
-            this.cBLightbyBattery = new System.Windows.Forms.CheckBox();
-            this.lbBlue = new System.Windows.Forms.Label();
-            this.lbGreen = new System.Windows.Forms.Label();
-            this.lbspc = new System.Windows.Forms.Label();
-            this.lbRed = new System.Windows.Forms.Label();
-            this.cBDoubleTap = new System.Windows.Forms.CheckBox();
-            this.cBTap = new System.Windows.Forms.CheckBox();
-            this.nUDTap = new System.Windows.Forms.NumericUpDown();
-            this.cBScroll = new System.Windows.Forms.CheckBox();
-            this.cBSlide = new System.Windows.Forms.CheckBox();
-            this.nUDScroll = new System.Windows.Forms.NumericUpDown();
-            this.nUDTouch = new System.Windows.Forms.NumericUpDown();
-            this.lbButtonMouseSens = new System.Windows.Forms.Label();
-            this.cBlowerRCOn = new System.Windows.Forms.CheckBox();
-            this.cBTouchpadJitterCompensation = new System.Windows.Forms.CheckBox();
-            this.lbL2 = new System.Windows.Forms.Label();
-            this.lbR2 = new System.Windows.Forms.Label();
-            this.lbIdleMinutes = new System.Windows.Forms.Label();
-            this.nUDIdleDisconnect = new System.Windows.Forms.NumericUpDown();
-            this.nUDR2 = new System.Windows.Forms.NumericUpDown();
-            this.cBFlushHIDQueue = new System.Windows.Forms.CheckBox();
-            this.nUDRumbleBoost = new System.Windows.Forms.NumericUpDown();
-            this.btnRumbleHeavyTest = new System.Windows.Forms.Button();
-            this.lbFull = new System.Windows.Forms.Label();
-            this.lbLowRed = new System.Windows.Forms.Label();
-            this.lbLowGreen = new System.Windows.Forms.Label();
-            this.lbLowBlue = new System.Windows.Forms.Label();
-            this.tBLowRedBar = new System.Windows.Forms.TrackBar();
-            this.tBLowGreenBar = new System.Windows.Forms.TrackBar();
-            this.tBLowBlueBar = new System.Windows.Forms.TrackBar();
-            this.lbEmpty = new System.Windows.Forms.Label();
-            this.pnlFull = new System.Windows.Forms.Panel();
-            this.pnlLowBattery = new System.Windows.Forms.Panel();
-            this.lbRS = new System.Windows.Forms.Label();
-            this.lbLS = new System.Windows.Forms.Label();
-            this.nUDRS = new System.Windows.Forms.NumericUpDown();
-            this.numUDMouseSens = new System.Windows.Forms.NumericUpDown();
-            this.nUDLS = new System.Windows.Forms.NumericUpDown();
-            this.nUDL2 = new System.Windows.Forms.NumericUpDown();
-            this.gBTouchpad = new System.Windows.Forms.GroupBox();
-            this.pnlTPMouse = new System.Windows.Forms.Panel();
-            this.trackFrictionLb = new System.Windows.Forms.Label();
-            this.trackFrictionNUD = new System.Windows.Forms.NumericUpDown();
-            this.trackballCk = new System.Windows.Forms.CheckBox();
-            this.touchpadDisInvertButton = new System.Windows.Forms.Button();
-            this.label25 = new System.Windows.Forms.Label();
-            this.label15 = new System.Windows.Forms.Label();
-            this.touchpadInvertComboBox = new System.Windows.Forms.ComboBox();
-            this.cbStartTouchpadOff = new System.Windows.Forms.CheckBox();
-            this.rBTPControls = new System.Windows.Forms.RadioButton();
-            this.rBTPMouse = new System.Windows.Forms.RadioButton();
-            this.fLPTouchSwipe = new System.Windows.Forms.FlowLayoutPanel();
-            this.bnSwipeUp = new System.Windows.Forms.Button();
-            this.cMSPresets = new System.Windows.Forms.ContextMenuStrip(this.components);
-            this.controlToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
-            this.defaultToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.DpadToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.tSMIDPadInverted = new System.Windows.Forms.ToolStripMenuItem();
-            this.tSMIDPadInvertedX = new System.Windows.Forms.ToolStripMenuItem();
-            this.tSMIDPadInvertedY = new System.Windows.Forms.ToolStripMenuItem();
-            this.LSToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.tSMILSInverted = new System.Windows.Forms.ToolStripMenuItem();
-            this.tSMILSInvertedX = new System.Windows.Forms.ToolStripMenuItem();
-            this.tSMILSInvertedY = new System.Windows.Forms.ToolStripMenuItem();
-            this.RSToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.tSMIRSInverted = new System.Windows.Forms.ToolStripMenuItem();
-            this.tSMIRSInvertedX = new System.Windows.Forms.ToolStripMenuItem();
-            this.tSMIRSInvertedY = new System.Windows.Forms.ToolStripMenuItem();
-            this.ABXYToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.WASDToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.wScanCodeWASDToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.ArrowKeysToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.wScanCodeArrowKeysToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.MouseToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.tSMIMouseInverted = new System.Windows.Forms.ToolStripMenuItem();
-            this.tSMIMouseInvertedX = new System.Windows.Forms.ToolStripMenuItem();
-            this.tSMIMouseInvertedY = new System.Windows.Forms.ToolStripMenuItem();
-            this.lbSwipeUp = new System.Windows.Forms.Label();
-            this.bnSwipeDown = new System.Windows.Forms.Button();
-            this.lbSwipeDown = new System.Windows.Forms.Label();
-            this.bnSwipeLeft = new System.Windows.Forms.Button();
-            this.lbSwipeLeft = new System.Windows.Forms.Label();
-            this.bnSwipeRight = new System.Windows.Forms.Button();
-            this.lbSwipeRight = new System.Windows.Forms.Label();
-            this.gBOther = new System.Windows.Forms.GroupBox();
-            this.OutContTypeCb = new System.Windows.Forms.ComboBox();
-            this.outcontLb = new System.Windows.Forms.Label();
-            this.btPollRateLabel = new System.Windows.Forms.Label();
-            this.btPollRateComboBox = new System.Windows.Forms.ComboBox();
-            this.enableTouchToggleCheckbox = new System.Windows.Forms.CheckBox();
-            this.cBDinput = new System.Windows.Forms.CheckBox();
-            this.pBProgram = new System.Windows.Forms.PictureBox();
-            this.cBLaunchProgram = new System.Windows.Forms.CheckBox();
-            this.btnBrowse = new System.Windows.Forms.Button();
-            this.lbUseController = new System.Windows.Forms.Label();
-            this.cBMouseAccel = new System.Windows.Forms.CheckBox();
-            this.nUDSixaxis = new System.Windows.Forms.NumericUpDown();
-            this.cBControllerInput = new System.Windows.Forms.CheckBox();
-            this.cBIdleDisconnect = new System.Windows.Forms.CheckBox();
-            this.gBLightbar = new System.Windows.Forms.GroupBox();
-            this.btnRainbow = new System.Windows.Forms.Button();
-            this.lbRainbowB = new System.Windows.Forms.Label();
-            this.nUDRainbowB = new System.Windows.Forms.NumericUpDown();
-            this.cBFlashType = new System.Windows.Forms.ComboBox();
-            this.cBWhileCharging = new System.Windows.Forms.ComboBox();
-            this.btnFlashColor = new System.Windows.Forms.Button();
-            this.btnChargingColor = new System.Windows.Forms.Button();
-            this.lbWhileCharging = new System.Windows.Forms.Label();
-            this.lbPercentFlashBar = new System.Windows.Forms.Label();
-            this.nUDflashLED = new System.Windows.Forms.NumericUpDown();
-            this.gBRumble = new System.Windows.Forms.GroupBox();
-            this.lbPercentRumble = new System.Windows.Forms.Label();
-            this.btnRumbleLightTest = new System.Windows.Forms.Button();
-            this.lbSixaxisX = new System.Windows.Forms.Label();
-            this.lbSixaxisZ = new System.Windows.Forms.Label();
-            this.nUDSZ = new System.Windows.Forms.NumericUpDown();
-            this.nUDSX = new System.Windows.Forms.NumericUpDown();
-            this.openFileDialog1 = new System.Windows.Forms.OpenFileDialog();
-            this.lbL2TrackS = new System.Windows.Forms.TabPage();
-            this.pnlSATrack = new System.Windows.Forms.Panel();
-            this.btnSATrack = new System.Windows.Forms.Button();
-            this.btnSATrackS = new System.Windows.Forms.Button();
-            this.lbL2Track = new System.Windows.Forms.Label();
-            this.lbRSTip = new System.Windows.Forms.Label();
-            this.lbInputDelay = new System.Windows.Forms.Label();
-            this.lbR2Track = new System.Windows.Forms.Label();
-            this.lbLSTip = new System.Windows.Forms.Label();
-            this.lbSATip = new System.Windows.Forms.Label();
-            this.tBR2 = new System.Windows.Forms.TrackBar();
-            this.tBL2 = new System.Windows.Forms.TrackBar();
-            this.pnlSixaxis = new System.Windows.Forms.Panel();
-            this.tBsixaxisAccelX = new System.Windows.Forms.TrackBar();
-            this.lb6Accel = new System.Windows.Forms.Label();
-            this.tBsixaxisGyroX = new System.Windows.Forms.TrackBar();
-            this.lb6Gryo = new System.Windows.Forms.Label();
-            this.tBsixaxisGyroY = new System.Windows.Forms.TrackBar();
-            this.tBsixaxisGyroZ = new System.Windows.Forms.TrackBar();
-            this.tBsixaxisAccelY = new System.Windows.Forms.TrackBar();
-            this.tBsixaxisAccelZ = new System.Windows.Forms.TrackBar();
-            this.pnlLSTrack = new System.Windows.Forms.Panel();
-            this.btnLSTrack = new System.Windows.Forms.Button();
-            this.btnLSTrackS = new System.Windows.Forms.Button();
-            this.pnlRSTrack = new System.Windows.Forms.Panel();
-            this.btnRSTrackS = new System.Windows.Forms.Button();
-            this.btnRSTrack = new System.Windows.Forms.Button();
-            this.fLPTiltControls = new System.Windows.Forms.FlowLayoutPanel();
-            this.bnGyroZN = new System.Windows.Forms.Button();
-            this.lbGyroZN = new System.Windows.Forms.Label();
-            this.bnGyroZP = new System.Windows.Forms.Button();
-            this.lbGyroZP = new System.Windows.Forms.Label();
-            this.bnGyroXP = new System.Windows.Forms.Button();
-            this.lbGyroXP = new System.Windows.Forms.Label();
-            this.bnGyroXN = new System.Windows.Forms.Button();
-            this.lbGyroXN = new System.Windows.Forms.Label();
-            this.lblSteeringWheelEmulationAxis = new System.Windows.Forms.Label();
-            this.cBSteeringWheelEmulationAxis = new System.Windows.Forms.ComboBox();
-            this.lblSteeringWheelEmulationRange = new System.Windows.Forms.Label();
-            this.cBSteeringWheelEmulationRange = new System.Windows.Forms.ComboBox();
-            this.btnSteeringWheelEmulationCalibrate = new System.Windows.Forms.Button();
-            this.tCControls = new System.Windows.Forms.TabControl();
-            this.tPControls = new System.Windows.Forms.TabPage();
-            this.lBControls = new System.Windows.Forms.ListBox();
-            this.lbControlTip = new System.Windows.Forms.Label();
-            this.pnlController = new System.Windows.Forms.Panel();
-            this.pBHoveredButton = new System.Windows.Forms.PictureBox();
-            this.lbLRS = new System.Windows.Forms.Label();
-            this.lbLLS = new System.Windows.Forms.Label();
-            this.bnRSDown = new System.Windows.Forms.Button();
-            this.lbLTouchUpper = new System.Windows.Forms.Label();
-            this.lbLTouchRight = new System.Windows.Forms.Label();
-            this.bnL3 = new System.Windows.Forms.Button();
-            this.lbLTouchLM = new System.Windows.Forms.Label();
-            this.bnRSUp = new System.Windows.Forms.Button();
-            this.lbLR2 = new System.Windows.Forms.Label();
-            this.bnRSRight = new System.Windows.Forms.Button();
-            this.lbLL2 = new System.Windows.Forms.Label();
-            this.bnR3 = new System.Windows.Forms.Button();
-            this.lbLR1 = new System.Windows.Forms.Label();
-            this.bnRSLeft = new System.Windows.Forms.Button();
-            this.lbLL1 = new System.Windows.Forms.Label();
-            this.bnLSLeft = new System.Windows.Forms.Button();
-            this.lbLPS = new System.Windows.Forms.Label();
-            this.bnLSUp = new System.Windows.Forms.Button();
-            this.lbLLeft = new System.Windows.Forms.Label();
-            this.bnLSRight = new System.Windows.Forms.Button();
-            this.lbLright = new System.Windows.Forms.Label();
-            this.bnLSDown = new System.Windows.Forms.Button();
-            this.lbLDown = new System.Windows.Forms.Label();
-            this.bnR2 = new System.Windows.Forms.Button();
-            this.bnUp = new System.Windows.Forms.Button();
-            this.bnDown = new System.Windows.Forms.Button();
-            this.bnTriangle = new System.Windows.Forms.Button();
-            this.bnR1 = new System.Windows.Forms.Button();
-            this.bnSquare = new System.Windows.Forms.Button();
-            this.bnRight = new System.Windows.Forms.Button();
-            this.lbLUp = new System.Windows.Forms.Label();
-            this.bnLeft = new System.Windows.Forms.Button();
-            this.lbLShare = new System.Windows.Forms.Label();
-            this.bnOptions = new System.Windows.Forms.Button();
-            this.bnShare = new System.Windows.Forms.Button();
-            this.lbLOptions = new System.Windows.Forms.Label();
-            this.bnL1 = new System.Windows.Forms.Button();
-            this.bnTouchRight = new System.Windows.Forms.Button();
-            this.bnL2 = new System.Windows.Forms.Button();
-            this.lbLTriangle = new System.Windows.Forms.Label();
-            this.bnTouchLeft = new System.Windows.Forms.Button();
-            this.lbLSquare = new System.Windows.Forms.Label();
-            this.bnTouchMulti = new System.Windows.Forms.Button();
-            this.lbLCircle = new System.Windows.Forms.Label();
-            this.lbLCross = new System.Windows.Forms.Label();
-            this.bnTouchUpper = new System.Windows.Forms.Button();
-            this.btnLightbar = new System.Windows.Forms.Button();
-            this.bnPS = new System.Windows.Forms.Button();
-            this.bnCross = new System.Windows.Forms.Button();
-            this.bnCircle = new System.Windows.Forms.Button();
-            this.lbControlName = new System.Windows.Forms.Label();
-            this.tPSpecial = new System.Windows.Forms.TabPage();
-            this.pnlActions = new System.Windows.Forms.Panel();
-            this.lVActions = new System.Windows.Forms.ListView();
-            this.cHName = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.cHTrigger = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.cHAction = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.panel2 = new System.Windows.Forms.Panel();
-            this.fLPActionButtons = new System.Windows.Forms.FlowLayoutPanel();
-            this.btnNewAction = new System.Windows.Forms.Button();
-            this.btnEditAction = new System.Windows.Forms.Button();
-            this.btnRemAction = new System.Windows.Forms.Button();
-            this.lbActionsTip = new System.Windows.Forms.Label();
-            this.tCSens = new System.Windows.Forms.TabControl();
-            this.tPDeadzone = new System.Windows.Forms.TabPage();
-            this.antiDeadzoneTabPage = new System.Windows.Forms.TabPage();
-            this.nUDSixaxisZAntiDead = new System.Windows.Forms.NumericUpDown();
-            this.nUDSixaxisXAntiDead = new System.Windows.Forms.NumericUpDown();
-            this.label20 = new System.Windows.Forms.Label();
-            this.label19 = new System.Windows.Forms.Label();
-            this.nUDR2AntiDead = new System.Windows.Forms.NumericUpDown();
-            this.label3 = new System.Windows.Forms.Label();
-            this.nUDL2AntiDead = new System.Windows.Forms.NumericUpDown();
-            this.label4 = new System.Windows.Forms.Label();
-            this.nUDRSAntiDead = new System.Windows.Forms.NumericUpDown();
-            this.label2 = new System.Windows.Forms.Label();
-            this.nUDLSAntiDead = new System.Windows.Forms.NumericUpDown();
-            this.label1 = new System.Windows.Forms.Label();
-            this.maxZoneTabPage = new System.Windows.Forms.TabPage();
-            this.nUDSixAxisZMaxZone = new System.Windows.Forms.NumericUpDown();
-            this.nUDSixAxisXMaxZone = new System.Windows.Forms.NumericUpDown();
-            this.label18 = new System.Windows.Forms.Label();
-            this.label17 = new System.Windows.Forms.Label();
-            this.nUDR2Maxzone = new System.Windows.Forms.NumericUpDown();
-            this.nUDL2Maxzone = new System.Windows.Forms.NumericUpDown();
-            this.label8 = new System.Windows.Forms.Label();
-            this.label7 = new System.Windows.Forms.Label();
-            this.nUDRSMaxZone = new System.Windows.Forms.NumericUpDown();
-            this.label6 = new System.Windows.Forms.Label();
-            this.nUDLSMaxZone = new System.Windows.Forms.NumericUpDown();
-            this.label5 = new System.Windows.Forms.Label();
-            this.squStickTabPage = new System.Windows.Forms.TabPage();
-            this.rsSquStickCk = new System.Windows.Forms.CheckBox();
-            this.lsSquStickCk = new System.Windows.Forms.CheckBox();
-            this.tPOutCurve = new System.Windows.Forms.TabPage();
-            this.cBSixaxisZOutputCurve = new System.Windows.Forms.ComboBox();
-            this.cBSixaxisXOutputCurve = new System.Windows.Forms.ComboBox();
-            this.label24 = new System.Windows.Forms.Label();
-            this.label23 = new System.Windows.Forms.Label();
-            this.cBR2OutputCurve = new System.Windows.Forms.ComboBox();
-            this.cBL2OutputCurve = new System.Windows.Forms.ComboBox();
-            this.label22 = new System.Windows.Forms.Label();
-            this.label21 = new System.Windows.Forms.Label();
-            this.rsOutCurveComboBox = new System.Windows.Forms.ComboBox();
-            this.lsOutCurveComboBox = new System.Windows.Forms.ComboBox();
-            this.label10 = new System.Windows.Forms.Label();
-            this.label9 = new System.Windows.Forms.Label();
-            this.tPCurve = new System.Windows.Forms.TabPage();
-            this.nUDLSCurve = new System.Windows.Forms.NumericUpDown();
-            this.nUDRSCurve = new System.Windows.Forms.NumericUpDown();
-            this.lbRSCurve = new System.Windows.Forms.Label();
-            this.lbRSCurvePercent = new System.Windows.Forms.Label();
-            this.lbLSCurvePercent = new System.Windows.Forms.Label();
-            this.lbLSCurve = new System.Windows.Forms.Label();
-            this.tpRotation = new System.Windows.Forms.TabPage();
-            this.nUDRSRotation = new System.Windows.Forms.NumericUpDown();
-            this.label14 = new System.Windows.Forms.Label();
-            this.nUDLSRotation = new System.Windows.Forms.NumericUpDown();
-            this.label13 = new System.Windows.Forms.Label();
-            this.fLPSettings = new System.Windows.Forms.FlowLayoutPanel();
-            this.gBGyro = new System.Windows.Forms.GroupBox();
-            this.rBSAControls = new System.Windows.Forms.RadioButton();
-            this.rBSAMouse = new System.Windows.Forms.RadioButton();
-            this.pnlSAMouse = new System.Windows.Forms.Panel();
-            this.toggleGyroMCb = new System.Windows.Forms.CheckBox();
-            this.label27 = new System.Windows.Forms.Label();
-            this.gyroMouseDzNUD = new System.Windows.Forms.NumericUpDown();
-            this.label26 = new System.Windows.Forms.Label();
-            this.triggerCondAndCombo = new System.Windows.Forms.ComboBox();
-            this.cBGyroMouseXAxis = new System.Windows.Forms.ComboBox();
-            this.label16 = new System.Windows.Forms.Label();
-            this.lbGyroSmooth = new System.Windows.Forms.Label();
-            this.cBGyroSmooth = new System.Windows.Forms.CheckBox();
-            this.lbSmoothWeight = new System.Windows.Forms.Label();
-            this.nUDGyroSmoothWeight = new System.Windows.Forms.NumericUpDown();
-            this.label12 = new System.Windows.Forms.Label();
-            this.nUDGyroMouseVertScale = new System.Windows.Forms.NumericUpDown();
-            this.label11 = new System.Windows.Forms.Label();
-            this.gyroTriggerBehavior = new System.Windows.Forms.CheckBox();
-            this.cBGyroInvertY = new System.Windows.Forms.CheckBox();
-            this.cBGyroInvertX = new System.Windows.Forms.CheckBox();
-            this.lbGyroInvert = new System.Windows.Forms.Label();
-            this.lbGyroTriggers = new System.Windows.Forms.Label();
-            this.btnGyroTriggers = new System.Windows.Forms.Button();
-            this.nUDGyroSensitivity = new System.Windows.Forms.NumericUpDown();
-            this.lbGyroSens = new System.Windows.Forms.Label();
-            this.gBSensitivity = new System.Windows.Forms.GroupBox();
-            this.lbL2S = new System.Windows.Forms.Label();
-            this.nUDL2S = new System.Windows.Forms.NumericUpDown();
-            this.nUDLSS = new System.Windows.Forms.NumericUpDown();
-            this.lbSixaxisXS = new System.Windows.Forms.Label();
-            this.nUDR2S = new System.Windows.Forms.NumericUpDown();
-            this.lbSixaxisZS = new System.Windows.Forms.Label();
-            this.nUDRSS = new System.Windows.Forms.NumericUpDown();
-            this.lbR2LS = new System.Windows.Forms.Label();
-            this.nUDSXS = new System.Windows.Forms.NumericUpDown();
-            this.lbRSS = new System.Windows.Forms.Label();
-            this.lbLSS = new System.Windows.Forms.Label();
-            this.nUDSZS = new System.Windows.Forms.NumericUpDown();
-            this.cMGyroTriggers = new System.Windows.Forms.ContextMenuStrip(this.components);
-            this.crossToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.circleToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.squareToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.triangleToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.l1ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.l2ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.r1ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.r2ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.onTouchpadToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.downToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.leftToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.rightToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.l3ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.r3ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.fingerOnTouchpadToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.fingersOnTouchpadToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.optionsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.shareToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.pSToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.alwaysOnToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.cMTouchDisableInvert = new System.Windows.Forms.ContextMenuStrip(this.components);
-            this.crossTouchInvStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.circleTouchInvStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.squareTouchInvStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.triangleTouchInvStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.l1TouchInvStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.l2TouchInvStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.r1TouchInvStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.r2TouchInvStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.upTouchInvStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.downTouchInvStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.leftTouchInvStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.rightTouchInvStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.l3TouchInvStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.r3TouchInvStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.oneFingerTouchInvStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.twoFingerTouchInvStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.optionsTouchInvStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.shareTouchInvStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.psTouchInvStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDRainbow)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.tBBlueBar)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.tBGreenBar)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.tBRedBar)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDTap)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDScroll)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDTouch)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDIdleDisconnect)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDR2)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDRumbleBoost)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.tBLowRedBar)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.tBLowGreenBar)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.tBLowBlueBar)).BeginInit();
-            this.pnlFull.SuspendLayout();
-            this.pnlLowBattery.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDRS)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.numUDMouseSens)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDLS)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDL2)).BeginInit();
-            this.gBTouchpad.SuspendLayout();
-            this.pnlTPMouse.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.trackFrictionNUD)).BeginInit();
-            this.fLPTouchSwipe.SuspendLayout();
-            this.cMSPresets.SuspendLayout();
-            this.gBOther.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.pBProgram)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDSixaxis)).BeginInit();
-            this.gBLightbar.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDRainbowB)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDflashLED)).BeginInit();
-            this.gBRumble.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDSZ)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDSX)).BeginInit();
-            this.lbL2TrackS.SuspendLayout();
-            this.pnlSATrack.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.tBR2)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.tBL2)).BeginInit();
-            this.pnlSixaxis.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.tBsixaxisAccelX)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.tBsixaxisGyroX)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.tBsixaxisGyroY)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.tBsixaxisGyroZ)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.tBsixaxisAccelY)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.tBsixaxisAccelZ)).BeginInit();
-            this.pnlLSTrack.SuspendLayout();
-            this.pnlRSTrack.SuspendLayout();
-            this.fLPTiltControls.SuspendLayout();
-            this.tCControls.SuspendLayout();
-            this.tPControls.SuspendLayout();
-            this.pnlController.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.pBHoveredButton)).BeginInit();
-            this.tPSpecial.SuspendLayout();
-            this.pnlActions.SuspendLayout();
-            this.panel2.SuspendLayout();
-            this.fLPActionButtons.SuspendLayout();
-            this.tCSens.SuspendLayout();
-            this.tPDeadzone.SuspendLayout();
-            this.antiDeadzoneTabPage.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDSixaxisZAntiDead)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDSixaxisXAntiDead)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDR2AntiDead)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDL2AntiDead)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDRSAntiDead)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDLSAntiDead)).BeginInit();
-            this.maxZoneTabPage.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDSixAxisZMaxZone)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDSixAxisXMaxZone)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDR2Maxzone)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDL2Maxzone)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDRSMaxZone)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDLSMaxZone)).BeginInit();
-            this.squStickTabPage.SuspendLayout();
-            this.tPOutCurve.SuspendLayout();
-            this.tPCurve.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDLSCurve)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDRSCurve)).BeginInit();
-            this.tpRotation.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDRSRotation)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDLSRotation)).BeginInit();
-            this.fLPSettings.SuspendLayout();
-            this.gBGyro.SuspendLayout();
-            this.pnlSAMouse.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.gyroMouseDzNUD)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDGyroSmoothWeight)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDGyroMouseVertScale)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDGyroSensitivity)).BeginInit();
-            this.gBSensitivity.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDL2S)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDLSS)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDR2S)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDRSS)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDSXS)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDSZS)).BeginInit();
-            this.cMGyroTriggers.SuspendLayout();
-            this.cMTouchDisableInvert.SuspendLayout();
-            this.SuspendLayout();
-            // 
-            // lowColorChooserButton
-            // 
-            this.lowColorChooserButton.BackColor = System.Drawing.Color.White;
-            resources.ApplyResources(this.lowColorChooserButton, "lowColorChooserButton");
-            this.lowColorChooserButton.Name = "lowColorChooserButton";
-            this.lowColorChooserButton.UseVisualStyleBackColor = false;
-            this.lowColorChooserButton.Click += new System.EventHandler(this.lowColorChooserButton_Click);
-            // 
-            // nUDRainbow
-            // 
-            resources.ApplyResources(this.nUDRainbow, "nUDRainbow");
-            this.nUDRainbow.Maximum = new decimal(new int[] {
+      this.components = new System.ComponentModel.Container();
+      System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Options));
+      this.lowColorChooserButton = new System.Windows.Forms.Button();
+      this.nUDRainbow = new System.Windows.Forms.NumericUpDown();
+      this.tBBlueBar = new System.Windows.Forms.TrackBar();
+      this.tBGreenBar = new System.Windows.Forms.TrackBar();
+      this.tBRedBar = new System.Windows.Forms.TrackBar();
+      this.cBLightbyBattery = new System.Windows.Forms.CheckBox();
+      this.lbBlue = new System.Windows.Forms.Label();
+      this.lbGreen = new System.Windows.Forms.Label();
+      this.lbspc = new System.Windows.Forms.Label();
+      this.lbRed = new System.Windows.Forms.Label();
+      this.cBDoubleTap = new System.Windows.Forms.CheckBox();
+      this.cBTap = new System.Windows.Forms.CheckBox();
+      this.nUDTap = new System.Windows.Forms.NumericUpDown();
+      this.cBScroll = new System.Windows.Forms.CheckBox();
+      this.cBSlide = new System.Windows.Forms.CheckBox();
+      this.nUDScroll = new System.Windows.Forms.NumericUpDown();
+      this.nUDTouch = new System.Windows.Forms.NumericUpDown();
+      this.lbButtonMouseSens = new System.Windows.Forms.Label();
+      this.cBlowerRCOn = new System.Windows.Forms.CheckBox();
+      this.cBTouchpadJitterCompensation = new System.Windows.Forms.CheckBox();
+      this.lbL2 = new System.Windows.Forms.Label();
+      this.lbR2 = new System.Windows.Forms.Label();
+      this.lbIdleMinutes = new System.Windows.Forms.Label();
+      this.nUDIdleDisconnect = new System.Windows.Forms.NumericUpDown();
+      this.nUDR2 = new System.Windows.Forms.NumericUpDown();
+      this.cBFlushHIDQueue = new System.Windows.Forms.CheckBox();
+      this.nUDRumbleBoost = new System.Windows.Forms.NumericUpDown();
+      this.btnRumbleHeavyTest = new System.Windows.Forms.Button();
+      this.lbFull = new System.Windows.Forms.Label();
+      this.lbLowRed = new System.Windows.Forms.Label();
+      this.lbLowGreen = new System.Windows.Forms.Label();
+      this.lbLowBlue = new System.Windows.Forms.Label();
+      this.tBLowRedBar = new System.Windows.Forms.TrackBar();
+      this.tBLowGreenBar = new System.Windows.Forms.TrackBar();
+      this.tBLowBlueBar = new System.Windows.Forms.TrackBar();
+      this.lbEmpty = new System.Windows.Forms.Label();
+      this.pnlFull = new System.Windows.Forms.Panel();
+      this.pnlLowBattery = new System.Windows.Forms.Panel();
+      this.lbRS = new System.Windows.Forms.Label();
+      this.lbLS = new System.Windows.Forms.Label();
+      this.nUDRS = new System.Windows.Forms.NumericUpDown();
+      this.numUDMouseSens = new System.Windows.Forms.NumericUpDown();
+      this.nUDLS = new System.Windows.Forms.NumericUpDown();
+      this.nUDL2 = new System.Windows.Forms.NumericUpDown();
+      this.gBTouchpad = new System.Windows.Forms.GroupBox();
+      this.pnlTPMouse = new System.Windows.Forms.Panel();
+      this.trackFrictionLb = new System.Windows.Forms.Label();
+      this.trackFrictionNUD = new System.Windows.Forms.NumericUpDown();
+      this.trackballCk = new System.Windows.Forms.CheckBox();
+      this.touchpadDisInvertButton = new System.Windows.Forms.Button();
+      this.label25 = new System.Windows.Forms.Label();
+      this.label15 = new System.Windows.Forms.Label();
+      this.touchpadInvertComboBox = new System.Windows.Forms.ComboBox();
+      this.cbStartTouchpadOff = new System.Windows.Forms.CheckBox();
+      this.rBTPControls = new System.Windows.Forms.RadioButton();
+      this.rBTPMouse = new System.Windows.Forms.RadioButton();
+      this.fLPTouchSwipe = new System.Windows.Forms.FlowLayoutPanel();
+      this.bnSwipeUp = new System.Windows.Forms.Button();
+      this.cMSPresets = new System.Windows.Forms.ContextMenuStrip(this.components);
+      this.controlToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+      this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
+      this.defaultToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+      this.DpadToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+      this.tSMIDPadInverted = new System.Windows.Forms.ToolStripMenuItem();
+      this.tSMIDPadInvertedX = new System.Windows.Forms.ToolStripMenuItem();
+      this.tSMIDPadInvertedY = new System.Windows.Forms.ToolStripMenuItem();
+      this.LSToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+      this.tSMILSInverted = new System.Windows.Forms.ToolStripMenuItem();
+      this.tSMILSInvertedX = new System.Windows.Forms.ToolStripMenuItem();
+      this.tSMILSInvertedY = new System.Windows.Forms.ToolStripMenuItem();
+      this.RSToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+      this.tSMIRSInverted = new System.Windows.Forms.ToolStripMenuItem();
+      this.tSMIRSInvertedX = new System.Windows.Forms.ToolStripMenuItem();
+      this.tSMIRSInvertedY = new System.Windows.Forms.ToolStripMenuItem();
+      this.ABXYToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+      this.WASDToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+      this.wScanCodeWASDToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+      this.ArrowKeysToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+      this.wScanCodeArrowKeysToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+      this.MouseToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+      this.tSMIMouseInverted = new System.Windows.Forms.ToolStripMenuItem();
+      this.tSMIMouseInvertedX = new System.Windows.Forms.ToolStripMenuItem();
+      this.tSMIMouseInvertedY = new System.Windows.Forms.ToolStripMenuItem();
+      this.lbSwipeUp = new System.Windows.Forms.Label();
+      this.bnSwipeDown = new System.Windows.Forms.Button();
+      this.lbSwipeDown = new System.Windows.Forms.Label();
+      this.bnSwipeLeft = new System.Windows.Forms.Button();
+      this.lbSwipeLeft = new System.Windows.Forms.Label();
+      this.bnSwipeRight = new System.Windows.Forms.Button();
+      this.lbSwipeRight = new System.Windows.Forms.Label();
+      this.gBOther = new System.Windows.Forms.GroupBox();
+      this.OutContTypeCb = new System.Windows.Forms.ComboBox();
+      this.outcontLb = new System.Windows.Forms.Label();
+      this.btPollRateLabel = new System.Windows.Forms.Label();
+      this.btPollRateComboBox = new System.Windows.Forms.ComboBox();
+      this.enableTouchToggleCheckbox = new System.Windows.Forms.CheckBox();
+      this.cBDinput = new System.Windows.Forms.CheckBox();
+      this.pBProgram = new System.Windows.Forms.PictureBox();
+      this.cBLaunchProgram = new System.Windows.Forms.CheckBox();
+      this.btnBrowse = new System.Windows.Forms.Button();
+      this.lbUseController = new System.Windows.Forms.Label();
+      this.cBMouseAccel = new System.Windows.Forms.CheckBox();
+      this.nUDSixaxis = new System.Windows.Forms.NumericUpDown();
+      this.cBControllerInput = new System.Windows.Forms.CheckBox();
+      this.cBIdleDisconnect = new System.Windows.Forms.CheckBox();
+      this.gBLightbar = new System.Windows.Forms.GroupBox();
+      this.btnRainbow = new System.Windows.Forms.Button();
+      this.lbRainbowB = new System.Windows.Forms.Label();
+      this.nUDRainbowB = new System.Windows.Forms.NumericUpDown();
+      this.cBFlashType = new System.Windows.Forms.ComboBox();
+      this.cBWhileCharging = new System.Windows.Forms.ComboBox();
+      this.btnFlashColor = new System.Windows.Forms.Button();
+      this.btnChargingColor = new System.Windows.Forms.Button();
+      this.lbWhileCharging = new System.Windows.Forms.Label();
+      this.lbPercentFlashBar = new System.Windows.Forms.Label();
+      this.nUDflashLED = new System.Windows.Forms.NumericUpDown();
+      this.gBRumble = new System.Windows.Forms.GroupBox();
+      this.lbPercentRumble = new System.Windows.Forms.Label();
+      this.btnRumbleLightTest = new System.Windows.Forms.Button();
+      this.lbSixaxisX = new System.Windows.Forms.Label();
+      this.lbSixaxisZ = new System.Windows.Forms.Label();
+      this.nUDSZ = new System.Windows.Forms.NumericUpDown();
+      this.nUDSX = new System.Windows.Forms.NumericUpDown();
+      this.openFileDialog1 = new System.Windows.Forms.OpenFileDialog();
+      this.lbL2TrackS = new System.Windows.Forms.TabPage();
+      this.pnlSATrack = new System.Windows.Forms.Panel();
+      this.btnSATrack = new System.Windows.Forms.Button();
+      this.btnSATrackS = new System.Windows.Forms.Button();
+      this.lbL2Track = new System.Windows.Forms.Label();
+      this.lbRSTip = new System.Windows.Forms.Label();
+      this.lbInputDelay = new System.Windows.Forms.Label();
+      this.lbR2Track = new System.Windows.Forms.Label();
+      this.lbLSTip = new System.Windows.Forms.Label();
+      this.lbSATip = new System.Windows.Forms.Label();
+      this.tBR2 = new System.Windows.Forms.TrackBar();
+      this.tBL2 = new System.Windows.Forms.TrackBar();
+      this.pnlSixaxis = new System.Windows.Forms.Panel();
+      this.tBsixaxisAccelX = new System.Windows.Forms.TrackBar();
+      this.lb6Accel = new System.Windows.Forms.Label();
+      this.tBsixaxisGyroX = new System.Windows.Forms.TrackBar();
+      this.lb6Gryo = new System.Windows.Forms.Label();
+      this.tBsixaxisGyroY = new System.Windows.Forms.TrackBar();
+      this.tBsixaxisGyroZ = new System.Windows.Forms.TrackBar();
+      this.tBsixaxisAccelY = new System.Windows.Forms.TrackBar();
+      this.tBsixaxisAccelZ = new System.Windows.Forms.TrackBar();
+      this.pnlLSTrack = new System.Windows.Forms.Panel();
+      this.btnLSTrack = new System.Windows.Forms.Button();
+      this.btnLSTrackS = new System.Windows.Forms.Button();
+      this.pnlRSTrack = new System.Windows.Forms.Panel();
+      this.btnRSTrackS = new System.Windows.Forms.Button();
+      this.btnRSTrack = new System.Windows.Forms.Button();
+      this.fLPTiltControls = new System.Windows.Forms.FlowLayoutPanel();
+      this.bnGyroZN = new System.Windows.Forms.Button();
+      this.lbGyroZN = new System.Windows.Forms.Label();
+      this.bnGyroZP = new System.Windows.Forms.Button();
+      this.lbGyroZP = new System.Windows.Forms.Label();
+      this.bnGyroXP = new System.Windows.Forms.Button();
+      this.lbGyroXP = new System.Windows.Forms.Label();
+      this.bnGyroXN = new System.Windows.Forms.Button();
+      this.lbGyroXN = new System.Windows.Forms.Label();
+      this.lblSteeringWheelEmulationAxis = new System.Windows.Forms.Label();
+      this.cBSteeringWheelEmulationAxis = new System.Windows.Forms.ComboBox();
+      this.lblSteeringWheelEmulationRange = new System.Windows.Forms.Label();
+      this.cBSteeringWheelEmulationRange = new System.Windows.Forms.ComboBox();
+      this.btnSteeringWheelEmulationCalibrate = new System.Windows.Forms.Button();
+      this.tCControls = new System.Windows.Forms.TabControl();
+      this.tPControls = new System.Windows.Forms.TabPage();
+      this.lBControls = new System.Windows.Forms.ListBox();
+      this.lbControlTip = new System.Windows.Forms.Label();
+      this.pnlController = new System.Windows.Forms.Panel();
+      this.pBHoveredButton = new System.Windows.Forms.PictureBox();
+      this.lbLRS = new System.Windows.Forms.Label();
+      this.lbLLS = new System.Windows.Forms.Label();
+      this.bnRSDown = new System.Windows.Forms.Button();
+      this.lbLTouchUpper = new System.Windows.Forms.Label();
+      this.lbLTouchRight = new System.Windows.Forms.Label();
+      this.bnL3 = new System.Windows.Forms.Button();
+      this.lbLTouchLM = new System.Windows.Forms.Label();
+      this.bnRSUp = new System.Windows.Forms.Button();
+      this.lbLR2 = new System.Windows.Forms.Label();
+      this.bnRSRight = new System.Windows.Forms.Button();
+      this.lbLL2 = new System.Windows.Forms.Label();
+      this.bnR3 = new System.Windows.Forms.Button();
+      this.lbLR1 = new System.Windows.Forms.Label();
+      this.bnRSLeft = new System.Windows.Forms.Button();
+      this.lbLL1 = new System.Windows.Forms.Label();
+      this.bnLSLeft = new System.Windows.Forms.Button();
+      this.lbLPS = new System.Windows.Forms.Label();
+      this.bnLSUp = new System.Windows.Forms.Button();
+      this.lbLLeft = new System.Windows.Forms.Label();
+      this.bnLSRight = new System.Windows.Forms.Button();
+      this.lbLright = new System.Windows.Forms.Label();
+      this.bnLSDown = new System.Windows.Forms.Button();
+      this.lbLDown = new System.Windows.Forms.Label();
+      this.bnR2 = new System.Windows.Forms.Button();
+      this.bnUp = new System.Windows.Forms.Button();
+      this.bnDown = new System.Windows.Forms.Button();
+      this.bnTriangle = new System.Windows.Forms.Button();
+      this.bnR1 = new System.Windows.Forms.Button();
+      this.bnSquare = new System.Windows.Forms.Button();
+      this.bnRight = new System.Windows.Forms.Button();
+      this.lbLUp = new System.Windows.Forms.Label();
+      this.bnLeft = new System.Windows.Forms.Button();
+      this.lbLShare = new System.Windows.Forms.Label();
+      this.bnOptions = new System.Windows.Forms.Button();
+      this.bnShare = new System.Windows.Forms.Button();
+      this.lbLOptions = new System.Windows.Forms.Label();
+      this.bnL1 = new System.Windows.Forms.Button();
+      this.bnTouchRight = new System.Windows.Forms.Button();
+      this.bnL2 = new System.Windows.Forms.Button();
+      this.lbLTriangle = new System.Windows.Forms.Label();
+      this.bnTouchLeft = new System.Windows.Forms.Button();
+      this.lbLSquare = new System.Windows.Forms.Label();
+      this.bnTouchMulti = new System.Windows.Forms.Button();
+      this.lbLCircle = new System.Windows.Forms.Label();
+      this.lbLCross = new System.Windows.Forms.Label();
+      this.bnTouchUpper = new System.Windows.Forms.Button();
+      this.btnLightbar = new System.Windows.Forms.Button();
+      this.bnPS = new System.Windows.Forms.Button();
+      this.bnCross = new System.Windows.Forms.Button();
+      this.bnCircle = new System.Windows.Forms.Button();
+      this.lbControlName = new System.Windows.Forms.Label();
+      this.tPSpecial = new System.Windows.Forms.TabPage();
+      this.pnlActions = new System.Windows.Forms.Panel();
+      this.lVActions = new System.Windows.Forms.ListView();
+      this.cHName = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+      this.cHTrigger = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+      this.cHAction = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+      this.panel2 = new System.Windows.Forms.Panel();
+      this.fLPActionButtons = new System.Windows.Forms.FlowLayoutPanel();
+      this.btnNewAction = new System.Windows.Forms.Button();
+      this.btnEditAction = new System.Windows.Forms.Button();
+      this.btnRemAction = new System.Windows.Forms.Button();
+      this.lbActionsTip = new System.Windows.Forms.Label();
+      this.tCSens = new System.Windows.Forms.TabControl();
+      this.tPDeadzone = new System.Windows.Forms.TabPage();
+      this.antiDeadzoneTabPage = new System.Windows.Forms.TabPage();
+      this.nUDSixaxisZAntiDead = new System.Windows.Forms.NumericUpDown();
+      this.nUDSixaxisXAntiDead = new System.Windows.Forms.NumericUpDown();
+      this.label20 = new System.Windows.Forms.Label();
+      this.label19 = new System.Windows.Forms.Label();
+      this.nUDR2AntiDead = new System.Windows.Forms.NumericUpDown();
+      this.label3 = new System.Windows.Forms.Label();
+      this.nUDL2AntiDead = new System.Windows.Forms.NumericUpDown();
+      this.label4 = new System.Windows.Forms.Label();
+      this.nUDRSAntiDead = new System.Windows.Forms.NumericUpDown();
+      this.label2 = new System.Windows.Forms.Label();
+      this.nUDLSAntiDead = new System.Windows.Forms.NumericUpDown();
+      this.label1 = new System.Windows.Forms.Label();
+      this.maxZoneTabPage = new System.Windows.Forms.TabPage();
+      this.nUDSixAxisZMaxZone = new System.Windows.Forms.NumericUpDown();
+      this.nUDSixAxisXMaxZone = new System.Windows.Forms.NumericUpDown();
+      this.label18 = new System.Windows.Forms.Label();
+      this.label17 = new System.Windows.Forms.Label();
+      this.nUDR2Maxzone = new System.Windows.Forms.NumericUpDown();
+      this.nUDL2Maxzone = new System.Windows.Forms.NumericUpDown();
+      this.label8 = new System.Windows.Forms.Label();
+      this.label7 = new System.Windows.Forms.Label();
+      this.nUDRSMaxZone = new System.Windows.Forms.NumericUpDown();
+      this.label6 = new System.Windows.Forms.Label();
+      this.nUDLSMaxZone = new System.Windows.Forms.NumericUpDown();
+      this.label5 = new System.Windows.Forms.Label();
+      this.squStickTabPage = new System.Windows.Forms.TabPage();
+      this.RoundnessNUpDown = new System.Windows.Forms.NumericUpDown();
+      this.label28 = new System.Windows.Forms.Label();
+      this.rsSquStickCk = new System.Windows.Forms.CheckBox();
+      this.lsSquStickCk = new System.Windows.Forms.CheckBox();
+      this.tPOutCurve = new System.Windows.Forms.TabPage();
+      this.cBSixaxisZOutputCurve = new System.Windows.Forms.ComboBox();
+      this.cBSixaxisXOutputCurve = new System.Windows.Forms.ComboBox();
+      this.label24 = new System.Windows.Forms.Label();
+      this.label23 = new System.Windows.Forms.Label();
+      this.cBR2OutputCurve = new System.Windows.Forms.ComboBox();
+      this.cBL2OutputCurve = new System.Windows.Forms.ComboBox();
+      this.label22 = new System.Windows.Forms.Label();
+      this.label21 = new System.Windows.Forms.Label();
+      this.rsOutCurveComboBox = new System.Windows.Forms.ComboBox();
+      this.lsOutCurveComboBox = new System.Windows.Forms.ComboBox();
+      this.label10 = new System.Windows.Forms.Label();
+      this.label9 = new System.Windows.Forms.Label();
+      this.tPCurve = new System.Windows.Forms.TabPage();
+      this.nUDLSCurve = new System.Windows.Forms.NumericUpDown();
+      this.nUDRSCurve = new System.Windows.Forms.NumericUpDown();
+      this.lbRSCurve = new System.Windows.Forms.Label();
+      this.lbRSCurvePercent = new System.Windows.Forms.Label();
+      this.lbLSCurvePercent = new System.Windows.Forms.Label();
+      this.lbLSCurve = new System.Windows.Forms.Label();
+      this.tpRotation = new System.Windows.Forms.TabPage();
+      this.nUDRSRotation = new System.Windows.Forms.NumericUpDown();
+      this.label14 = new System.Windows.Forms.Label();
+      this.nUDLSRotation = new System.Windows.Forms.NumericUpDown();
+      this.label13 = new System.Windows.Forms.Label();
+      this.fLPSettings = new System.Windows.Forms.FlowLayoutPanel();
+      this.gBGyro = new System.Windows.Forms.GroupBox();
+      this.rBSAControls = new System.Windows.Forms.RadioButton();
+      this.rBSAMouse = new System.Windows.Forms.RadioButton();
+      this.pnlSAMouse = new System.Windows.Forms.Panel();
+      this.toggleGyroMCb = new System.Windows.Forms.CheckBox();
+      this.label27 = new System.Windows.Forms.Label();
+      this.gyroMouseDzNUD = new System.Windows.Forms.NumericUpDown();
+      this.label26 = new System.Windows.Forms.Label();
+      this.triggerCondAndCombo = new System.Windows.Forms.ComboBox();
+      this.cBGyroMouseXAxis = new System.Windows.Forms.ComboBox();
+      this.label16 = new System.Windows.Forms.Label();
+      this.lbGyroSmooth = new System.Windows.Forms.Label();
+      this.cBGyroSmooth = new System.Windows.Forms.CheckBox();
+      this.lbSmoothWeight = new System.Windows.Forms.Label();
+      this.nUDGyroSmoothWeight = new System.Windows.Forms.NumericUpDown();
+      this.label12 = new System.Windows.Forms.Label();
+      this.nUDGyroMouseVertScale = new System.Windows.Forms.NumericUpDown();
+      this.label11 = new System.Windows.Forms.Label();
+      this.gyroTriggerBehavior = new System.Windows.Forms.CheckBox();
+      this.cBGyroInvertY = new System.Windows.Forms.CheckBox();
+      this.cBGyroInvertX = new System.Windows.Forms.CheckBox();
+      this.lbGyroInvert = new System.Windows.Forms.Label();
+      this.lbGyroTriggers = new System.Windows.Forms.Label();
+      this.btnGyroTriggers = new System.Windows.Forms.Button();
+      this.nUDGyroSensitivity = new System.Windows.Forms.NumericUpDown();
+      this.lbGyroSens = new System.Windows.Forms.Label();
+      this.gBSensitivity = new System.Windows.Forms.GroupBox();
+      this.lbL2S = new System.Windows.Forms.Label();
+      this.nUDL2S = new System.Windows.Forms.NumericUpDown();
+      this.nUDLSS = new System.Windows.Forms.NumericUpDown();
+      this.lbSixaxisXS = new System.Windows.Forms.Label();
+      this.nUDR2S = new System.Windows.Forms.NumericUpDown();
+      this.lbSixaxisZS = new System.Windows.Forms.Label();
+      this.nUDRSS = new System.Windows.Forms.NumericUpDown();
+      this.lbR2LS = new System.Windows.Forms.Label();
+      this.nUDSXS = new System.Windows.Forms.NumericUpDown();
+      this.lbRSS = new System.Windows.Forms.Label();
+      this.lbLSS = new System.Windows.Forms.Label();
+      this.nUDSZS = new System.Windows.Forms.NumericUpDown();
+      this.cMGyroTriggers = new System.Windows.Forms.ContextMenuStrip(this.components);
+      this.crossToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+      this.circleToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+      this.squareToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+      this.triangleToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+      this.l1ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+      this.l2ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+      this.r1ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+      this.r2ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+      this.onTouchpadToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+      this.downToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+      this.leftToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+      this.rightToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+      this.l3ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+      this.r3ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+      this.fingerOnTouchpadToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+      this.fingersOnTouchpadToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+      this.optionsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+      this.shareToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+      this.pSToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+      this.alwaysOnToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+      this.cMTouchDisableInvert = new System.Windows.Forms.ContextMenuStrip(this.components);
+      this.crossTouchInvStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+      this.circleTouchInvStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+      this.squareTouchInvStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+      this.triangleTouchInvStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+      this.l1TouchInvStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+      this.l2TouchInvStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+      this.r1TouchInvStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+      this.r2TouchInvStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+      this.upTouchInvStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+      this.downTouchInvStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+      this.leftTouchInvStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+      this.rightTouchInvStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+      this.l3TouchInvStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+      this.r3TouchInvStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+      this.oneFingerTouchInvStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+      this.twoFingerTouchInvStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+      this.optionsTouchInvStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+      this.shareTouchInvStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+      this.psTouchInvStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDRainbow)).BeginInit();
+      ((System.ComponentModel.ISupportInitialize)(this.tBBlueBar)).BeginInit();
+      ((System.ComponentModel.ISupportInitialize)(this.tBGreenBar)).BeginInit();
+      ((System.ComponentModel.ISupportInitialize)(this.tBRedBar)).BeginInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDTap)).BeginInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDScroll)).BeginInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDTouch)).BeginInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDIdleDisconnect)).BeginInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDR2)).BeginInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDRumbleBoost)).BeginInit();
+      ((System.ComponentModel.ISupportInitialize)(this.tBLowRedBar)).BeginInit();
+      ((System.ComponentModel.ISupportInitialize)(this.tBLowGreenBar)).BeginInit();
+      ((System.ComponentModel.ISupportInitialize)(this.tBLowBlueBar)).BeginInit();
+      this.pnlFull.SuspendLayout();
+      this.pnlLowBattery.SuspendLayout();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDRS)).BeginInit();
+      ((System.ComponentModel.ISupportInitialize)(this.numUDMouseSens)).BeginInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDLS)).BeginInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDL2)).BeginInit();
+      this.gBTouchpad.SuspendLayout();
+      this.pnlTPMouse.SuspendLayout();
+      ((System.ComponentModel.ISupportInitialize)(this.trackFrictionNUD)).BeginInit();
+      this.fLPTouchSwipe.SuspendLayout();
+      this.cMSPresets.SuspendLayout();
+      this.gBOther.SuspendLayout();
+      ((System.ComponentModel.ISupportInitialize)(this.pBProgram)).BeginInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDSixaxis)).BeginInit();
+      this.gBLightbar.SuspendLayout();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDRainbowB)).BeginInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDflashLED)).BeginInit();
+      this.gBRumble.SuspendLayout();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDSZ)).BeginInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDSX)).BeginInit();
+      this.lbL2TrackS.SuspendLayout();
+      this.pnlSATrack.SuspendLayout();
+      ((System.ComponentModel.ISupportInitialize)(this.tBR2)).BeginInit();
+      ((System.ComponentModel.ISupportInitialize)(this.tBL2)).BeginInit();
+      this.pnlSixaxis.SuspendLayout();
+      ((System.ComponentModel.ISupportInitialize)(this.tBsixaxisAccelX)).BeginInit();
+      ((System.ComponentModel.ISupportInitialize)(this.tBsixaxisGyroX)).BeginInit();
+      ((System.ComponentModel.ISupportInitialize)(this.tBsixaxisGyroY)).BeginInit();
+      ((System.ComponentModel.ISupportInitialize)(this.tBsixaxisGyroZ)).BeginInit();
+      ((System.ComponentModel.ISupportInitialize)(this.tBsixaxisAccelY)).BeginInit();
+      ((System.ComponentModel.ISupportInitialize)(this.tBsixaxisAccelZ)).BeginInit();
+      this.pnlLSTrack.SuspendLayout();
+      this.pnlRSTrack.SuspendLayout();
+      this.fLPTiltControls.SuspendLayout();
+      this.tCControls.SuspendLayout();
+      this.tPControls.SuspendLayout();
+      this.pnlController.SuspendLayout();
+      ((System.ComponentModel.ISupportInitialize)(this.pBHoveredButton)).BeginInit();
+      this.tPSpecial.SuspendLayout();
+      this.pnlActions.SuspendLayout();
+      this.panel2.SuspendLayout();
+      this.fLPActionButtons.SuspendLayout();
+      this.tCSens.SuspendLayout();
+      this.tPDeadzone.SuspendLayout();
+      this.antiDeadzoneTabPage.SuspendLayout();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDSixaxisZAntiDead)).BeginInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDSixaxisXAntiDead)).BeginInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDR2AntiDead)).BeginInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDL2AntiDead)).BeginInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDRSAntiDead)).BeginInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDLSAntiDead)).BeginInit();
+      this.maxZoneTabPage.SuspendLayout();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDSixAxisZMaxZone)).BeginInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDSixAxisXMaxZone)).BeginInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDR2Maxzone)).BeginInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDL2Maxzone)).BeginInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDRSMaxZone)).BeginInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDLSMaxZone)).BeginInit();
+      this.squStickTabPage.SuspendLayout();
+      ((System.ComponentModel.ISupportInitialize)(this.RoundnessNUpDown)).BeginInit();
+      this.tPOutCurve.SuspendLayout();
+      this.tPCurve.SuspendLayout();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDLSCurve)).BeginInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDRSCurve)).BeginInit();
+      this.tpRotation.SuspendLayout();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDRSRotation)).BeginInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDLSRotation)).BeginInit();
+      this.fLPSettings.SuspendLayout();
+      this.gBGyro.SuspendLayout();
+      this.pnlSAMouse.SuspendLayout();
+      ((System.ComponentModel.ISupportInitialize)(this.gyroMouseDzNUD)).BeginInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDGyroSmoothWeight)).BeginInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDGyroMouseVertScale)).BeginInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDGyroSensitivity)).BeginInit();
+      this.gBSensitivity.SuspendLayout();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDL2S)).BeginInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDLSS)).BeginInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDR2S)).BeginInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDRSS)).BeginInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDSXS)).BeginInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDSZS)).BeginInit();
+      this.cMGyroTriggers.SuspendLayout();
+      this.cMTouchDisableInvert.SuspendLayout();
+      this.SuspendLayout();
+      // 
+      // lowColorChooserButton
+      // 
+      this.lowColorChooserButton.BackColor = System.Drawing.Color.White;
+      resources.ApplyResources(this.lowColorChooserButton, "lowColorChooserButton");
+      this.lowColorChooserButton.Name = "lowColorChooserButton";
+      this.lowColorChooserButton.UseVisualStyleBackColor = false;
+      this.lowColorChooserButton.Click += new System.EventHandler(this.lowColorChooserButton_Click);
+      // 
+      // nUDRainbow
+      // 
+      resources.ApplyResources(this.nUDRainbow, "nUDRainbow");
+      this.nUDRainbow.Maximum = new decimal(new int[] {
             60,
             0,
             0,
             0});
-            this.nUDRainbow.Name = "nUDRainbow";
-            this.nUDRainbow.ValueChanged += new System.EventHandler(this.numUDRainbow_ValueChanged);
-            // 
-            // tBBlueBar
-            // 
-            resources.ApplyResources(this.tBBlueBar, "tBBlueBar");
-            this.tBBlueBar.BackColor = System.Drawing.Color.Blue;
-            this.tBBlueBar.Maximum = 255;
-            this.tBBlueBar.Name = "tBBlueBar";
-            this.tBBlueBar.TickFrequency = 25;
-            this.tBBlueBar.TickStyle = System.Windows.Forms.TickStyle.None;
-            this.tBBlueBar.Value = 255;
-            this.tBBlueBar.ValueChanged += new System.EventHandler(this.MainBar_ValueChanged);
-            this.tBBlueBar.MouseDown += new System.Windows.Forms.MouseEventHandler(this.LightBar_MouseDown);
-            this.tBBlueBar.MouseUp += new System.Windows.Forms.MouseEventHandler(this.Lightbar_MouseUp);
-            // 
-            // tBGreenBar
-            // 
-            resources.ApplyResources(this.tBGreenBar, "tBGreenBar");
-            this.tBGreenBar.BackColor = System.Drawing.Color.Green;
-            this.tBGreenBar.Maximum = 255;
-            this.tBGreenBar.Name = "tBGreenBar";
-            this.tBGreenBar.TickFrequency = 25;
-            this.tBGreenBar.TickStyle = System.Windows.Forms.TickStyle.None;
-            this.tBGreenBar.Value = 255;
-            this.tBGreenBar.ValueChanged += new System.EventHandler(this.MainBar_ValueChanged);
-            this.tBGreenBar.MouseDown += new System.Windows.Forms.MouseEventHandler(this.LightBar_MouseDown);
-            this.tBGreenBar.MouseUp += new System.Windows.Forms.MouseEventHandler(this.Lightbar_MouseUp);
-            // 
-            // tBRedBar
-            // 
-            resources.ApplyResources(this.tBRedBar, "tBRedBar");
-            this.tBRedBar.BackColor = System.Drawing.Color.Red;
-            this.tBRedBar.Maximum = 255;
-            this.tBRedBar.Name = "tBRedBar";
-            this.tBRedBar.TickFrequency = 25;
-            this.tBRedBar.TickStyle = System.Windows.Forms.TickStyle.None;
-            this.tBRedBar.Value = 255;
-            this.tBRedBar.ValueChanged += new System.EventHandler(this.MainBar_ValueChanged);
-            this.tBRedBar.MouseDown += new System.Windows.Forms.MouseEventHandler(this.LightBar_MouseDown);
-            this.tBRedBar.MouseUp += new System.Windows.Forms.MouseEventHandler(this.Lightbar_MouseUp);
-            // 
-            // cBLightbyBattery
-            // 
-            resources.ApplyResources(this.cBLightbyBattery, "cBLightbyBattery");
-            this.cBLightbyBattery.Name = "cBLightbyBattery";
-            this.cBLightbyBattery.UseVisualStyleBackColor = true;
-            this.cBLightbyBattery.CheckedChanged += new System.EventHandler(this.ledAsBatteryIndicator_CheckedChanged);
-            // 
-            // lbBlue
-            // 
-            resources.ApplyResources(this.lbBlue, "lbBlue");
-            this.lbBlue.Name = "lbBlue";
-            // 
-            // lbGreen
-            // 
-            resources.ApplyResources(this.lbGreen, "lbGreen");
-            this.lbGreen.Name = "lbGreen";
-            // 
-            // lbspc
-            // 
-            resources.ApplyResources(this.lbspc, "lbspc");
-            this.lbspc.Name = "lbspc";
-            // 
-            // lbRed
-            // 
-            resources.ApplyResources(this.lbRed, "lbRed");
-            this.lbRed.Name = "lbRed";
-            // 
-            // cBDoubleTap
-            // 
-            resources.ApplyResources(this.cBDoubleTap, "cBDoubleTap");
-            this.cBDoubleTap.Checked = true;
-            this.cBDoubleTap.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.cBDoubleTap.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.cBDoubleTap.Name = "cBDoubleTap";
-            this.cBDoubleTap.UseVisualStyleBackColor = true;
-            this.cBDoubleTap.CheckedChanged += new System.EventHandler(this.cBDoubleTap_CheckedChanged);
-            // 
-            // cBTap
-            // 
-            resources.ApplyResources(this.cBTap, "cBTap");
-            this.cBTap.Checked = true;
-            this.cBTap.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.cBTap.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.cBTap.Name = "cBTap";
-            this.cBTap.UseVisualStyleBackColor = true;
-            this.cBTap.CheckedChanged += new System.EventHandler(this.cBTap_CheckedChanged);
-            // 
-            // nUDTap
-            // 
-            resources.ApplyResources(this.nUDTap, "nUDTap");
-            this.nUDTap.Maximum = new decimal(new int[] {
+      this.nUDRainbow.Name = "nUDRainbow";
+      this.nUDRainbow.ValueChanged += new System.EventHandler(this.numUDRainbow_ValueChanged);
+      // 
+      // tBBlueBar
+      // 
+      resources.ApplyResources(this.tBBlueBar, "tBBlueBar");
+      this.tBBlueBar.BackColor = System.Drawing.Color.Blue;
+      this.tBBlueBar.Maximum = 255;
+      this.tBBlueBar.Name = "tBBlueBar";
+      this.tBBlueBar.TickFrequency = 25;
+      this.tBBlueBar.TickStyle = System.Windows.Forms.TickStyle.None;
+      this.tBBlueBar.Value = 255;
+      this.tBBlueBar.ValueChanged += new System.EventHandler(this.MainBar_ValueChanged);
+      this.tBBlueBar.MouseDown += new System.Windows.Forms.MouseEventHandler(this.LightBar_MouseDown);
+      this.tBBlueBar.MouseUp += new System.Windows.Forms.MouseEventHandler(this.Lightbar_MouseUp);
+      // 
+      // tBGreenBar
+      // 
+      resources.ApplyResources(this.tBGreenBar, "tBGreenBar");
+      this.tBGreenBar.BackColor = System.Drawing.Color.Green;
+      this.tBGreenBar.Maximum = 255;
+      this.tBGreenBar.Name = "tBGreenBar";
+      this.tBGreenBar.TickFrequency = 25;
+      this.tBGreenBar.TickStyle = System.Windows.Forms.TickStyle.None;
+      this.tBGreenBar.Value = 255;
+      this.tBGreenBar.ValueChanged += new System.EventHandler(this.MainBar_ValueChanged);
+      this.tBGreenBar.MouseDown += new System.Windows.Forms.MouseEventHandler(this.LightBar_MouseDown);
+      this.tBGreenBar.MouseUp += new System.Windows.Forms.MouseEventHandler(this.Lightbar_MouseUp);
+      // 
+      // tBRedBar
+      // 
+      resources.ApplyResources(this.tBRedBar, "tBRedBar");
+      this.tBRedBar.BackColor = System.Drawing.Color.Red;
+      this.tBRedBar.Maximum = 255;
+      this.tBRedBar.Name = "tBRedBar";
+      this.tBRedBar.TickFrequency = 25;
+      this.tBRedBar.TickStyle = System.Windows.Forms.TickStyle.None;
+      this.tBRedBar.Value = 255;
+      this.tBRedBar.ValueChanged += new System.EventHandler(this.MainBar_ValueChanged);
+      this.tBRedBar.MouseDown += new System.Windows.Forms.MouseEventHandler(this.LightBar_MouseDown);
+      this.tBRedBar.MouseUp += new System.Windows.Forms.MouseEventHandler(this.Lightbar_MouseUp);
+      // 
+      // cBLightbyBattery
+      // 
+      resources.ApplyResources(this.cBLightbyBattery, "cBLightbyBattery");
+      this.cBLightbyBattery.Name = "cBLightbyBattery";
+      this.cBLightbyBattery.UseVisualStyleBackColor = true;
+      this.cBLightbyBattery.CheckedChanged += new System.EventHandler(this.ledAsBatteryIndicator_CheckedChanged);
+      // 
+      // lbBlue
+      // 
+      resources.ApplyResources(this.lbBlue, "lbBlue");
+      this.lbBlue.Name = "lbBlue";
+      // 
+      // lbGreen
+      // 
+      resources.ApplyResources(this.lbGreen, "lbGreen");
+      this.lbGreen.Name = "lbGreen";
+      // 
+      // lbspc
+      // 
+      resources.ApplyResources(this.lbspc, "lbspc");
+      this.lbspc.Name = "lbspc";
+      // 
+      // lbRed
+      // 
+      resources.ApplyResources(this.lbRed, "lbRed");
+      this.lbRed.Name = "lbRed";
+      // 
+      // cBDoubleTap
+      // 
+      resources.ApplyResources(this.cBDoubleTap, "cBDoubleTap");
+      this.cBDoubleTap.Checked = true;
+      this.cBDoubleTap.CheckState = System.Windows.Forms.CheckState.Checked;
+      this.cBDoubleTap.ForeColor = System.Drawing.SystemColors.ControlText;
+      this.cBDoubleTap.Name = "cBDoubleTap";
+      this.cBDoubleTap.UseVisualStyleBackColor = true;
+      this.cBDoubleTap.CheckedChanged += new System.EventHandler(this.cBDoubleTap_CheckedChanged);
+      // 
+      // cBTap
+      // 
+      resources.ApplyResources(this.cBTap, "cBTap");
+      this.cBTap.Checked = true;
+      this.cBTap.CheckState = System.Windows.Forms.CheckState.Checked;
+      this.cBTap.ForeColor = System.Drawing.SystemColors.ControlText;
+      this.cBTap.Name = "cBTap";
+      this.cBTap.UseVisualStyleBackColor = true;
+      this.cBTap.CheckedChanged += new System.EventHandler(this.cBTap_CheckedChanged);
+      // 
+      // nUDTap
+      // 
+      resources.ApplyResources(this.nUDTap, "nUDTap");
+      this.nUDTap.Maximum = new decimal(new int[] {
             200,
             0,
             0,
             0});
-            this.nUDTap.Name = "nUDTap";
-            this.nUDTap.Value = new decimal(new int[] {
+      this.nUDTap.Name = "nUDTap";
+      this.nUDTap.Value = new decimal(new int[] {
             100,
             0,
             0,
             0});
-            this.nUDTap.ValueChanged += new System.EventHandler(this.numUDTap_ValueChanged);
-            // 
-            // cBScroll
-            // 
-            resources.ApplyResources(this.cBScroll, "cBScroll");
-            this.cBScroll.Checked = true;
-            this.cBScroll.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.cBScroll.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.cBScroll.Name = "cBScroll";
-            this.cBScroll.UseVisualStyleBackColor = true;
-            this.cBScroll.CheckedChanged += new System.EventHandler(this.cBScroll_CheckedChanged);
-            // 
-            // cBSlide
-            // 
-            resources.ApplyResources(this.cBSlide, "cBSlide");
-            this.cBSlide.Checked = true;
-            this.cBSlide.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.cBSlide.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.cBSlide.Name = "cBSlide";
-            this.cBSlide.UseVisualStyleBackColor = true;
-            this.cBSlide.CheckedChanged += new System.EventHandler(this.cBSlide_CheckedChanged);
-            // 
-            // nUDScroll
-            // 
-            resources.ApplyResources(this.nUDScroll, "nUDScroll");
-            this.nUDScroll.Maximum = new decimal(new int[] {
+      this.nUDTap.ValueChanged += new System.EventHandler(this.numUDTap_ValueChanged);
+      // 
+      // cBScroll
+      // 
+      resources.ApplyResources(this.cBScroll, "cBScroll");
+      this.cBScroll.Checked = true;
+      this.cBScroll.CheckState = System.Windows.Forms.CheckState.Checked;
+      this.cBScroll.ForeColor = System.Drawing.SystemColors.ControlText;
+      this.cBScroll.Name = "cBScroll";
+      this.cBScroll.UseVisualStyleBackColor = true;
+      this.cBScroll.CheckedChanged += new System.EventHandler(this.cBScroll_CheckedChanged);
+      // 
+      // cBSlide
+      // 
+      resources.ApplyResources(this.cBSlide, "cBSlide");
+      this.cBSlide.Checked = true;
+      this.cBSlide.CheckState = System.Windows.Forms.CheckState.Checked;
+      this.cBSlide.ForeColor = System.Drawing.SystemColors.ControlText;
+      this.cBSlide.Name = "cBSlide";
+      this.cBSlide.UseVisualStyleBackColor = true;
+      this.cBSlide.CheckedChanged += new System.EventHandler(this.cBSlide_CheckedChanged);
+      // 
+      // nUDScroll
+      // 
+      resources.ApplyResources(this.nUDScroll, "nUDScroll");
+      this.nUDScroll.Maximum = new decimal(new int[] {
             10,
             0,
             0,
             0});
-            this.nUDScroll.Minimum = new decimal(new int[] {
+      this.nUDScroll.Minimum = new decimal(new int[] {
             10,
             0,
             0,
             -2147483648});
-            this.nUDScroll.Name = "nUDScroll";
-            this.nUDScroll.Value = new decimal(new int[] {
+      this.nUDScroll.Name = "nUDScroll";
+      this.nUDScroll.Value = new decimal(new int[] {
             5,
             0,
             0,
             0});
-            this.nUDScroll.ValueChanged += new System.EventHandler(this.numUDScroll_ValueChanged);
-            // 
-            // nUDTouch
-            // 
-            resources.ApplyResources(this.nUDTouch, "nUDTouch");
-            this.nUDTouch.Maximum = new decimal(new int[] {
+      this.nUDScroll.ValueChanged += new System.EventHandler(this.numUDScroll_ValueChanged);
+      // 
+      // nUDTouch
+      // 
+      resources.ApplyResources(this.nUDTouch, "nUDTouch");
+      this.nUDTouch.Maximum = new decimal(new int[] {
             150,
             0,
             0,
             0});
-            this.nUDTouch.Name = "nUDTouch";
-            this.nUDTouch.Value = new decimal(new int[] {
+      this.nUDTouch.Name = "nUDTouch";
+      this.nUDTouch.Value = new decimal(new int[] {
             100,
             0,
             0,
             0});
-            this.nUDTouch.ValueChanged += new System.EventHandler(this.numUDTouch_ValueChanged);
-            // 
-            // lbButtonMouseSens
-            // 
-            resources.ApplyResources(this.lbButtonMouseSens, "lbButtonMouseSens");
-            this.lbButtonMouseSens.Name = "lbButtonMouseSens";
-            // 
-            // cBlowerRCOn
-            // 
-            resources.ApplyResources(this.cBlowerRCOn, "cBlowerRCOn");
-            this.cBlowerRCOn.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.cBlowerRCOn.Name = "cBlowerRCOn";
-            this.cBlowerRCOn.UseVisualStyleBackColor = true;
-            this.cBlowerRCOn.CheckedChanged += new System.EventHandler(this.lowerRCOffCheckBox_CheckedChanged);
-            // 
-            // cBTouchpadJitterCompensation
-            // 
-            resources.ApplyResources(this.cBTouchpadJitterCompensation, "cBTouchpadJitterCompensation");
-            this.cBTouchpadJitterCompensation.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.cBTouchpadJitterCompensation.Name = "cBTouchpadJitterCompensation";
-            this.cBTouchpadJitterCompensation.UseVisualStyleBackColor = true;
-            this.cBTouchpadJitterCompensation.CheckedChanged += new System.EventHandler(this.touchpadJitterCompensation_CheckedChanged);
-            // 
-            // lbL2
-            // 
-            resources.ApplyResources(this.lbL2, "lbL2");
-            this.lbL2.Name = "lbL2";
-            // 
-            // lbR2
-            // 
-            resources.ApplyResources(this.lbR2, "lbR2");
-            this.lbR2.Name = "lbR2";
-            // 
-            // lbIdleMinutes
-            // 
-            resources.ApplyResources(this.lbIdleMinutes, "lbIdleMinutes");
-            this.lbIdleMinutes.Name = "lbIdleMinutes";
-            // 
-            // nUDIdleDisconnect
-            // 
-            this.nUDIdleDisconnect.DecimalPlaces = 1;
-            resources.ApplyResources(this.nUDIdleDisconnect, "nUDIdleDisconnect");
-            this.nUDIdleDisconnect.Maximum = new decimal(new int[] {
+      this.nUDTouch.ValueChanged += new System.EventHandler(this.numUDTouch_ValueChanged);
+      // 
+      // lbButtonMouseSens
+      // 
+      resources.ApplyResources(this.lbButtonMouseSens, "lbButtonMouseSens");
+      this.lbButtonMouseSens.Name = "lbButtonMouseSens";
+      // 
+      // cBlowerRCOn
+      // 
+      resources.ApplyResources(this.cBlowerRCOn, "cBlowerRCOn");
+      this.cBlowerRCOn.ForeColor = System.Drawing.SystemColors.ControlText;
+      this.cBlowerRCOn.Name = "cBlowerRCOn";
+      this.cBlowerRCOn.UseVisualStyleBackColor = true;
+      this.cBlowerRCOn.CheckedChanged += new System.EventHandler(this.lowerRCOffCheckBox_CheckedChanged);
+      // 
+      // cBTouchpadJitterCompensation
+      // 
+      resources.ApplyResources(this.cBTouchpadJitterCompensation, "cBTouchpadJitterCompensation");
+      this.cBTouchpadJitterCompensation.ForeColor = System.Drawing.SystemColors.ControlText;
+      this.cBTouchpadJitterCompensation.Name = "cBTouchpadJitterCompensation";
+      this.cBTouchpadJitterCompensation.UseVisualStyleBackColor = true;
+      this.cBTouchpadJitterCompensation.CheckedChanged += new System.EventHandler(this.touchpadJitterCompensation_CheckedChanged);
+      // 
+      // lbL2
+      // 
+      resources.ApplyResources(this.lbL2, "lbL2");
+      this.lbL2.Name = "lbL2";
+      // 
+      // lbR2
+      // 
+      resources.ApplyResources(this.lbR2, "lbR2");
+      this.lbR2.Name = "lbR2";
+      // 
+      // lbIdleMinutes
+      // 
+      resources.ApplyResources(this.lbIdleMinutes, "lbIdleMinutes");
+      this.lbIdleMinutes.Name = "lbIdleMinutes";
+      // 
+      // nUDIdleDisconnect
+      // 
+      this.nUDIdleDisconnect.DecimalPlaces = 1;
+      resources.ApplyResources(this.nUDIdleDisconnect, "nUDIdleDisconnect");
+      this.nUDIdleDisconnect.Maximum = new decimal(new int[] {
             60,
             0,
             0,
             0});
-            this.nUDIdleDisconnect.Name = "nUDIdleDisconnect";
-            this.nUDIdleDisconnect.ValueChanged += new System.EventHandler(this.nUDIdleDisconnect_ValueChanged);
-            // 
-            // nUDR2
-            // 
-            this.nUDR2.DecimalPlaces = 2;
-            this.nUDR2.Increment = new decimal(new int[] {
+      this.nUDIdleDisconnect.Name = "nUDIdleDisconnect";
+      this.nUDIdleDisconnect.ValueChanged += new System.EventHandler(this.nUDIdleDisconnect_ValueChanged);
+      // 
+      // nUDR2
+      // 
+      this.nUDR2.DecimalPlaces = 2;
+      this.nUDR2.Increment = new decimal(new int[] {
             1,
             0,
             0,
             65536});
-            resources.ApplyResources(this.nUDR2, "nUDR2");
-            this.nUDR2.Maximum = new decimal(new int[] {
+      resources.ApplyResources(this.nUDR2, "nUDR2");
+      this.nUDR2.Maximum = new decimal(new int[] {
             1,
             0,
             0,
             0});
-            this.nUDR2.Name = "nUDR2";
-            this.nUDR2.ValueChanged += new System.EventHandler(this.numUDR2_ValueChanged);
-            // 
-            // cBFlushHIDQueue
-            // 
-            resources.ApplyResources(this.cBFlushHIDQueue, "cBFlushHIDQueue");
-            this.cBFlushHIDQueue.Name = "cBFlushHIDQueue";
-            this.cBFlushHIDQueue.UseVisualStyleBackColor = true;
-            this.cBFlushHIDQueue.CheckedChanged += new System.EventHandler(this.flushHIDQueue_CheckedChanged);
-            // 
-            // nUDRumbleBoost
-            // 
-            resources.ApplyResources(this.nUDRumbleBoost, "nUDRumbleBoost");
-            this.nUDRumbleBoost.Maximum = new decimal(new int[] {
+      this.nUDR2.Name = "nUDR2";
+      this.nUDR2.ValueChanged += new System.EventHandler(this.numUDR2_ValueChanged);
+      // 
+      // cBFlushHIDQueue
+      // 
+      resources.ApplyResources(this.cBFlushHIDQueue, "cBFlushHIDQueue");
+      this.cBFlushHIDQueue.Name = "cBFlushHIDQueue";
+      this.cBFlushHIDQueue.UseVisualStyleBackColor = true;
+      this.cBFlushHIDQueue.CheckedChanged += new System.EventHandler(this.flushHIDQueue_CheckedChanged);
+      // 
+      // nUDRumbleBoost
+      // 
+      resources.ApplyResources(this.nUDRumbleBoost, "nUDRumbleBoost");
+      this.nUDRumbleBoost.Maximum = new decimal(new int[] {
             150,
             0,
             0,
             0});
-            this.nUDRumbleBoost.Name = "nUDRumbleBoost";
-            this.nUDRumbleBoost.Value = new decimal(new int[] {
+      this.nUDRumbleBoost.Name = "nUDRumbleBoost";
+      this.nUDRumbleBoost.Value = new decimal(new int[] {
             100,
             0,
             0,
             0});
-            this.nUDRumbleBoost.ValueChanged += new System.EventHandler(this.rumbleBoostBar_ValueChanged);
-            // 
-            // btnRumbleHeavyTest
-            // 
-            resources.ApplyResources(this.btnRumbleHeavyTest, "btnRumbleHeavyTest");
-            this.btnRumbleHeavyTest.Name = "btnRumbleHeavyTest";
-            this.btnRumbleHeavyTest.UseVisualStyleBackColor = true;
-            this.btnRumbleHeavyTest.Click += new System.EventHandler(this.btnRumbleHeavyTest_Click);
-            // 
-            // lbFull
-            // 
-            resources.ApplyResources(this.lbFull, "lbFull");
-            this.lbFull.Name = "lbFull";
-            // 
-            // lbLowRed
-            // 
-            resources.ApplyResources(this.lbLowRed, "lbLowRed");
-            this.lbLowRed.Name = "lbLowRed";
-            // 
-            // lbLowGreen
-            // 
-            resources.ApplyResources(this.lbLowGreen, "lbLowGreen");
-            this.lbLowGreen.Name = "lbLowGreen";
-            // 
-            // lbLowBlue
-            // 
-            resources.ApplyResources(this.lbLowBlue, "lbLowBlue");
-            this.lbLowBlue.Name = "lbLowBlue";
-            // 
-            // tBLowRedBar
-            // 
-            resources.ApplyResources(this.tBLowRedBar, "tBLowRedBar");
-            this.tBLowRedBar.BackColor = System.Drawing.Color.Red;
-            this.tBLowRedBar.Maximum = 255;
-            this.tBLowRedBar.Name = "tBLowRedBar";
-            this.tBLowRedBar.TickFrequency = 25;
-            this.tBLowRedBar.TickStyle = System.Windows.Forms.TickStyle.None;
-            this.tBLowRedBar.Value = 255;
-            this.tBLowRedBar.ValueChanged += new System.EventHandler(this.LowBar_ValueChanged);
-            this.tBLowRedBar.MouseDown += new System.Windows.Forms.MouseEventHandler(this.LightBar_MouseDown);
-            this.tBLowRedBar.MouseUp += new System.Windows.Forms.MouseEventHandler(this.Lightbar_MouseUp);
-            // 
-            // tBLowGreenBar
-            // 
-            resources.ApplyResources(this.tBLowGreenBar, "tBLowGreenBar");
-            this.tBLowGreenBar.BackColor = System.Drawing.Color.Green;
-            this.tBLowGreenBar.Maximum = 255;
-            this.tBLowGreenBar.Name = "tBLowGreenBar";
-            this.tBLowGreenBar.TickFrequency = 25;
-            this.tBLowGreenBar.TickStyle = System.Windows.Forms.TickStyle.None;
-            this.tBLowGreenBar.Value = 255;
-            this.tBLowGreenBar.ValueChanged += new System.EventHandler(this.LowBar_ValueChanged);
-            this.tBLowGreenBar.MouseDown += new System.Windows.Forms.MouseEventHandler(this.LightBar_MouseDown);
-            this.tBLowGreenBar.MouseUp += new System.Windows.Forms.MouseEventHandler(this.Lightbar_MouseUp);
-            // 
-            // tBLowBlueBar
-            // 
-            resources.ApplyResources(this.tBLowBlueBar, "tBLowBlueBar");
-            this.tBLowBlueBar.BackColor = System.Drawing.Color.Blue;
-            this.tBLowBlueBar.Maximum = 255;
-            this.tBLowBlueBar.Name = "tBLowBlueBar";
-            this.tBLowBlueBar.TickFrequency = 25;
-            this.tBLowBlueBar.TickStyle = System.Windows.Forms.TickStyle.None;
-            this.tBLowBlueBar.Value = 255;
-            this.tBLowBlueBar.ValueChanged += new System.EventHandler(this.LowBar_ValueChanged);
-            this.tBLowBlueBar.MouseDown += new System.Windows.Forms.MouseEventHandler(this.LightBar_MouseDown);
-            this.tBLowBlueBar.MouseUp += new System.Windows.Forms.MouseEventHandler(this.Lightbar_MouseUp);
-            // 
-            // lbEmpty
-            // 
-            resources.ApplyResources(this.lbEmpty, "lbEmpty");
-            this.lbEmpty.Name = "lbEmpty";
-            this.lbEmpty.Click += new System.EventHandler(this.lbEmpty_Click);
-            // 
-            // pnlFull
-            // 
-            this.pnlFull.Controls.Add(this.lbFull);
-            this.pnlFull.Controls.Add(this.lbRed);
-            this.pnlFull.Controls.Add(this.lbGreen);
-            this.pnlFull.Controls.Add(this.lbBlue);
-            this.pnlFull.Controls.Add(this.tBRedBar);
-            this.pnlFull.Controls.Add(this.tBGreenBar);
-            this.pnlFull.Controls.Add(this.tBBlueBar);
-            resources.ApplyResources(this.pnlFull, "pnlFull");
-            this.pnlFull.Name = "pnlFull";
-            // 
-            // pnlLowBattery
-            // 
-            this.pnlLowBattery.Controls.Add(this.lowColorChooserButton);
-            this.pnlLowBattery.Controls.Add(this.lbLowRed);
-            this.pnlLowBattery.Controls.Add(this.lbLowGreen);
-            this.pnlLowBattery.Controls.Add(this.lbLowBlue);
-            this.pnlLowBattery.Controls.Add(this.tBLowRedBar);
-            this.pnlLowBattery.Controls.Add(this.tBLowGreenBar);
-            this.pnlLowBattery.Controls.Add(this.tBLowBlueBar);
-            this.pnlLowBattery.Controls.Add(this.lbEmpty);
-            resources.ApplyResources(this.pnlLowBattery, "pnlLowBattery");
-            this.pnlLowBattery.Name = "pnlLowBattery";
-            // 
-            // lbRS
-            // 
-            resources.ApplyResources(this.lbRS, "lbRS");
-            this.lbRS.Name = "lbRS";
-            // 
-            // lbLS
-            // 
-            resources.ApplyResources(this.lbLS, "lbLS");
-            this.lbLS.Name = "lbLS";
-            // 
-            // nUDRS
-            // 
-            this.nUDRS.DecimalPlaces = 2;
-            this.nUDRS.Increment = new decimal(new int[] {
+      this.nUDRumbleBoost.ValueChanged += new System.EventHandler(this.rumbleBoostBar_ValueChanged);
+      // 
+      // btnRumbleHeavyTest
+      // 
+      resources.ApplyResources(this.btnRumbleHeavyTest, "btnRumbleHeavyTest");
+      this.btnRumbleHeavyTest.Name = "btnRumbleHeavyTest";
+      this.btnRumbleHeavyTest.UseVisualStyleBackColor = true;
+      this.btnRumbleHeavyTest.Click += new System.EventHandler(this.btnRumbleHeavyTest_Click);
+      // 
+      // lbFull
+      // 
+      resources.ApplyResources(this.lbFull, "lbFull");
+      this.lbFull.Name = "lbFull";
+      // 
+      // lbLowRed
+      // 
+      resources.ApplyResources(this.lbLowRed, "lbLowRed");
+      this.lbLowRed.Name = "lbLowRed";
+      // 
+      // lbLowGreen
+      // 
+      resources.ApplyResources(this.lbLowGreen, "lbLowGreen");
+      this.lbLowGreen.Name = "lbLowGreen";
+      // 
+      // lbLowBlue
+      // 
+      resources.ApplyResources(this.lbLowBlue, "lbLowBlue");
+      this.lbLowBlue.Name = "lbLowBlue";
+      // 
+      // tBLowRedBar
+      // 
+      resources.ApplyResources(this.tBLowRedBar, "tBLowRedBar");
+      this.tBLowRedBar.BackColor = System.Drawing.Color.Red;
+      this.tBLowRedBar.Maximum = 255;
+      this.tBLowRedBar.Name = "tBLowRedBar";
+      this.tBLowRedBar.TickFrequency = 25;
+      this.tBLowRedBar.TickStyle = System.Windows.Forms.TickStyle.None;
+      this.tBLowRedBar.Value = 255;
+      this.tBLowRedBar.ValueChanged += new System.EventHandler(this.LowBar_ValueChanged);
+      this.tBLowRedBar.MouseDown += new System.Windows.Forms.MouseEventHandler(this.LightBar_MouseDown);
+      this.tBLowRedBar.MouseUp += new System.Windows.Forms.MouseEventHandler(this.Lightbar_MouseUp);
+      // 
+      // tBLowGreenBar
+      // 
+      resources.ApplyResources(this.tBLowGreenBar, "tBLowGreenBar");
+      this.tBLowGreenBar.BackColor = System.Drawing.Color.Green;
+      this.tBLowGreenBar.Maximum = 255;
+      this.tBLowGreenBar.Name = "tBLowGreenBar";
+      this.tBLowGreenBar.TickFrequency = 25;
+      this.tBLowGreenBar.TickStyle = System.Windows.Forms.TickStyle.None;
+      this.tBLowGreenBar.Value = 255;
+      this.tBLowGreenBar.ValueChanged += new System.EventHandler(this.LowBar_ValueChanged);
+      this.tBLowGreenBar.MouseDown += new System.Windows.Forms.MouseEventHandler(this.LightBar_MouseDown);
+      this.tBLowGreenBar.MouseUp += new System.Windows.Forms.MouseEventHandler(this.Lightbar_MouseUp);
+      // 
+      // tBLowBlueBar
+      // 
+      resources.ApplyResources(this.tBLowBlueBar, "tBLowBlueBar");
+      this.tBLowBlueBar.BackColor = System.Drawing.Color.Blue;
+      this.tBLowBlueBar.Maximum = 255;
+      this.tBLowBlueBar.Name = "tBLowBlueBar";
+      this.tBLowBlueBar.TickFrequency = 25;
+      this.tBLowBlueBar.TickStyle = System.Windows.Forms.TickStyle.None;
+      this.tBLowBlueBar.Value = 255;
+      this.tBLowBlueBar.ValueChanged += new System.EventHandler(this.LowBar_ValueChanged);
+      this.tBLowBlueBar.MouseDown += new System.Windows.Forms.MouseEventHandler(this.LightBar_MouseDown);
+      this.tBLowBlueBar.MouseUp += new System.Windows.Forms.MouseEventHandler(this.Lightbar_MouseUp);
+      // 
+      // lbEmpty
+      // 
+      resources.ApplyResources(this.lbEmpty, "lbEmpty");
+      this.lbEmpty.Name = "lbEmpty";
+      this.lbEmpty.Click += new System.EventHandler(this.lbEmpty_Click);
+      // 
+      // pnlFull
+      // 
+      this.pnlFull.Controls.Add(this.lbFull);
+      this.pnlFull.Controls.Add(this.lbRed);
+      this.pnlFull.Controls.Add(this.lbGreen);
+      this.pnlFull.Controls.Add(this.lbBlue);
+      this.pnlFull.Controls.Add(this.tBRedBar);
+      this.pnlFull.Controls.Add(this.tBGreenBar);
+      this.pnlFull.Controls.Add(this.tBBlueBar);
+      resources.ApplyResources(this.pnlFull, "pnlFull");
+      this.pnlFull.Name = "pnlFull";
+      // 
+      // pnlLowBattery
+      // 
+      this.pnlLowBattery.Controls.Add(this.lowColorChooserButton);
+      this.pnlLowBattery.Controls.Add(this.lbLowRed);
+      this.pnlLowBattery.Controls.Add(this.lbLowGreen);
+      this.pnlLowBattery.Controls.Add(this.lbLowBlue);
+      this.pnlLowBattery.Controls.Add(this.tBLowRedBar);
+      this.pnlLowBattery.Controls.Add(this.tBLowGreenBar);
+      this.pnlLowBattery.Controls.Add(this.tBLowBlueBar);
+      this.pnlLowBattery.Controls.Add(this.lbEmpty);
+      resources.ApplyResources(this.pnlLowBattery, "pnlLowBattery");
+      this.pnlLowBattery.Name = "pnlLowBattery";
+      // 
+      // lbRS
+      // 
+      resources.ApplyResources(this.lbRS, "lbRS");
+      this.lbRS.Name = "lbRS";
+      // 
+      // lbLS
+      // 
+      resources.ApplyResources(this.lbLS, "lbLS");
+      this.lbLS.Name = "lbLS";
+      // 
+      // nUDRS
+      // 
+      this.nUDRS.DecimalPlaces = 2;
+      this.nUDRS.Increment = new decimal(new int[] {
             1,
             0,
             0,
             65536});
-            resources.ApplyResources(this.nUDRS, "nUDRS");
-            this.nUDRS.Maximum = new decimal(new int[] {
+      resources.ApplyResources(this.nUDRS, "nUDRS");
+      this.nUDRS.Maximum = new decimal(new int[] {
             1,
             0,
             0,
             0});
-            this.nUDRS.Name = "nUDRS";
-            this.nUDRS.ValueChanged += new System.EventHandler(this.numUDRS_ValueChanged);
-            // 
-            // numUDMouseSens
-            // 
-            resources.ApplyResources(this.numUDMouseSens, "numUDMouseSens");
-            this.numUDMouseSens.Maximum = new decimal(new int[] {
+      this.nUDRS.Name = "nUDRS";
+      this.nUDRS.ValueChanged += new System.EventHandler(this.numUDRS_ValueChanged);
+      // 
+      // numUDMouseSens
+      // 
+      resources.ApplyResources(this.numUDMouseSens, "numUDMouseSens");
+      this.numUDMouseSens.Maximum = new decimal(new int[] {
             255,
             0,
             0,
             0});
-            this.numUDMouseSens.Name = "numUDMouseSens";
-            this.numUDMouseSens.Value = new decimal(new int[] {
+      this.numUDMouseSens.Name = "numUDMouseSens";
+      this.numUDMouseSens.Value = new decimal(new int[] {
             25,
             0,
             0,
             0});
-            this.numUDMouseSens.ValueChanged += new System.EventHandler(this.numUDMouseSens_ValueChanged);
-            // 
-            // nUDLS
-            // 
-            this.nUDLS.DecimalPlaces = 2;
-            this.nUDLS.Increment = new decimal(new int[] {
+      this.numUDMouseSens.ValueChanged += new System.EventHandler(this.numUDMouseSens_ValueChanged);
+      // 
+      // nUDLS
+      // 
+      this.nUDLS.DecimalPlaces = 2;
+      this.nUDLS.Increment = new decimal(new int[] {
             1,
             0,
             0,
             65536});
-            resources.ApplyResources(this.nUDLS, "nUDLS");
-            this.nUDLS.Maximum = new decimal(new int[] {
+      resources.ApplyResources(this.nUDLS, "nUDLS");
+      this.nUDLS.Maximum = new decimal(new int[] {
             1,
             0,
             0,
             0});
-            this.nUDLS.Name = "nUDLS";
-            this.nUDLS.ValueChanged += new System.EventHandler(this.numUDLS_ValueChanged);
-            // 
-            // nUDL2
-            // 
-            this.nUDL2.DecimalPlaces = 2;
-            this.nUDL2.Increment = new decimal(new int[] {
+      this.nUDLS.Name = "nUDLS";
+      this.nUDLS.ValueChanged += new System.EventHandler(this.numUDLS_ValueChanged);
+      // 
+      // nUDL2
+      // 
+      this.nUDL2.DecimalPlaces = 2;
+      this.nUDL2.Increment = new decimal(new int[] {
             1,
             0,
             0,
             65536});
-            resources.ApplyResources(this.nUDL2, "nUDL2");
-            this.nUDL2.Maximum = new decimal(new int[] {
+      resources.ApplyResources(this.nUDL2, "nUDL2");
+      this.nUDL2.Maximum = new decimal(new int[] {
             1,
             0,
             0,
             0});
-            this.nUDL2.Name = "nUDL2";
-            this.nUDL2.ValueChanged += new System.EventHandler(this.numUDL2_ValueChanged);
-            // 
-            // gBTouchpad
-            // 
-            this.gBTouchpad.BackColor = System.Drawing.SystemColors.Control;
-            this.gBTouchpad.Controls.Add(this.pnlTPMouse);
-            this.gBTouchpad.Controls.Add(this.rBTPControls);
-            this.gBTouchpad.Controls.Add(this.rBTPMouse);
-            this.gBTouchpad.Controls.Add(this.fLPTouchSwipe);
-            this.gBTouchpad.ForeColor = System.Drawing.SystemColors.ControlText;
-            resources.ApplyResources(this.gBTouchpad, "gBTouchpad");
-            this.gBTouchpad.Name = "gBTouchpad";
-            this.gBTouchpad.TabStop = false;
-            // 
-            // pnlTPMouse
-            // 
-            this.pnlTPMouse.Controls.Add(this.trackFrictionLb);
-            this.pnlTPMouse.Controls.Add(this.trackFrictionNUD);
-            this.pnlTPMouse.Controls.Add(this.trackballCk);
-            this.pnlTPMouse.Controls.Add(this.touchpadDisInvertButton);
-            this.pnlTPMouse.Controls.Add(this.label25);
-            this.pnlTPMouse.Controls.Add(this.label15);
-            this.pnlTPMouse.Controls.Add(this.touchpadInvertComboBox);
-            this.pnlTPMouse.Controls.Add(this.nUDScroll);
-            this.pnlTPMouse.Controls.Add(this.cBDoubleTap);
-            this.pnlTPMouse.Controls.Add(this.cBScroll);
-            this.pnlTPMouse.Controls.Add(this.cBTouchpadJitterCompensation);
-            this.pnlTPMouse.Controls.Add(this.nUDTap);
-            this.pnlTPMouse.Controls.Add(this.cBlowerRCOn);
-            this.pnlTPMouse.Controls.Add(this.cBTap);
-            this.pnlTPMouse.Controls.Add(this.cBSlide);
-            this.pnlTPMouse.Controls.Add(this.nUDTouch);
-            this.pnlTPMouse.Controls.Add(this.cbStartTouchpadOff);
-            resources.ApplyResources(this.pnlTPMouse, "pnlTPMouse");
-            this.pnlTPMouse.Name = "pnlTPMouse";
-            // 
-            // trackFrictionLb
-            // 
-            resources.ApplyResources(this.trackFrictionLb, "trackFrictionLb");
-            this.trackFrictionLb.Name = "trackFrictionLb";
-            // 
-            // trackFrictionNUD
-            // 
-            this.trackFrictionNUD.DecimalPlaces = 1;
-            resources.ApplyResources(this.trackFrictionNUD, "trackFrictionNUD");
-            this.trackFrictionNUD.Name = "trackFrictionNUD";
-            this.trackFrictionNUD.Value = new decimal(new int[] {
+      this.nUDL2.Name = "nUDL2";
+      this.nUDL2.ValueChanged += new System.EventHandler(this.numUDL2_ValueChanged);
+      // 
+      // gBTouchpad
+      // 
+      this.gBTouchpad.BackColor = System.Drawing.SystemColors.Control;
+      this.gBTouchpad.Controls.Add(this.pnlTPMouse);
+      this.gBTouchpad.Controls.Add(this.rBTPControls);
+      this.gBTouchpad.Controls.Add(this.rBTPMouse);
+      this.gBTouchpad.Controls.Add(this.fLPTouchSwipe);
+      this.gBTouchpad.ForeColor = System.Drawing.SystemColors.ControlText;
+      resources.ApplyResources(this.gBTouchpad, "gBTouchpad");
+      this.gBTouchpad.Name = "gBTouchpad";
+      this.gBTouchpad.TabStop = false;
+      // 
+      // pnlTPMouse
+      // 
+      this.pnlTPMouse.Controls.Add(this.trackFrictionLb);
+      this.pnlTPMouse.Controls.Add(this.trackFrictionNUD);
+      this.pnlTPMouse.Controls.Add(this.trackballCk);
+      this.pnlTPMouse.Controls.Add(this.touchpadDisInvertButton);
+      this.pnlTPMouse.Controls.Add(this.label25);
+      this.pnlTPMouse.Controls.Add(this.label15);
+      this.pnlTPMouse.Controls.Add(this.touchpadInvertComboBox);
+      this.pnlTPMouse.Controls.Add(this.nUDScroll);
+      this.pnlTPMouse.Controls.Add(this.cBDoubleTap);
+      this.pnlTPMouse.Controls.Add(this.cBScroll);
+      this.pnlTPMouse.Controls.Add(this.cBTouchpadJitterCompensation);
+      this.pnlTPMouse.Controls.Add(this.nUDTap);
+      this.pnlTPMouse.Controls.Add(this.cBlowerRCOn);
+      this.pnlTPMouse.Controls.Add(this.cBTap);
+      this.pnlTPMouse.Controls.Add(this.cBSlide);
+      this.pnlTPMouse.Controls.Add(this.nUDTouch);
+      this.pnlTPMouse.Controls.Add(this.cbStartTouchpadOff);
+      resources.ApplyResources(this.pnlTPMouse, "pnlTPMouse");
+      this.pnlTPMouse.Name = "pnlTPMouse";
+      // 
+      // trackFrictionLb
+      // 
+      resources.ApplyResources(this.trackFrictionLb, "trackFrictionLb");
+      this.trackFrictionLb.Name = "trackFrictionLb";
+      // 
+      // trackFrictionNUD
+      // 
+      this.trackFrictionNUD.DecimalPlaces = 1;
+      resources.ApplyResources(this.trackFrictionNUD, "trackFrictionNUD");
+      this.trackFrictionNUD.Name = "trackFrictionNUD";
+      this.trackFrictionNUD.Value = new decimal(new int[] {
             10,
             0,
             0,
             0});
-            this.trackFrictionNUD.ValueChanged += new System.EventHandler(this.trackFrictionNUD_ValueChanged);
-            // 
-            // trackballCk
-            // 
-            resources.ApplyResources(this.trackballCk, "trackballCk");
-            this.trackballCk.Name = "trackballCk";
-            this.trackballCk.UseVisualStyleBackColor = true;
-            this.trackballCk.CheckedChanged += new System.EventHandler(this.trackballCk_CheckedChanged);
-            // 
-            // touchpadDisInvertButton
-            // 
-            this.touchpadDisInvertButton.ForeColor = System.Drawing.SystemColors.ControlText;
-            resources.ApplyResources(this.touchpadDisInvertButton, "touchpadDisInvertButton");
-            this.touchpadDisInvertButton.Name = "touchpadDisInvertButton";
-            this.touchpadDisInvertButton.UseVisualStyleBackColor = true;
-            this.touchpadDisInvertButton.Click += new System.EventHandler(this.touchpadDisInvertButton_Click);
-            // 
-            // label25
-            // 
-            resources.ApplyResources(this.label25, "label25");
-            this.label25.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.label25.Name = "label25";
-            // 
-            // label15
-            // 
-            resources.ApplyResources(this.label15, "label15");
-            this.label15.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.label15.Name = "label15";
-            // 
-            // touchpadInvertComboBox
-            // 
-            this.touchpadInvertComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.touchpadInvertComboBox.FormattingEnabled = true;
-            this.touchpadInvertComboBox.Items.AddRange(new object[] {
+      this.trackFrictionNUD.ValueChanged += new System.EventHandler(this.trackFrictionNUD_ValueChanged);
+      // 
+      // trackballCk
+      // 
+      resources.ApplyResources(this.trackballCk, "trackballCk");
+      this.trackballCk.Name = "trackballCk";
+      this.trackballCk.UseVisualStyleBackColor = true;
+      this.trackballCk.CheckedChanged += new System.EventHandler(this.trackballCk_CheckedChanged);
+      // 
+      // touchpadDisInvertButton
+      // 
+      this.touchpadDisInvertButton.ForeColor = System.Drawing.SystemColors.ControlText;
+      resources.ApplyResources(this.touchpadDisInvertButton, "touchpadDisInvertButton");
+      this.touchpadDisInvertButton.Name = "touchpadDisInvertButton";
+      this.touchpadDisInvertButton.UseVisualStyleBackColor = true;
+      this.touchpadDisInvertButton.Click += new System.EventHandler(this.touchpadDisInvertButton_Click);
+      // 
+      // label25
+      // 
+      resources.ApplyResources(this.label25, "label25");
+      this.label25.ForeColor = System.Drawing.SystemColors.ControlText;
+      this.label25.Name = "label25";
+      // 
+      // label15
+      // 
+      resources.ApplyResources(this.label15, "label15");
+      this.label15.ForeColor = System.Drawing.SystemColors.ControlText;
+      this.label15.Name = "label15";
+      // 
+      // touchpadInvertComboBox
+      // 
+      this.touchpadInvertComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+      this.touchpadInvertComboBox.FormattingEnabled = true;
+      this.touchpadInvertComboBox.Items.AddRange(new object[] {
             resources.GetString("touchpadInvertComboBox.Items"),
             resources.GetString("touchpadInvertComboBox.Items1"),
             resources.GetString("touchpadInvertComboBox.Items2"),
             resources.GetString("touchpadInvertComboBox.Items3")});
-            resources.ApplyResources(this.touchpadInvertComboBox, "touchpadInvertComboBox");
-            this.touchpadInvertComboBox.Name = "touchpadInvertComboBox";
-            this.touchpadInvertComboBox.SelectedIndexChanged += new System.EventHandler(this.touchpadInvertComboBox_SelectedIndexChanged);
-            // 
-            // cbStartTouchpadOff
-            // 
-            resources.ApplyResources(this.cbStartTouchpadOff, "cbStartTouchpadOff");
-            this.cbStartTouchpadOff.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.cbStartTouchpadOff.Name = "cbStartTouchpadOff";
-            this.cbStartTouchpadOff.UseVisualStyleBackColor = true;
-            this.cbStartTouchpadOff.CheckedChanged += new System.EventHandler(this.cbStartTouchpadOff_CheckedChanged);
-            // 
-            // rBTPControls
-            // 
-            resources.ApplyResources(this.rBTPControls, "rBTPControls");
-            this.rBTPControls.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.rBTPControls.Name = "rBTPControls";
-            this.rBTPControls.TabStop = true;
-            this.rBTPControls.UseVisualStyleBackColor = true;
-            this.rBTPControls.CheckedChanged += new System.EventHandler(this.cBTPforControls_CheckedChanged);
-            // 
-            // rBTPMouse
-            // 
-            resources.ApplyResources(this.rBTPMouse, "rBTPMouse");
-            this.rBTPMouse.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.rBTPMouse.Name = "rBTPMouse";
-            this.rBTPMouse.TabStop = true;
-            this.rBTPMouse.UseVisualStyleBackColor = true;
-            this.rBTPMouse.CheckedChanged += new System.EventHandler(this.cBTPforControls_CheckedChanged);
-            // 
-            // fLPTouchSwipe
-            // 
-            this.fLPTouchSwipe.Controls.Add(this.bnSwipeUp);
-            this.fLPTouchSwipe.Controls.Add(this.lbSwipeUp);
-            this.fLPTouchSwipe.Controls.Add(this.bnSwipeDown);
-            this.fLPTouchSwipe.Controls.Add(this.lbSwipeDown);
-            this.fLPTouchSwipe.Controls.Add(this.bnSwipeLeft);
-            this.fLPTouchSwipe.Controls.Add(this.lbSwipeLeft);
-            this.fLPTouchSwipe.Controls.Add(this.bnSwipeRight);
-            this.fLPTouchSwipe.Controls.Add(this.lbSwipeRight);
-            resources.ApplyResources(this.fLPTouchSwipe, "fLPTouchSwipe");
-            this.fLPTouchSwipe.Name = "fLPTouchSwipe";
-            // 
-            // bnSwipeUp
-            // 
-            this.bnSwipeUp.BackColor = System.Drawing.SystemColors.ControlText;
-            this.bnSwipeUp.ContextMenuStrip = this.cMSPresets;
-            resources.ApplyResources(this.bnSwipeUp, "bnSwipeUp");
-            this.bnSwipeUp.ForeColor = System.Drawing.SystemColors.ControlLightLight;
-            this.bnSwipeUp.Name = "bnSwipeUp";
-            this.bnSwipeUp.UseVisualStyleBackColor = false;
-            this.bnSwipeUp.Click += new System.EventHandler(this.Show_ControlsBn);
-            // 
-            // cMSPresets
-            // 
-            this.cMSPresets.ImageScalingSize = new System.Drawing.Size(20, 20);
-            this.cMSPresets.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+      resources.ApplyResources(this.touchpadInvertComboBox, "touchpadInvertComboBox");
+      this.touchpadInvertComboBox.Name = "touchpadInvertComboBox";
+      this.touchpadInvertComboBox.SelectedIndexChanged += new System.EventHandler(this.touchpadInvertComboBox_SelectedIndexChanged);
+      // 
+      // cbStartTouchpadOff
+      // 
+      resources.ApplyResources(this.cbStartTouchpadOff, "cbStartTouchpadOff");
+      this.cbStartTouchpadOff.ForeColor = System.Drawing.SystemColors.ControlText;
+      this.cbStartTouchpadOff.Name = "cbStartTouchpadOff";
+      this.cbStartTouchpadOff.UseVisualStyleBackColor = true;
+      this.cbStartTouchpadOff.CheckedChanged += new System.EventHandler(this.cbStartTouchpadOff_CheckedChanged);
+      // 
+      // rBTPControls
+      // 
+      resources.ApplyResources(this.rBTPControls, "rBTPControls");
+      this.rBTPControls.ForeColor = System.Drawing.SystemColors.ControlText;
+      this.rBTPControls.Name = "rBTPControls";
+      this.rBTPControls.TabStop = true;
+      this.rBTPControls.UseVisualStyleBackColor = true;
+      this.rBTPControls.CheckedChanged += new System.EventHandler(this.cBTPforControls_CheckedChanged);
+      // 
+      // rBTPMouse
+      // 
+      resources.ApplyResources(this.rBTPMouse, "rBTPMouse");
+      this.rBTPMouse.ForeColor = System.Drawing.SystemColors.ControlText;
+      this.rBTPMouse.Name = "rBTPMouse";
+      this.rBTPMouse.TabStop = true;
+      this.rBTPMouse.UseVisualStyleBackColor = true;
+      this.rBTPMouse.CheckedChanged += new System.EventHandler(this.cBTPforControls_CheckedChanged);
+      // 
+      // fLPTouchSwipe
+      // 
+      this.fLPTouchSwipe.Controls.Add(this.bnSwipeUp);
+      this.fLPTouchSwipe.Controls.Add(this.lbSwipeUp);
+      this.fLPTouchSwipe.Controls.Add(this.bnSwipeDown);
+      this.fLPTouchSwipe.Controls.Add(this.lbSwipeDown);
+      this.fLPTouchSwipe.Controls.Add(this.bnSwipeLeft);
+      this.fLPTouchSwipe.Controls.Add(this.lbSwipeLeft);
+      this.fLPTouchSwipe.Controls.Add(this.bnSwipeRight);
+      this.fLPTouchSwipe.Controls.Add(this.lbSwipeRight);
+      resources.ApplyResources(this.fLPTouchSwipe, "fLPTouchSwipe");
+      this.fLPTouchSwipe.Name = "fLPTouchSwipe";
+      // 
+      // bnSwipeUp
+      // 
+      this.bnSwipeUp.BackColor = System.Drawing.SystemColors.ControlText;
+      this.bnSwipeUp.ContextMenuStrip = this.cMSPresets;
+      resources.ApplyResources(this.bnSwipeUp, "bnSwipeUp");
+      this.bnSwipeUp.ForeColor = System.Drawing.SystemColors.ControlLightLight;
+      this.bnSwipeUp.Name = "bnSwipeUp";
+      this.bnSwipeUp.UseVisualStyleBackColor = false;
+      this.bnSwipeUp.Click += new System.EventHandler(this.Show_ControlsBn);
+      // 
+      // cMSPresets
+      // 
+      this.cMSPresets.ImageScalingSize = new System.Drawing.Size(20, 20);
+      this.cMSPresets.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.controlToolStripMenuItem,
             this.toolStripSeparator1,
             this.defaultToolStripMenuItem,
@@ -1092,280 +1095,280 @@
             this.WASDToolStripMenuItem,
             this.ArrowKeysToolStripMenuItem,
             this.MouseToolStripMenuItem});
-            this.cMSPresets.Name = "contextMenuStrip1";
-            this.cMSPresets.ShowImageMargin = false;
-            resources.ApplyResources(this.cMSPresets, "cMSPresets");
-            this.cMSPresets.Opened += new System.EventHandler(this.cMSPresets_Opened);
-            // 
-            // controlToolStripMenuItem
-            // 
-            resources.ApplyResources(this.controlToolStripMenuItem, "controlToolStripMenuItem");
-            this.controlToolStripMenuItem.Name = "controlToolStripMenuItem";
-            // 
-            // toolStripSeparator1
-            // 
-            this.toolStripSeparator1.Name = "toolStripSeparator1";
-            resources.ApplyResources(this.toolStripSeparator1, "toolStripSeparator1");
-            // 
-            // defaultToolStripMenuItem
-            // 
-            this.defaultToolStripMenuItem.Name = "defaultToolStripMenuItem";
-            resources.ApplyResources(this.defaultToolStripMenuItem, "defaultToolStripMenuItem");
-            this.defaultToolStripMenuItem.Click += new System.EventHandler(this.SetPreset);
-            // 
-            // DpadToolStripMenuItem
-            // 
-            this.DpadToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+      this.cMSPresets.Name = "contextMenuStrip1";
+      this.cMSPresets.ShowImageMargin = false;
+      resources.ApplyResources(this.cMSPresets, "cMSPresets");
+      this.cMSPresets.Opened += new System.EventHandler(this.cMSPresets_Opened);
+      // 
+      // controlToolStripMenuItem
+      // 
+      resources.ApplyResources(this.controlToolStripMenuItem, "controlToolStripMenuItem");
+      this.controlToolStripMenuItem.Name = "controlToolStripMenuItem";
+      // 
+      // toolStripSeparator1
+      // 
+      this.toolStripSeparator1.Name = "toolStripSeparator1";
+      resources.ApplyResources(this.toolStripSeparator1, "toolStripSeparator1");
+      // 
+      // defaultToolStripMenuItem
+      // 
+      this.defaultToolStripMenuItem.Name = "defaultToolStripMenuItem";
+      resources.ApplyResources(this.defaultToolStripMenuItem, "defaultToolStripMenuItem");
+      this.defaultToolStripMenuItem.Click += new System.EventHandler(this.SetPreset);
+      // 
+      // DpadToolStripMenuItem
+      // 
+      this.DpadToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.tSMIDPadInverted,
             this.tSMIDPadInvertedX,
             this.tSMIDPadInvertedY});
-            this.DpadToolStripMenuItem.Name = "DpadToolStripMenuItem";
-            resources.ApplyResources(this.DpadToolStripMenuItem, "DpadToolStripMenuItem");
-            this.DpadToolStripMenuItem.Click += new System.EventHandler(this.SetPreset);
-            // 
-            // tSMIDPadInverted
-            // 
-            this.tSMIDPadInverted.Name = "tSMIDPadInverted";
-            resources.ApplyResources(this.tSMIDPadInverted, "tSMIDPadInverted");
-            this.tSMIDPadInverted.Click += new System.EventHandler(this.SetPreset);
-            // 
-            // tSMIDPadInvertedX
-            // 
-            this.tSMIDPadInvertedX.Name = "tSMIDPadInvertedX";
-            resources.ApplyResources(this.tSMIDPadInvertedX, "tSMIDPadInvertedX");
-            this.tSMIDPadInvertedX.Click += new System.EventHandler(this.SetPreset);
-            // 
-            // tSMIDPadInvertedY
-            // 
-            this.tSMIDPadInvertedY.Name = "tSMIDPadInvertedY";
-            resources.ApplyResources(this.tSMIDPadInvertedY, "tSMIDPadInvertedY");
-            this.tSMIDPadInvertedY.Click += new System.EventHandler(this.SetPreset);
-            // 
-            // LSToolStripMenuItem
-            // 
-            this.LSToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+      this.DpadToolStripMenuItem.Name = "DpadToolStripMenuItem";
+      resources.ApplyResources(this.DpadToolStripMenuItem, "DpadToolStripMenuItem");
+      this.DpadToolStripMenuItem.Click += new System.EventHandler(this.SetPreset);
+      // 
+      // tSMIDPadInverted
+      // 
+      this.tSMIDPadInverted.Name = "tSMIDPadInverted";
+      resources.ApplyResources(this.tSMIDPadInverted, "tSMIDPadInverted");
+      this.tSMIDPadInverted.Click += new System.EventHandler(this.SetPreset);
+      // 
+      // tSMIDPadInvertedX
+      // 
+      this.tSMIDPadInvertedX.Name = "tSMIDPadInvertedX";
+      resources.ApplyResources(this.tSMIDPadInvertedX, "tSMIDPadInvertedX");
+      this.tSMIDPadInvertedX.Click += new System.EventHandler(this.SetPreset);
+      // 
+      // tSMIDPadInvertedY
+      // 
+      this.tSMIDPadInvertedY.Name = "tSMIDPadInvertedY";
+      resources.ApplyResources(this.tSMIDPadInvertedY, "tSMIDPadInvertedY");
+      this.tSMIDPadInvertedY.Click += new System.EventHandler(this.SetPreset);
+      // 
+      // LSToolStripMenuItem
+      // 
+      this.LSToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.tSMILSInverted,
             this.tSMILSInvertedX,
             this.tSMILSInvertedY});
-            this.LSToolStripMenuItem.Name = "LSToolStripMenuItem";
-            resources.ApplyResources(this.LSToolStripMenuItem, "LSToolStripMenuItem");
-            this.LSToolStripMenuItem.Click += new System.EventHandler(this.SetPreset);
-            // 
-            // tSMILSInverted
-            // 
-            this.tSMILSInverted.Name = "tSMILSInverted";
-            resources.ApplyResources(this.tSMILSInverted, "tSMILSInverted");
-            this.tSMILSInverted.Click += new System.EventHandler(this.SetPreset);
-            // 
-            // tSMILSInvertedX
-            // 
-            this.tSMILSInvertedX.Name = "tSMILSInvertedX";
-            resources.ApplyResources(this.tSMILSInvertedX, "tSMILSInvertedX");
-            this.tSMILSInvertedX.Click += new System.EventHandler(this.SetPreset);
-            // 
-            // tSMILSInvertedY
-            // 
-            this.tSMILSInvertedY.Name = "tSMILSInvertedY";
-            resources.ApplyResources(this.tSMILSInvertedY, "tSMILSInvertedY");
-            this.tSMILSInvertedY.Click += new System.EventHandler(this.SetPreset);
-            // 
-            // RSToolStripMenuItem
-            // 
-            this.RSToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+      this.LSToolStripMenuItem.Name = "LSToolStripMenuItem";
+      resources.ApplyResources(this.LSToolStripMenuItem, "LSToolStripMenuItem");
+      this.LSToolStripMenuItem.Click += new System.EventHandler(this.SetPreset);
+      // 
+      // tSMILSInverted
+      // 
+      this.tSMILSInverted.Name = "tSMILSInverted";
+      resources.ApplyResources(this.tSMILSInverted, "tSMILSInverted");
+      this.tSMILSInverted.Click += new System.EventHandler(this.SetPreset);
+      // 
+      // tSMILSInvertedX
+      // 
+      this.tSMILSInvertedX.Name = "tSMILSInvertedX";
+      resources.ApplyResources(this.tSMILSInvertedX, "tSMILSInvertedX");
+      this.tSMILSInvertedX.Click += new System.EventHandler(this.SetPreset);
+      // 
+      // tSMILSInvertedY
+      // 
+      this.tSMILSInvertedY.Name = "tSMILSInvertedY";
+      resources.ApplyResources(this.tSMILSInvertedY, "tSMILSInvertedY");
+      this.tSMILSInvertedY.Click += new System.EventHandler(this.SetPreset);
+      // 
+      // RSToolStripMenuItem
+      // 
+      this.RSToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.tSMIRSInverted,
             this.tSMIRSInvertedX,
             this.tSMIRSInvertedY});
-            this.RSToolStripMenuItem.Name = "RSToolStripMenuItem";
-            resources.ApplyResources(this.RSToolStripMenuItem, "RSToolStripMenuItem");
-            this.RSToolStripMenuItem.Click += new System.EventHandler(this.SetPreset);
-            // 
-            // tSMIRSInverted
-            // 
-            this.tSMIRSInverted.Name = "tSMIRSInverted";
-            resources.ApplyResources(this.tSMIRSInverted, "tSMIRSInverted");
-            this.tSMIRSInverted.Click += new System.EventHandler(this.SetPreset);
-            // 
-            // tSMIRSInvertedX
-            // 
-            this.tSMIRSInvertedX.Name = "tSMIRSInvertedX";
-            resources.ApplyResources(this.tSMIRSInvertedX, "tSMIRSInvertedX");
-            this.tSMIRSInvertedX.Click += new System.EventHandler(this.SetPreset);
-            // 
-            // tSMIRSInvertedY
-            // 
-            this.tSMIRSInvertedY.Name = "tSMIRSInvertedY";
-            resources.ApplyResources(this.tSMIRSInvertedY, "tSMIRSInvertedY");
-            this.tSMIRSInvertedY.Click += new System.EventHandler(this.SetPreset);
-            // 
-            // ABXYToolStripMenuItem
-            // 
-            this.ABXYToolStripMenuItem.Name = "ABXYToolStripMenuItem";
-            resources.ApplyResources(this.ABXYToolStripMenuItem, "ABXYToolStripMenuItem");
-            this.ABXYToolStripMenuItem.Click += new System.EventHandler(this.SetPreset);
-            // 
-            // WASDToolStripMenuItem
-            // 
-            this.WASDToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+      this.RSToolStripMenuItem.Name = "RSToolStripMenuItem";
+      resources.ApplyResources(this.RSToolStripMenuItem, "RSToolStripMenuItem");
+      this.RSToolStripMenuItem.Click += new System.EventHandler(this.SetPreset);
+      // 
+      // tSMIRSInverted
+      // 
+      this.tSMIRSInverted.Name = "tSMIRSInverted";
+      resources.ApplyResources(this.tSMIRSInverted, "tSMIRSInverted");
+      this.tSMIRSInverted.Click += new System.EventHandler(this.SetPreset);
+      // 
+      // tSMIRSInvertedX
+      // 
+      this.tSMIRSInvertedX.Name = "tSMIRSInvertedX";
+      resources.ApplyResources(this.tSMIRSInvertedX, "tSMIRSInvertedX");
+      this.tSMIRSInvertedX.Click += new System.EventHandler(this.SetPreset);
+      // 
+      // tSMIRSInvertedY
+      // 
+      this.tSMIRSInvertedY.Name = "tSMIRSInvertedY";
+      resources.ApplyResources(this.tSMIRSInvertedY, "tSMIRSInvertedY");
+      this.tSMIRSInvertedY.Click += new System.EventHandler(this.SetPreset);
+      // 
+      // ABXYToolStripMenuItem
+      // 
+      this.ABXYToolStripMenuItem.Name = "ABXYToolStripMenuItem";
+      resources.ApplyResources(this.ABXYToolStripMenuItem, "ABXYToolStripMenuItem");
+      this.ABXYToolStripMenuItem.Click += new System.EventHandler(this.SetPreset);
+      // 
+      // WASDToolStripMenuItem
+      // 
+      this.WASDToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.wScanCodeWASDToolStripMenuItem});
-            this.WASDToolStripMenuItem.Name = "WASDToolStripMenuItem";
-            resources.ApplyResources(this.WASDToolStripMenuItem, "WASDToolStripMenuItem");
-            this.WASDToolStripMenuItem.Click += new System.EventHandler(this.SetPreset);
-            // 
-            // wScanCodeWASDToolStripMenuItem
-            // 
-            this.wScanCodeWASDToolStripMenuItem.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.wScanCodeWASDToolStripMenuItem.Name = "wScanCodeWASDToolStripMenuItem";
-            resources.ApplyResources(this.wScanCodeWASDToolStripMenuItem, "wScanCodeWASDToolStripMenuItem");
-            this.wScanCodeWASDToolStripMenuItem.Click += new System.EventHandler(this.SetPreset);
-            // 
-            // ArrowKeysToolStripMenuItem
-            // 
-            this.ArrowKeysToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+      this.WASDToolStripMenuItem.Name = "WASDToolStripMenuItem";
+      resources.ApplyResources(this.WASDToolStripMenuItem, "WASDToolStripMenuItem");
+      this.WASDToolStripMenuItem.Click += new System.EventHandler(this.SetPreset);
+      // 
+      // wScanCodeWASDToolStripMenuItem
+      // 
+      this.wScanCodeWASDToolStripMenuItem.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+      this.wScanCodeWASDToolStripMenuItem.Name = "wScanCodeWASDToolStripMenuItem";
+      resources.ApplyResources(this.wScanCodeWASDToolStripMenuItem, "wScanCodeWASDToolStripMenuItem");
+      this.wScanCodeWASDToolStripMenuItem.Click += new System.EventHandler(this.SetPreset);
+      // 
+      // ArrowKeysToolStripMenuItem
+      // 
+      this.ArrowKeysToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.wScanCodeArrowKeysToolStripMenuItem});
-            this.ArrowKeysToolStripMenuItem.Name = "ArrowKeysToolStripMenuItem";
-            resources.ApplyResources(this.ArrowKeysToolStripMenuItem, "ArrowKeysToolStripMenuItem");
-            this.ArrowKeysToolStripMenuItem.Click += new System.EventHandler(this.SetPreset);
-            // 
-            // wScanCodeArrowKeysToolStripMenuItem
-            // 
-            this.wScanCodeArrowKeysToolStripMenuItem.Name = "wScanCodeArrowKeysToolStripMenuItem";
-            resources.ApplyResources(this.wScanCodeArrowKeysToolStripMenuItem, "wScanCodeArrowKeysToolStripMenuItem");
-            this.wScanCodeArrowKeysToolStripMenuItem.Click += new System.EventHandler(this.SetPreset);
-            // 
-            // MouseToolStripMenuItem
-            // 
-            this.MouseToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+      this.ArrowKeysToolStripMenuItem.Name = "ArrowKeysToolStripMenuItem";
+      resources.ApplyResources(this.ArrowKeysToolStripMenuItem, "ArrowKeysToolStripMenuItem");
+      this.ArrowKeysToolStripMenuItem.Click += new System.EventHandler(this.SetPreset);
+      // 
+      // wScanCodeArrowKeysToolStripMenuItem
+      // 
+      this.wScanCodeArrowKeysToolStripMenuItem.Name = "wScanCodeArrowKeysToolStripMenuItem";
+      resources.ApplyResources(this.wScanCodeArrowKeysToolStripMenuItem, "wScanCodeArrowKeysToolStripMenuItem");
+      this.wScanCodeArrowKeysToolStripMenuItem.Click += new System.EventHandler(this.SetPreset);
+      // 
+      // MouseToolStripMenuItem
+      // 
+      this.MouseToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.tSMIMouseInverted,
             this.tSMIMouseInvertedX,
             this.tSMIMouseInvertedY});
-            this.MouseToolStripMenuItem.Name = "MouseToolStripMenuItem";
-            resources.ApplyResources(this.MouseToolStripMenuItem, "MouseToolStripMenuItem");
-            this.MouseToolStripMenuItem.Click += new System.EventHandler(this.SetPreset);
-            // 
-            // tSMIMouseInverted
-            // 
-            this.tSMIMouseInverted.Name = "tSMIMouseInverted";
-            resources.ApplyResources(this.tSMIMouseInverted, "tSMIMouseInverted");
-            this.tSMIMouseInverted.Click += new System.EventHandler(this.SetPreset);
-            // 
-            // tSMIMouseInvertedX
-            // 
-            this.tSMIMouseInvertedX.Name = "tSMIMouseInvertedX";
-            resources.ApplyResources(this.tSMIMouseInvertedX, "tSMIMouseInvertedX");
-            this.tSMIMouseInvertedX.Click += new System.EventHandler(this.SetPreset);
-            // 
-            // tSMIMouseInvertedY
-            // 
-            this.tSMIMouseInvertedY.Name = "tSMIMouseInvertedY";
-            resources.ApplyResources(this.tSMIMouseInvertedY, "tSMIMouseInvertedY");
-            this.tSMIMouseInvertedY.Click += new System.EventHandler(this.SetPreset);
-            // 
-            // lbSwipeUp
-            // 
-            this.lbSwipeUp.ForeColor = System.Drawing.SystemColors.ControlText;
-            resources.ApplyResources(this.lbSwipeUp, "lbSwipeUp");
-            this.lbSwipeUp.Name = "lbSwipeUp";
-            // 
-            // bnSwipeDown
-            // 
-            this.bnSwipeDown.BackColor = System.Drawing.SystemColors.ControlText;
-            this.bnSwipeDown.ContextMenuStrip = this.cMSPresets;
-            resources.ApplyResources(this.bnSwipeDown, "bnSwipeDown");
-            this.bnSwipeDown.ForeColor = System.Drawing.SystemColors.ControlLightLight;
-            this.bnSwipeDown.Name = "bnSwipeDown";
-            this.bnSwipeDown.UseVisualStyleBackColor = false;
-            this.bnSwipeDown.Click += new System.EventHandler(this.Show_ControlsBn);
-            // 
-            // lbSwipeDown
-            // 
-            this.lbSwipeDown.ForeColor = System.Drawing.SystemColors.ControlText;
-            resources.ApplyResources(this.lbSwipeDown, "lbSwipeDown");
-            this.lbSwipeDown.Name = "lbSwipeDown";
-            // 
-            // bnSwipeLeft
-            // 
-            this.bnSwipeLeft.BackColor = System.Drawing.SystemColors.ControlText;
-            this.bnSwipeLeft.ContextMenuStrip = this.cMSPresets;
-            resources.ApplyResources(this.bnSwipeLeft, "bnSwipeLeft");
-            this.bnSwipeLeft.ForeColor = System.Drawing.SystemColors.ControlLightLight;
-            this.bnSwipeLeft.Name = "bnSwipeLeft";
-            this.bnSwipeLeft.UseVisualStyleBackColor = false;
-            this.bnSwipeLeft.Click += new System.EventHandler(this.Show_ControlsBn);
-            // 
-            // lbSwipeLeft
-            // 
-            this.lbSwipeLeft.ForeColor = System.Drawing.SystemColors.ControlText;
-            resources.ApplyResources(this.lbSwipeLeft, "lbSwipeLeft");
-            this.lbSwipeLeft.Name = "lbSwipeLeft";
-            // 
-            // bnSwipeRight
-            // 
-            this.bnSwipeRight.BackColor = System.Drawing.SystemColors.ControlText;
-            this.bnSwipeRight.ContextMenuStrip = this.cMSPresets;
-            resources.ApplyResources(this.bnSwipeRight, "bnSwipeRight");
-            this.bnSwipeRight.ForeColor = System.Drawing.SystemColors.ControlLightLight;
-            this.bnSwipeRight.Name = "bnSwipeRight";
-            this.bnSwipeRight.UseVisualStyleBackColor = false;
-            this.bnSwipeRight.Click += new System.EventHandler(this.Show_ControlsBn);
-            // 
-            // lbSwipeRight
-            // 
-            this.lbSwipeRight.ForeColor = System.Drawing.SystemColors.ControlText;
-            resources.ApplyResources(this.lbSwipeRight, "lbSwipeRight");
-            this.lbSwipeRight.Name = "lbSwipeRight";
-            // 
-            // gBOther
-            // 
-            this.gBOther.BackColor = System.Drawing.SystemColors.Control;
-            this.gBOther.Controls.Add(this.OutContTypeCb);
-            this.gBOther.Controls.Add(this.outcontLb);
-            this.gBOther.Controls.Add(this.btPollRateLabel);
-            this.gBOther.Controls.Add(this.btPollRateComboBox);
-            this.gBOther.Controls.Add(this.enableTouchToggleCheckbox);
-            this.gBOther.Controls.Add(this.cBDinput);
-            this.gBOther.Controls.Add(this.pBProgram);
-            this.gBOther.Controls.Add(this.cBLaunchProgram);
-            this.gBOther.Controls.Add(this.btnBrowse);
-            this.gBOther.Controls.Add(this.lbUseController);
-            this.gBOther.Controls.Add(this.cBMouseAccel);
-            this.gBOther.Controls.Add(this.nUDSixaxis);
-            this.gBOther.Controls.Add(this.cBControllerInput);
-            this.gBOther.Controls.Add(this.nUDIdleDisconnect);
-            this.gBOther.Controls.Add(this.cBIdleDisconnect);
-            this.gBOther.Controls.Add(this.lbButtonMouseSens);
-            this.gBOther.Controls.Add(this.numUDMouseSens);
-            this.gBOther.Controls.Add(this.cBFlushHIDQueue);
-            this.gBOther.Controls.Add(this.lbIdleMinutes);
-            resources.ApplyResources(this.gBOther, "gBOther");
-            this.gBOther.Name = "gBOther";
-            this.gBOther.TabStop = false;
-            // 
-            // OutContTypeCb
-            // 
-            this.OutContTypeCb.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.OutContTypeCb.FormattingEnabled = true;
-            this.OutContTypeCb.Items.AddRange(new object[] {
+      this.MouseToolStripMenuItem.Name = "MouseToolStripMenuItem";
+      resources.ApplyResources(this.MouseToolStripMenuItem, "MouseToolStripMenuItem");
+      this.MouseToolStripMenuItem.Click += new System.EventHandler(this.SetPreset);
+      // 
+      // tSMIMouseInverted
+      // 
+      this.tSMIMouseInverted.Name = "tSMIMouseInverted";
+      resources.ApplyResources(this.tSMIMouseInverted, "tSMIMouseInverted");
+      this.tSMIMouseInverted.Click += new System.EventHandler(this.SetPreset);
+      // 
+      // tSMIMouseInvertedX
+      // 
+      this.tSMIMouseInvertedX.Name = "tSMIMouseInvertedX";
+      resources.ApplyResources(this.tSMIMouseInvertedX, "tSMIMouseInvertedX");
+      this.tSMIMouseInvertedX.Click += new System.EventHandler(this.SetPreset);
+      // 
+      // tSMIMouseInvertedY
+      // 
+      this.tSMIMouseInvertedY.Name = "tSMIMouseInvertedY";
+      resources.ApplyResources(this.tSMIMouseInvertedY, "tSMIMouseInvertedY");
+      this.tSMIMouseInvertedY.Click += new System.EventHandler(this.SetPreset);
+      // 
+      // lbSwipeUp
+      // 
+      this.lbSwipeUp.ForeColor = System.Drawing.SystemColors.ControlText;
+      resources.ApplyResources(this.lbSwipeUp, "lbSwipeUp");
+      this.lbSwipeUp.Name = "lbSwipeUp";
+      // 
+      // bnSwipeDown
+      // 
+      this.bnSwipeDown.BackColor = System.Drawing.SystemColors.ControlText;
+      this.bnSwipeDown.ContextMenuStrip = this.cMSPresets;
+      resources.ApplyResources(this.bnSwipeDown, "bnSwipeDown");
+      this.bnSwipeDown.ForeColor = System.Drawing.SystemColors.ControlLightLight;
+      this.bnSwipeDown.Name = "bnSwipeDown";
+      this.bnSwipeDown.UseVisualStyleBackColor = false;
+      this.bnSwipeDown.Click += new System.EventHandler(this.Show_ControlsBn);
+      // 
+      // lbSwipeDown
+      // 
+      this.lbSwipeDown.ForeColor = System.Drawing.SystemColors.ControlText;
+      resources.ApplyResources(this.lbSwipeDown, "lbSwipeDown");
+      this.lbSwipeDown.Name = "lbSwipeDown";
+      // 
+      // bnSwipeLeft
+      // 
+      this.bnSwipeLeft.BackColor = System.Drawing.SystemColors.ControlText;
+      this.bnSwipeLeft.ContextMenuStrip = this.cMSPresets;
+      resources.ApplyResources(this.bnSwipeLeft, "bnSwipeLeft");
+      this.bnSwipeLeft.ForeColor = System.Drawing.SystemColors.ControlLightLight;
+      this.bnSwipeLeft.Name = "bnSwipeLeft";
+      this.bnSwipeLeft.UseVisualStyleBackColor = false;
+      this.bnSwipeLeft.Click += new System.EventHandler(this.Show_ControlsBn);
+      // 
+      // lbSwipeLeft
+      // 
+      this.lbSwipeLeft.ForeColor = System.Drawing.SystemColors.ControlText;
+      resources.ApplyResources(this.lbSwipeLeft, "lbSwipeLeft");
+      this.lbSwipeLeft.Name = "lbSwipeLeft";
+      // 
+      // bnSwipeRight
+      // 
+      this.bnSwipeRight.BackColor = System.Drawing.SystemColors.ControlText;
+      this.bnSwipeRight.ContextMenuStrip = this.cMSPresets;
+      resources.ApplyResources(this.bnSwipeRight, "bnSwipeRight");
+      this.bnSwipeRight.ForeColor = System.Drawing.SystemColors.ControlLightLight;
+      this.bnSwipeRight.Name = "bnSwipeRight";
+      this.bnSwipeRight.UseVisualStyleBackColor = false;
+      this.bnSwipeRight.Click += new System.EventHandler(this.Show_ControlsBn);
+      // 
+      // lbSwipeRight
+      // 
+      this.lbSwipeRight.ForeColor = System.Drawing.SystemColors.ControlText;
+      resources.ApplyResources(this.lbSwipeRight, "lbSwipeRight");
+      this.lbSwipeRight.Name = "lbSwipeRight";
+      // 
+      // gBOther
+      // 
+      this.gBOther.BackColor = System.Drawing.SystemColors.Control;
+      this.gBOther.Controls.Add(this.OutContTypeCb);
+      this.gBOther.Controls.Add(this.outcontLb);
+      this.gBOther.Controls.Add(this.btPollRateLabel);
+      this.gBOther.Controls.Add(this.btPollRateComboBox);
+      this.gBOther.Controls.Add(this.enableTouchToggleCheckbox);
+      this.gBOther.Controls.Add(this.cBDinput);
+      this.gBOther.Controls.Add(this.pBProgram);
+      this.gBOther.Controls.Add(this.cBLaunchProgram);
+      this.gBOther.Controls.Add(this.btnBrowse);
+      this.gBOther.Controls.Add(this.lbUseController);
+      this.gBOther.Controls.Add(this.cBMouseAccel);
+      this.gBOther.Controls.Add(this.nUDSixaxis);
+      this.gBOther.Controls.Add(this.cBControllerInput);
+      this.gBOther.Controls.Add(this.nUDIdleDisconnect);
+      this.gBOther.Controls.Add(this.cBIdleDisconnect);
+      this.gBOther.Controls.Add(this.lbButtonMouseSens);
+      this.gBOther.Controls.Add(this.numUDMouseSens);
+      this.gBOther.Controls.Add(this.cBFlushHIDQueue);
+      this.gBOther.Controls.Add(this.lbIdleMinutes);
+      resources.ApplyResources(this.gBOther, "gBOther");
+      this.gBOther.Name = "gBOther";
+      this.gBOther.TabStop = false;
+      // 
+      // OutContTypeCb
+      // 
+      this.OutContTypeCb.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+      this.OutContTypeCb.FormattingEnabled = true;
+      this.OutContTypeCb.Items.AddRange(new object[] {
             resources.GetString("OutContTypeCb.Items"),
             resources.GetString("OutContTypeCb.Items1")});
-            resources.ApplyResources(this.OutContTypeCb, "OutContTypeCb");
-            this.OutContTypeCb.Name = "OutContTypeCb";
-            // 
-            // outcontLb
-            // 
-            resources.ApplyResources(this.outcontLb, "outcontLb");
-            this.outcontLb.Name = "outcontLb";
-            // 
-            // btPollRateLabel
-            // 
-            resources.ApplyResources(this.btPollRateLabel, "btPollRateLabel");
-            this.btPollRateLabel.Name = "btPollRateLabel";
-            // 
-            // btPollRateComboBox
-            // 
-            this.btPollRateComboBox.BackColor = System.Drawing.SystemColors.Window;
-            this.btPollRateComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.btPollRateComboBox.FormattingEnabled = true;
-            this.btPollRateComboBox.Items.AddRange(new object[] {
+      resources.ApplyResources(this.OutContTypeCb, "OutContTypeCb");
+      this.OutContTypeCb.Name = "OutContTypeCb";
+      // 
+      // outcontLb
+      // 
+      resources.ApplyResources(this.outcontLb, "outcontLb");
+      this.outcontLb.Name = "outcontLb";
+      // 
+      // btPollRateLabel
+      // 
+      resources.ApplyResources(this.btPollRateLabel, "btPollRateLabel");
+      this.btPollRateLabel.Name = "btPollRateLabel";
+      // 
+      // btPollRateComboBox
+      // 
+      this.btPollRateComboBox.BackColor = System.Drawing.SystemColors.Window;
+      this.btPollRateComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+      this.btPollRateComboBox.FormattingEnabled = true;
+      this.btPollRateComboBox.Items.AddRange(new object[] {
             resources.GetString("btPollRateComboBox.Items"),
             resources.GetString("btPollRateComboBox.Items1"),
             resources.GetString("btPollRateComboBox.Items2"),
@@ -1383,580 +1386,580 @@
             resources.GetString("btPollRateComboBox.Items14"),
             resources.GetString("btPollRateComboBox.Items15"),
             resources.GetString("btPollRateComboBox.Items16")});
-            resources.ApplyResources(this.btPollRateComboBox, "btPollRateComboBox");
-            this.btPollRateComboBox.Name = "btPollRateComboBox";
-            this.btPollRateComboBox.SelectedIndexChanged += new System.EventHandler(this.btPollRateComboBox_SelectedIndexChanged);
-            // 
-            // enableTouchToggleCheckbox
-            // 
-            resources.ApplyResources(this.enableTouchToggleCheckbox, "enableTouchToggleCheckbox");
-            this.enableTouchToggleCheckbox.Name = "enableTouchToggleCheckbox";
-            this.enableTouchToggleCheckbox.UseVisualStyleBackColor = true;
-            this.enableTouchToggleCheckbox.CheckedChanged += new System.EventHandler(this.enableTouchToggleCheckbox_CheckedChanged);
-            // 
-            // cBDinput
-            // 
-            resources.ApplyResources(this.cBDinput, "cBDinput");
-            this.cBDinput.Name = "cBDinput";
-            this.cBDinput.UseVisualStyleBackColor = true;
-            this.cBDinput.CheckedChanged += new System.EventHandler(this.CBDinput_CheckedChanged);
-            // 
-            // pBProgram
-            // 
-            resources.ApplyResources(this.pBProgram, "pBProgram");
-            this.pBProgram.Name = "pBProgram";
-            this.pBProgram.TabStop = false;
-            // 
-            // cBLaunchProgram
-            // 
-            resources.ApplyResources(this.cBLaunchProgram, "cBLaunchProgram");
-            this.cBLaunchProgram.Name = "cBLaunchProgram";
-            this.cBLaunchProgram.UseVisualStyleBackColor = true;
-            this.cBLaunchProgram.CheckedChanged += new System.EventHandler(this.cBLaunchProgram_CheckedChanged);
-            // 
-            // btnBrowse
-            // 
-            resources.ApplyResources(this.btnBrowse, "btnBrowse");
-            this.btnBrowse.Name = "btnBrowse";
-            this.btnBrowse.UseVisualStyleBackColor = true;
-            this.btnBrowse.Click += new System.EventHandler(this.btnBrowse_Click);
-            // 
-            // lbUseController
-            // 
-            resources.ApplyResources(this.lbUseController, "lbUseController");
-            this.lbUseController.Name = "lbUseController";
-            // 
-            // cBMouseAccel
-            // 
-            resources.ApplyResources(this.cBMouseAccel, "cBMouseAccel");
-            this.cBMouseAccel.Name = "cBMouseAccel";
-            this.cBMouseAccel.UseVisualStyleBackColor = true;
-            this.cBMouseAccel.CheckedChanged += new System.EventHandler(this.cBMouseAccel_CheckedChanged);
-            // 
-            // nUDSixaxis
-            // 
-            resources.ApplyResources(this.nUDSixaxis, "nUDSixaxis");
-            this.nUDSixaxis.Maximum = new decimal(new int[] {
+      resources.ApplyResources(this.btPollRateComboBox, "btPollRateComboBox");
+      this.btPollRateComboBox.Name = "btPollRateComboBox";
+      this.btPollRateComboBox.SelectedIndexChanged += new System.EventHandler(this.btPollRateComboBox_SelectedIndexChanged);
+      // 
+      // enableTouchToggleCheckbox
+      // 
+      resources.ApplyResources(this.enableTouchToggleCheckbox, "enableTouchToggleCheckbox");
+      this.enableTouchToggleCheckbox.Name = "enableTouchToggleCheckbox";
+      this.enableTouchToggleCheckbox.UseVisualStyleBackColor = true;
+      this.enableTouchToggleCheckbox.CheckedChanged += new System.EventHandler(this.enableTouchToggleCheckbox_CheckedChanged);
+      // 
+      // cBDinput
+      // 
+      resources.ApplyResources(this.cBDinput, "cBDinput");
+      this.cBDinput.Name = "cBDinput";
+      this.cBDinput.UseVisualStyleBackColor = true;
+      this.cBDinput.CheckedChanged += new System.EventHandler(this.CBDinput_CheckedChanged);
+      // 
+      // pBProgram
+      // 
+      resources.ApplyResources(this.pBProgram, "pBProgram");
+      this.pBProgram.Name = "pBProgram";
+      this.pBProgram.TabStop = false;
+      // 
+      // cBLaunchProgram
+      // 
+      resources.ApplyResources(this.cBLaunchProgram, "cBLaunchProgram");
+      this.cBLaunchProgram.Name = "cBLaunchProgram";
+      this.cBLaunchProgram.UseVisualStyleBackColor = true;
+      this.cBLaunchProgram.CheckedChanged += new System.EventHandler(this.cBLaunchProgram_CheckedChanged);
+      // 
+      // btnBrowse
+      // 
+      resources.ApplyResources(this.btnBrowse, "btnBrowse");
+      this.btnBrowse.Name = "btnBrowse";
+      this.btnBrowse.UseVisualStyleBackColor = true;
+      this.btnBrowse.Click += new System.EventHandler(this.btnBrowse_Click);
+      // 
+      // lbUseController
+      // 
+      resources.ApplyResources(this.lbUseController, "lbUseController");
+      this.lbUseController.Name = "lbUseController";
+      // 
+      // cBMouseAccel
+      // 
+      resources.ApplyResources(this.cBMouseAccel, "cBMouseAccel");
+      this.cBMouseAccel.Name = "cBMouseAccel";
+      this.cBMouseAccel.UseVisualStyleBackColor = true;
+      this.cBMouseAccel.CheckedChanged += new System.EventHandler(this.cBMouseAccel_CheckedChanged);
+      // 
+      // nUDSixaxis
+      // 
+      resources.ApplyResources(this.nUDSixaxis, "nUDSixaxis");
+      this.nUDSixaxis.Maximum = new decimal(new int[] {
             4,
             0,
             0,
             0});
-            this.nUDSixaxis.Minimum = new decimal(new int[] {
+      this.nUDSixaxis.Minimum = new decimal(new int[] {
             1,
             0,
             0,
             0});
-            this.nUDSixaxis.Name = "nUDSixaxis";
-            this.nUDSixaxis.Value = new decimal(new int[] {
+      this.nUDSixaxis.Name = "nUDSixaxis";
+      this.nUDSixaxis.Value = new decimal(new int[] {
             1,
             0,
             0,
             0});
-            // 
-            // cBControllerInput
-            // 
-            resources.ApplyResources(this.cBControllerInput, "cBControllerInput");
-            this.cBControllerInput.Checked = true;
-            this.cBControllerInput.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.cBControllerInput.Name = "cBControllerInput";
-            this.cBControllerInput.UseVisualStyleBackColor = true;
-            this.cBControllerInput.CheckedChanged += new System.EventHandler(this.cBControllerInput_CheckedChanged);
-            // 
-            // cBIdleDisconnect
-            // 
-            resources.ApplyResources(this.cBIdleDisconnect, "cBIdleDisconnect");
-            this.cBIdleDisconnect.Checked = true;
-            this.cBIdleDisconnect.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.cBIdleDisconnect.Name = "cBIdleDisconnect";
-            this.cBIdleDisconnect.UseVisualStyleBackColor = true;
-            this.cBIdleDisconnect.CheckedChanged += new System.EventHandler(this.cBIdleDisconnect_CheckedChanged);
-            // 
-            // gBLightbar
-            // 
-            this.gBLightbar.BackColor = System.Drawing.SystemColors.Control;
-            this.gBLightbar.Controls.Add(this.btnRainbow);
-            this.gBLightbar.Controls.Add(this.lbRainbowB);
-            this.gBLightbar.Controls.Add(this.nUDRainbowB);
-            this.gBLightbar.Controls.Add(this.cBFlashType);
-            this.gBLightbar.Controls.Add(this.cBWhileCharging);
-            this.gBLightbar.Controls.Add(this.btnFlashColor);
-            this.gBLightbar.Controls.Add(this.btnChargingColor);
-            this.gBLightbar.Controls.Add(this.lbWhileCharging);
-            this.gBLightbar.Controls.Add(this.lbPercentFlashBar);
-            this.gBLightbar.Controls.Add(this.nUDflashLED);
-            this.gBLightbar.Controls.Add(this.nUDRainbow);
-            this.gBLightbar.Controls.Add(this.lbspc);
-            this.gBLightbar.Controls.Add(this.cBLightbyBattery);
-            this.gBLightbar.Controls.Add(this.pnlLowBattery);
-            this.gBLightbar.Controls.Add(this.pnlFull);
-            resources.ApplyResources(this.gBLightbar, "gBLightbar");
-            this.gBLightbar.Name = "gBLightbar";
-            this.gBLightbar.TabStop = false;
-            // 
-            // btnRainbow
-            // 
-            this.btnRainbow.Image = global::DS4Windows.Properties.Resources.rainbow;
-            resources.ApplyResources(this.btnRainbow, "btnRainbow");
-            this.btnRainbow.Name = "btnRainbow";
-            this.btnRainbow.UseVisualStyleBackColor = true;
-            this.btnRainbow.Click += new System.EventHandler(this.btnRainbow_Click);
-            // 
-            // lbRainbowB
-            // 
-            resources.ApplyResources(this.lbRainbowB, "lbRainbowB");
-            this.lbRainbowB.Name = "lbRainbowB";
-            // 
-            // nUDRainbowB
-            // 
-            resources.ApplyResources(this.nUDRainbowB, "nUDRainbowB");
-            this.nUDRainbowB.Maximum = new decimal(new int[] {
+      // 
+      // cBControllerInput
+      // 
+      resources.ApplyResources(this.cBControllerInput, "cBControllerInput");
+      this.cBControllerInput.Checked = true;
+      this.cBControllerInput.CheckState = System.Windows.Forms.CheckState.Checked;
+      this.cBControllerInput.Name = "cBControllerInput";
+      this.cBControllerInput.UseVisualStyleBackColor = true;
+      this.cBControllerInput.CheckedChanged += new System.EventHandler(this.cBControllerInput_CheckedChanged);
+      // 
+      // cBIdleDisconnect
+      // 
+      resources.ApplyResources(this.cBIdleDisconnect, "cBIdleDisconnect");
+      this.cBIdleDisconnect.Checked = true;
+      this.cBIdleDisconnect.CheckState = System.Windows.Forms.CheckState.Checked;
+      this.cBIdleDisconnect.Name = "cBIdleDisconnect";
+      this.cBIdleDisconnect.UseVisualStyleBackColor = true;
+      this.cBIdleDisconnect.CheckedChanged += new System.EventHandler(this.cBIdleDisconnect_CheckedChanged);
+      // 
+      // gBLightbar
+      // 
+      this.gBLightbar.BackColor = System.Drawing.SystemColors.Control;
+      this.gBLightbar.Controls.Add(this.btnRainbow);
+      this.gBLightbar.Controls.Add(this.lbRainbowB);
+      this.gBLightbar.Controls.Add(this.nUDRainbowB);
+      this.gBLightbar.Controls.Add(this.cBFlashType);
+      this.gBLightbar.Controls.Add(this.cBWhileCharging);
+      this.gBLightbar.Controls.Add(this.btnFlashColor);
+      this.gBLightbar.Controls.Add(this.btnChargingColor);
+      this.gBLightbar.Controls.Add(this.lbWhileCharging);
+      this.gBLightbar.Controls.Add(this.lbPercentFlashBar);
+      this.gBLightbar.Controls.Add(this.nUDflashLED);
+      this.gBLightbar.Controls.Add(this.nUDRainbow);
+      this.gBLightbar.Controls.Add(this.lbspc);
+      this.gBLightbar.Controls.Add(this.cBLightbyBattery);
+      this.gBLightbar.Controls.Add(this.pnlLowBattery);
+      this.gBLightbar.Controls.Add(this.pnlFull);
+      resources.ApplyResources(this.gBLightbar, "gBLightbar");
+      this.gBLightbar.Name = "gBLightbar";
+      this.gBLightbar.TabStop = false;
+      // 
+      // btnRainbow
+      // 
+      this.btnRainbow.Image = global::DS4Windows.Properties.Resources.rainbow;
+      resources.ApplyResources(this.btnRainbow, "btnRainbow");
+      this.btnRainbow.Name = "btnRainbow";
+      this.btnRainbow.UseVisualStyleBackColor = true;
+      this.btnRainbow.Click += new System.EventHandler(this.btnRainbow_Click);
+      // 
+      // lbRainbowB
+      // 
+      resources.ApplyResources(this.lbRainbowB, "lbRainbowB");
+      this.lbRainbowB.Name = "lbRainbowB";
+      // 
+      // nUDRainbowB
+      // 
+      resources.ApplyResources(this.nUDRainbowB, "nUDRainbowB");
+      this.nUDRainbowB.Maximum = new decimal(new int[] {
             150,
             0,
             0,
             0});
-            this.nUDRainbowB.Name = "nUDRainbowB";
-            this.nUDRainbowB.Value = new decimal(new int[] {
+      this.nUDRainbowB.Name = "nUDRainbowB";
+      this.nUDRainbowB.Value = new decimal(new int[] {
             100,
             0,
             0,
             0});
-            // 
-            // cBFlashType
-            // 
-            this.cBFlashType.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cBFlashType.FormattingEnabled = true;
-            this.cBFlashType.Items.AddRange(new object[] {
+      // 
+      // cBFlashType
+      // 
+      this.cBFlashType.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+      this.cBFlashType.FormattingEnabled = true;
+      this.cBFlashType.Items.AddRange(new object[] {
             resources.GetString("cBFlashType.Items"),
             resources.GetString("cBFlashType.Items1")});
-            resources.ApplyResources(this.cBFlashType, "cBFlashType");
-            this.cBFlashType.Name = "cBFlashType";
-            this.cBFlashType.SelectedIndexChanged += new System.EventHandler(this.cBFlashType_SelectedIndexChanged);
-            // 
-            // cBWhileCharging
-            // 
-            this.cBWhileCharging.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cBWhileCharging.FormattingEnabled = true;
-            this.cBWhileCharging.Items.AddRange(new object[] {
+      resources.ApplyResources(this.cBFlashType, "cBFlashType");
+      this.cBFlashType.Name = "cBFlashType";
+      this.cBFlashType.SelectedIndexChanged += new System.EventHandler(this.cBFlashType_SelectedIndexChanged);
+      // 
+      // cBWhileCharging
+      // 
+      this.cBWhileCharging.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+      this.cBWhileCharging.FormattingEnabled = true;
+      this.cBWhileCharging.Items.AddRange(new object[] {
             resources.GetString("cBWhileCharging.Items"),
             resources.GetString("cBWhileCharging.Items1"),
             resources.GetString("cBWhileCharging.Items2"),
             resources.GetString("cBWhileCharging.Items3")});
-            resources.ApplyResources(this.cBWhileCharging, "cBWhileCharging");
-            this.cBWhileCharging.Name = "cBWhileCharging";
-            this.cBWhileCharging.SelectedIndexChanged += new System.EventHandler(this.cBWhileCharging_SelectedIndexChanged);
-            // 
-            // btnFlashColor
-            // 
-            this.btnFlashColor.BackColor = System.Drawing.Color.White;
-            resources.ApplyResources(this.btnFlashColor, "btnFlashColor");
-            this.btnFlashColor.Name = "btnFlashColor";
-            this.btnFlashColor.UseVisualStyleBackColor = false;
-            this.btnFlashColor.Click += new System.EventHandler(this.btnFlashColor_Click);
-            // 
-            // btnChargingColor
-            // 
-            this.btnChargingColor.BackColor = System.Drawing.Color.White;
-            resources.ApplyResources(this.btnChargingColor, "btnChargingColor");
-            this.btnChargingColor.Name = "btnChargingColor";
-            this.btnChargingColor.UseVisualStyleBackColor = false;
-            this.btnChargingColor.Click += new System.EventHandler(this.btnChargingColor_Click);
-            // 
-            // lbWhileCharging
-            // 
-            resources.ApplyResources(this.lbWhileCharging, "lbWhileCharging");
-            this.lbWhileCharging.Name = "lbWhileCharging";
-            // 
-            // lbPercentFlashBar
-            // 
-            resources.ApplyResources(this.lbPercentFlashBar, "lbPercentFlashBar");
-            this.lbPercentFlashBar.Name = "lbPercentFlashBar";
-            // 
-            // nUDflashLED
-            // 
-            this.nUDflashLED.Increment = new decimal(new int[] {
+      resources.ApplyResources(this.cBWhileCharging, "cBWhileCharging");
+      this.cBWhileCharging.Name = "cBWhileCharging";
+      this.cBWhileCharging.SelectedIndexChanged += new System.EventHandler(this.cBWhileCharging_SelectedIndexChanged);
+      // 
+      // btnFlashColor
+      // 
+      this.btnFlashColor.BackColor = System.Drawing.Color.White;
+      resources.ApplyResources(this.btnFlashColor, "btnFlashColor");
+      this.btnFlashColor.Name = "btnFlashColor";
+      this.btnFlashColor.UseVisualStyleBackColor = false;
+      this.btnFlashColor.Click += new System.EventHandler(this.btnFlashColor_Click);
+      // 
+      // btnChargingColor
+      // 
+      this.btnChargingColor.BackColor = System.Drawing.Color.White;
+      resources.ApplyResources(this.btnChargingColor, "btnChargingColor");
+      this.btnChargingColor.Name = "btnChargingColor";
+      this.btnChargingColor.UseVisualStyleBackColor = false;
+      this.btnChargingColor.Click += new System.EventHandler(this.btnChargingColor_Click);
+      // 
+      // lbWhileCharging
+      // 
+      resources.ApplyResources(this.lbWhileCharging, "lbWhileCharging");
+      this.lbWhileCharging.Name = "lbWhileCharging";
+      // 
+      // lbPercentFlashBar
+      // 
+      resources.ApplyResources(this.lbPercentFlashBar, "lbPercentFlashBar");
+      this.lbPercentFlashBar.Name = "lbPercentFlashBar";
+      // 
+      // nUDflashLED
+      // 
+      this.nUDflashLED.Increment = new decimal(new int[] {
             10,
             0,
             0,
             0});
-            resources.ApplyResources(this.nUDflashLED, "nUDflashLED");
-            this.nUDflashLED.Name = "nUDflashLED";
-            this.nUDflashLED.ValueChanged += new System.EventHandler(this.nUDflashLED_ValueChanged);
-            // 
-            // gBRumble
-            // 
-            this.gBRumble.BackColor = System.Drawing.SystemColors.Control;
-            this.gBRumble.Controls.Add(this.lbPercentRumble);
-            this.gBRumble.Controls.Add(this.btnRumbleLightTest);
-            this.gBRumble.Controls.Add(this.btnRumbleHeavyTest);
-            this.gBRumble.Controls.Add(this.nUDRumbleBoost);
-            resources.ApplyResources(this.gBRumble, "gBRumble");
-            this.gBRumble.Name = "gBRumble";
-            this.gBRumble.TabStop = false;
-            // 
-            // lbPercentRumble
-            // 
-            resources.ApplyResources(this.lbPercentRumble, "lbPercentRumble");
-            this.lbPercentRumble.Name = "lbPercentRumble";
-            // 
-            // btnRumbleLightTest
-            // 
-            resources.ApplyResources(this.btnRumbleLightTest, "btnRumbleLightTest");
-            this.btnRumbleLightTest.Name = "btnRumbleLightTest";
-            this.btnRumbleLightTest.UseVisualStyleBackColor = true;
-            this.btnRumbleLightTest.Click += new System.EventHandler(this.btnRumbleLightTest_Click);
-            // 
-            // lbSixaxisX
-            // 
-            resources.ApplyResources(this.lbSixaxisX, "lbSixaxisX");
-            this.lbSixaxisX.Name = "lbSixaxisX";
-            // 
-            // lbSixaxisZ
-            // 
-            resources.ApplyResources(this.lbSixaxisZ, "lbSixaxisZ");
-            this.lbSixaxisZ.Name = "lbSixaxisZ";
-            // 
-            // nUDSZ
-            // 
-            this.nUDSZ.DecimalPlaces = 2;
-            this.nUDSZ.Increment = new decimal(new int[] {
+      resources.ApplyResources(this.nUDflashLED, "nUDflashLED");
+      this.nUDflashLED.Name = "nUDflashLED";
+      this.nUDflashLED.ValueChanged += new System.EventHandler(this.nUDflashLED_ValueChanged);
+      // 
+      // gBRumble
+      // 
+      this.gBRumble.BackColor = System.Drawing.SystemColors.Control;
+      this.gBRumble.Controls.Add(this.lbPercentRumble);
+      this.gBRumble.Controls.Add(this.btnRumbleLightTest);
+      this.gBRumble.Controls.Add(this.btnRumbleHeavyTest);
+      this.gBRumble.Controls.Add(this.nUDRumbleBoost);
+      resources.ApplyResources(this.gBRumble, "gBRumble");
+      this.gBRumble.Name = "gBRumble";
+      this.gBRumble.TabStop = false;
+      // 
+      // lbPercentRumble
+      // 
+      resources.ApplyResources(this.lbPercentRumble, "lbPercentRumble");
+      this.lbPercentRumble.Name = "lbPercentRumble";
+      // 
+      // btnRumbleLightTest
+      // 
+      resources.ApplyResources(this.btnRumbleLightTest, "btnRumbleLightTest");
+      this.btnRumbleLightTest.Name = "btnRumbleLightTest";
+      this.btnRumbleLightTest.UseVisualStyleBackColor = true;
+      this.btnRumbleLightTest.Click += new System.EventHandler(this.btnRumbleLightTest_Click);
+      // 
+      // lbSixaxisX
+      // 
+      resources.ApplyResources(this.lbSixaxisX, "lbSixaxisX");
+      this.lbSixaxisX.Name = "lbSixaxisX";
+      // 
+      // lbSixaxisZ
+      // 
+      resources.ApplyResources(this.lbSixaxisZ, "lbSixaxisZ");
+      this.lbSixaxisZ.Name = "lbSixaxisZ";
+      // 
+      // nUDSZ
+      // 
+      this.nUDSZ.DecimalPlaces = 2;
+      this.nUDSZ.Increment = new decimal(new int[] {
             1,
             0,
             0,
             65536});
-            resources.ApplyResources(this.nUDSZ, "nUDSZ");
-            this.nUDSZ.Maximum = new decimal(new int[] {
+      resources.ApplyResources(this.nUDSZ, "nUDSZ");
+      this.nUDSZ.Maximum = new decimal(new int[] {
             1,
             0,
             0,
             0});
-            this.nUDSZ.Name = "nUDSZ";
-            this.nUDSZ.Value = new decimal(new int[] {
+      this.nUDSZ.Name = "nUDSZ";
+      this.nUDSZ.Value = new decimal(new int[] {
             25,
             0,
             0,
             131072});
-            this.nUDSZ.ValueChanged += new System.EventHandler(this.nUDSZ_ValueChanged);
-            // 
-            // nUDSX
-            // 
-            this.nUDSX.DecimalPlaces = 2;
-            this.nUDSX.Increment = new decimal(new int[] {
+      this.nUDSZ.ValueChanged += new System.EventHandler(this.nUDSZ_ValueChanged);
+      // 
+      // nUDSX
+      // 
+      this.nUDSX.DecimalPlaces = 2;
+      this.nUDSX.Increment = new decimal(new int[] {
             1,
             0,
             0,
             65536});
-            resources.ApplyResources(this.nUDSX, "nUDSX");
-            this.nUDSX.Maximum = new decimal(new int[] {
+      resources.ApplyResources(this.nUDSX, "nUDSX");
+      this.nUDSX.Maximum = new decimal(new int[] {
             1,
             0,
             0,
             0});
-            this.nUDSX.Name = "nUDSX";
-            this.nUDSX.Value = new decimal(new int[] {
+      this.nUDSX.Name = "nUDSX";
+      this.nUDSX.Value = new decimal(new int[] {
             25,
             0,
             0,
             131072});
-            this.nUDSX.ValueChanged += new System.EventHandler(this.nUDSX_ValueChanged);
-            // 
-            // lbL2TrackS
-            // 
-            this.lbL2TrackS.BackColor = System.Drawing.Color.Transparent;
-            this.lbL2TrackS.Controls.Add(this.pnlSATrack);
-            this.lbL2TrackS.Controls.Add(this.lbL2Track);
-            this.lbL2TrackS.Controls.Add(this.lbRSTip);
-            this.lbL2TrackS.Controls.Add(this.lbInputDelay);
-            this.lbL2TrackS.Controls.Add(this.lbR2Track);
-            this.lbL2TrackS.Controls.Add(this.lbLSTip);
-            this.lbL2TrackS.Controls.Add(this.lbSATip);
-            this.lbL2TrackS.Controls.Add(this.tBR2);
-            this.lbL2TrackS.Controls.Add(this.tBL2);
-            this.lbL2TrackS.Controls.Add(this.pnlSixaxis);
-            this.lbL2TrackS.Controls.Add(this.pnlLSTrack);
-            this.lbL2TrackS.Controls.Add(this.pnlRSTrack);
-            resources.ApplyResources(this.lbL2TrackS, "lbL2TrackS");
-            this.lbL2TrackS.Name = "lbL2TrackS";
-            // 
-            // pnlSATrack
-            // 
-            this.pnlSATrack.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.pnlSATrack.Controls.Add(this.btnSATrack);
-            this.pnlSATrack.Controls.Add(this.btnSATrackS);
-            resources.ApplyResources(this.pnlSATrack, "pnlSATrack");
-            this.pnlSATrack.Name = "pnlSATrack";
-            this.pnlSATrack.Paint += new System.Windows.Forms.PaintEventHandler(this.pnlSATrack_Paint);
-            // 
-            // btnSATrack
-            // 
-            this.btnSATrack.BackColor = System.Drawing.Color.Black;
-            resources.ApplyResources(this.btnSATrack, "btnSATrack");
-            this.btnSATrack.Name = "btnSATrack";
-            this.btnSATrack.UseVisualStyleBackColor = false;
-            // 
-            // btnSATrackS
-            // 
-            this.btnSATrackS.BackColor = System.Drawing.Color.DimGray;
-            resources.ApplyResources(this.btnSATrackS, "btnSATrackS");
-            this.btnSATrackS.ForeColor = System.Drawing.SystemColors.ControlDark;
-            this.btnSATrackS.Name = "btnSATrackS";
-            this.btnSATrackS.UseVisualStyleBackColor = false;
-            // 
-            // lbL2Track
-            // 
-            resources.ApplyResources(this.lbL2Track, "lbL2Track");
-            this.lbL2Track.Name = "lbL2Track";
-            // 
-            // lbRSTip
-            // 
-            resources.ApplyResources(this.lbRSTip, "lbRSTip");
-            this.lbRSTip.Name = "lbRSTip";
-            // 
-            // lbInputDelay
-            // 
-            resources.ApplyResources(this.lbInputDelay, "lbInputDelay");
-            this.lbInputDelay.Name = "lbInputDelay";
-            // 
-            // lbR2Track
-            // 
-            resources.ApplyResources(this.lbR2Track, "lbR2Track");
-            this.lbR2Track.Name = "lbR2Track";
-            // 
-            // lbLSTip
-            // 
-            resources.ApplyResources(this.lbLSTip, "lbLSTip");
-            this.lbLSTip.Name = "lbLSTip";
-            // 
-            // lbSATip
-            // 
-            resources.ApplyResources(this.lbSATip, "lbSATip");
-            this.lbSATip.Name = "lbSATip";
-            this.lbSATip.Click += new System.EventHandler(this.lbSATip_Click);
-            // 
-            // tBR2
-            // 
-            resources.ApplyResources(this.tBR2, "tBR2");
-            this.tBR2.BackColor = System.Drawing.SystemColors.ControlLightLight;
-            this.tBR2.Maximum = 255;
-            this.tBR2.Name = "tBR2";
-            this.tBR2.TickFrequency = 0;
-            this.tBR2.TickStyle = System.Windows.Forms.TickStyle.None;
-            // 
-            // tBL2
-            // 
-            resources.ApplyResources(this.tBL2, "tBL2");
-            this.tBL2.BackColor = System.Drawing.SystemColors.ControlLightLight;
-            this.tBL2.Maximum = 255;
-            this.tBL2.Name = "tBL2";
-            this.tBL2.TickFrequency = 127;
-            this.tBL2.TickStyle = System.Windows.Forms.TickStyle.None;
-            // 
-            // pnlSixaxis
-            // 
-            this.pnlSixaxis.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.pnlSixaxis.Controls.Add(this.tBsixaxisAccelX);
-            this.pnlSixaxis.Controls.Add(this.lb6Accel);
-            this.pnlSixaxis.Controls.Add(this.tBsixaxisGyroX);
-            this.pnlSixaxis.Controls.Add(this.lb6Gryo);
-            this.pnlSixaxis.Controls.Add(this.tBsixaxisGyroY);
-            this.pnlSixaxis.Controls.Add(this.tBsixaxisGyroZ);
-            this.pnlSixaxis.Controls.Add(this.tBsixaxisAccelY);
-            this.pnlSixaxis.Controls.Add(this.tBsixaxisAccelZ);
-            resources.ApplyResources(this.pnlSixaxis, "pnlSixaxis");
-            this.pnlSixaxis.Name = "pnlSixaxis";
-            this.pnlSixaxis.Click += new System.EventHandler(this.SixaxisPanel_Click);
-            // 
-            // tBsixaxisAccelX
-            // 
-            resources.ApplyResources(this.tBsixaxisAccelX, "tBsixaxisAccelX");
-            this.tBsixaxisAccelX.BackColor = System.Drawing.SystemColors.ControlLightLight;
-            this.tBsixaxisAccelX.Maximum = 100;
-            this.tBsixaxisAccelX.Minimum = -100;
-            this.tBsixaxisAccelX.Name = "tBsixaxisAccelX";
-            this.tBsixaxisAccelX.TickFrequency = 4750;
-            // 
-            // lb6Accel
-            // 
-            resources.ApplyResources(this.lb6Accel, "lb6Accel");
-            this.lb6Accel.Name = "lb6Accel";
-            // 
-            // tBsixaxisGyroX
-            // 
-            resources.ApplyResources(this.tBsixaxisGyroX, "tBsixaxisGyroX");
-            this.tBsixaxisGyroX.BackColor = System.Drawing.SystemColors.ControlLightLight;
-            this.tBsixaxisGyroX.Maximum = 127;
-            this.tBsixaxisGyroX.Minimum = -127;
-            this.tBsixaxisGyroX.Name = "tBsixaxisGyroX";
-            this.tBsixaxisGyroX.TickFrequency = 4750;
-            // 
-            // lb6Gryo
-            // 
-            resources.ApplyResources(this.lb6Gryo, "lb6Gryo");
-            this.lb6Gryo.Name = "lb6Gryo";
-            // 
-            // tBsixaxisGyroY
-            // 
-            resources.ApplyResources(this.tBsixaxisGyroY, "tBsixaxisGyroY");
-            this.tBsixaxisGyroY.BackColor = System.Drawing.SystemColors.ControlLightLight;
-            this.tBsixaxisGyroY.Maximum = 127;
-            this.tBsixaxisGyroY.Minimum = -127;
-            this.tBsixaxisGyroY.Name = "tBsixaxisGyroY";
-            this.tBsixaxisGyroY.TickFrequency = 4750;
-            // 
-            // tBsixaxisGyroZ
-            // 
-            resources.ApplyResources(this.tBsixaxisGyroZ, "tBsixaxisGyroZ");
-            this.tBsixaxisGyroZ.BackColor = System.Drawing.SystemColors.ControlLightLight;
-            this.tBsixaxisGyroZ.Maximum = 127;
-            this.tBsixaxisGyroZ.Minimum = -127;
-            this.tBsixaxisGyroZ.Name = "tBsixaxisGyroZ";
-            this.tBsixaxisGyroZ.TickFrequency = 4750;
-            // 
-            // tBsixaxisAccelY
-            // 
-            resources.ApplyResources(this.tBsixaxisAccelY, "tBsixaxisAccelY");
-            this.tBsixaxisAccelY.BackColor = System.Drawing.SystemColors.ControlLightLight;
-            this.tBsixaxisAccelY.Maximum = 100;
-            this.tBsixaxisAccelY.Minimum = -100;
-            this.tBsixaxisAccelY.Name = "tBsixaxisAccelY";
-            this.tBsixaxisAccelY.TickFrequency = 4750;
-            // 
-            // tBsixaxisAccelZ
-            // 
-            resources.ApplyResources(this.tBsixaxisAccelZ, "tBsixaxisAccelZ");
-            this.tBsixaxisAccelZ.BackColor = System.Drawing.SystemColors.ControlLightLight;
-            this.tBsixaxisAccelZ.Maximum = 100;
-            this.tBsixaxisAccelZ.Minimum = -100;
-            this.tBsixaxisAccelZ.Name = "tBsixaxisAccelZ";
-            this.tBsixaxisAccelZ.TickFrequency = 4750;
-            // 
-            // pnlLSTrack
-            // 
-            this.pnlLSTrack.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.pnlLSTrack.Controls.Add(this.btnLSTrack);
-            this.pnlLSTrack.Controls.Add(this.btnLSTrackS);
-            resources.ApplyResources(this.pnlLSTrack, "pnlLSTrack");
-            this.pnlLSTrack.Name = "pnlLSTrack";
-            this.pnlLSTrack.Paint += new System.Windows.Forms.PaintEventHandler(this.pnlLSTrack_Paint);
-            // 
-            // btnLSTrack
-            // 
-            this.btnLSTrack.BackColor = System.Drawing.Color.Black;
-            resources.ApplyResources(this.btnLSTrack, "btnLSTrack");
-            this.btnLSTrack.Name = "btnLSTrack";
-            this.btnLSTrack.UseVisualStyleBackColor = false;
-            // 
-            // btnLSTrackS
-            // 
-            this.btnLSTrackS.BackColor = System.Drawing.Color.DimGray;
-            resources.ApplyResources(this.btnLSTrackS, "btnLSTrackS");
-            this.btnLSTrackS.ForeColor = System.Drawing.SystemColors.ControlDark;
-            this.btnLSTrackS.Name = "btnLSTrackS";
-            this.btnLSTrackS.UseVisualStyleBackColor = false;
-            // 
-            // pnlRSTrack
-            // 
-            this.pnlRSTrack.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.pnlRSTrack.Controls.Add(this.btnRSTrackS);
-            this.pnlRSTrack.Controls.Add(this.btnRSTrack);
-            resources.ApplyResources(this.pnlRSTrack, "pnlRSTrack");
-            this.pnlRSTrack.Name = "pnlRSTrack";
-            this.pnlRSTrack.Paint += new System.Windows.Forms.PaintEventHandler(this.pnlRSTrack_Paint);
-            // 
-            // btnRSTrackS
-            // 
-            this.btnRSTrackS.BackColor = System.Drawing.Color.DimGray;
-            resources.ApplyResources(this.btnRSTrackS, "btnRSTrackS");
-            this.btnRSTrackS.ForeColor = System.Drawing.SystemColors.ControlDark;
-            this.btnRSTrackS.Name = "btnRSTrackS";
-            this.btnRSTrackS.UseVisualStyleBackColor = false;
-            // 
-            // btnRSTrack
-            // 
-            this.btnRSTrack.BackColor = System.Drawing.Color.Black;
-            resources.ApplyResources(this.btnRSTrack, "btnRSTrack");
-            this.btnRSTrack.Name = "btnRSTrack";
-            this.btnRSTrack.UseVisualStyleBackColor = false;
-            // 
-            // fLPTiltControls
-            // 
-            this.fLPTiltControls.Controls.Add(this.bnGyroZN);
-            this.fLPTiltControls.Controls.Add(this.lbGyroZN);
-            this.fLPTiltControls.Controls.Add(this.bnGyroZP);
-            this.fLPTiltControls.Controls.Add(this.lbGyroZP);
-            this.fLPTiltControls.Controls.Add(this.bnGyroXP);
-            this.fLPTiltControls.Controls.Add(this.lbGyroXP);
-            this.fLPTiltControls.Controls.Add(this.bnGyroXN);
-            this.fLPTiltControls.Controls.Add(this.lbGyroXN);
-            this.fLPTiltControls.Controls.Add(this.lblSteeringWheelEmulationAxis);
-            this.fLPTiltControls.Controls.Add(this.cBSteeringWheelEmulationAxis);
-            this.fLPTiltControls.Controls.Add(this.lblSteeringWheelEmulationRange);
-            this.fLPTiltControls.Controls.Add(this.cBSteeringWheelEmulationRange);
-            this.fLPTiltControls.Controls.Add(this.btnSteeringWheelEmulationCalibrate);
-            resources.ApplyResources(this.fLPTiltControls, "fLPTiltControls");
-            this.fLPTiltControls.Name = "fLPTiltControls";
-            // 
-            // bnGyroZN
-            // 
-            this.bnGyroZN.ContextMenuStrip = this.cMSPresets;
-            resources.ApplyResources(this.bnGyroZN, "bnGyroZN");
-            this.bnGyroZN.Name = "bnGyroZN";
-            this.bnGyroZN.UseVisualStyleBackColor = true;
-            this.bnGyroZN.Click += new System.EventHandler(this.Show_ControlsBn);
-            // 
-            // lbGyroZN
-            // 
-            resources.ApplyResources(this.lbGyroZN, "lbGyroZN");
-            this.lbGyroZN.Name = "lbGyroZN";
-            // 
-            // bnGyroZP
-            // 
-            this.bnGyroZP.ContextMenuStrip = this.cMSPresets;
-            resources.ApplyResources(this.bnGyroZP, "bnGyroZP");
-            this.bnGyroZP.Name = "bnGyroZP";
-            this.bnGyroZP.UseVisualStyleBackColor = true;
-            this.bnGyroZP.Click += new System.EventHandler(this.Show_ControlsBn);
-            // 
-            // lbGyroZP
-            // 
-            resources.ApplyResources(this.lbGyroZP, "lbGyroZP");
-            this.lbGyroZP.Name = "lbGyroZP";
-            // 
-            // bnGyroXP
-            // 
-            this.bnGyroXP.ContextMenuStrip = this.cMSPresets;
-            resources.ApplyResources(this.bnGyroXP, "bnGyroXP");
-            this.bnGyroXP.Name = "bnGyroXP";
-            this.bnGyroXP.UseVisualStyleBackColor = true;
-            this.bnGyroXP.Click += new System.EventHandler(this.Show_ControlsBn);
-            // 
-            // lbGyroXP
-            // 
-            resources.ApplyResources(this.lbGyroXP, "lbGyroXP");
-            this.lbGyroXP.Name = "lbGyroXP";
-            // 
-            // bnGyroXN
-            // 
-            this.bnGyroXN.ContextMenuStrip = this.cMSPresets;
-            resources.ApplyResources(this.bnGyroXN, "bnGyroXN");
-            this.bnGyroXN.Name = "bnGyroXN";
-            this.bnGyroXN.UseVisualStyleBackColor = true;
-            this.bnGyroXN.Click += new System.EventHandler(this.Show_ControlsBn);
-            // 
-            // lbGyroXN
-            // 
-            resources.ApplyResources(this.lbGyroXN, "lbGyroXN");
-            this.lbGyroXN.Name = "lbGyroXN";
-            // 
-            // lblSteeringWheelEmulationAxis
-            // 
-            resources.ApplyResources(this.lblSteeringWheelEmulationAxis, "lblSteeringWheelEmulationAxis");
-            this.lblSteeringWheelEmulationAxis.Name = "lblSteeringWheelEmulationAxis";
-            // 
-            // cBSteeringWheelEmulationAxis
-            // 
-            this.cBSteeringWheelEmulationAxis.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cBSteeringWheelEmulationAxis.FormattingEnabled = true;
-            this.cBSteeringWheelEmulationAxis.Items.AddRange(new object[] {
+      this.nUDSX.ValueChanged += new System.EventHandler(this.nUDSX_ValueChanged);
+      // 
+      // lbL2TrackS
+      // 
+      this.lbL2TrackS.BackColor = System.Drawing.Color.Transparent;
+      this.lbL2TrackS.Controls.Add(this.pnlSATrack);
+      this.lbL2TrackS.Controls.Add(this.lbL2Track);
+      this.lbL2TrackS.Controls.Add(this.lbRSTip);
+      this.lbL2TrackS.Controls.Add(this.lbInputDelay);
+      this.lbL2TrackS.Controls.Add(this.lbR2Track);
+      this.lbL2TrackS.Controls.Add(this.lbLSTip);
+      this.lbL2TrackS.Controls.Add(this.lbSATip);
+      this.lbL2TrackS.Controls.Add(this.tBR2);
+      this.lbL2TrackS.Controls.Add(this.tBL2);
+      this.lbL2TrackS.Controls.Add(this.pnlSixaxis);
+      this.lbL2TrackS.Controls.Add(this.pnlLSTrack);
+      this.lbL2TrackS.Controls.Add(this.pnlRSTrack);
+      resources.ApplyResources(this.lbL2TrackS, "lbL2TrackS");
+      this.lbL2TrackS.Name = "lbL2TrackS";
+      // 
+      // pnlSATrack
+      // 
+      this.pnlSATrack.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+      this.pnlSATrack.Controls.Add(this.btnSATrack);
+      this.pnlSATrack.Controls.Add(this.btnSATrackS);
+      resources.ApplyResources(this.pnlSATrack, "pnlSATrack");
+      this.pnlSATrack.Name = "pnlSATrack";
+      this.pnlSATrack.Paint += new System.Windows.Forms.PaintEventHandler(this.pnlSATrack_Paint);
+      // 
+      // btnSATrack
+      // 
+      this.btnSATrack.BackColor = System.Drawing.Color.Black;
+      resources.ApplyResources(this.btnSATrack, "btnSATrack");
+      this.btnSATrack.Name = "btnSATrack";
+      this.btnSATrack.UseVisualStyleBackColor = false;
+      // 
+      // btnSATrackS
+      // 
+      this.btnSATrackS.BackColor = System.Drawing.Color.DimGray;
+      resources.ApplyResources(this.btnSATrackS, "btnSATrackS");
+      this.btnSATrackS.ForeColor = System.Drawing.SystemColors.ControlDark;
+      this.btnSATrackS.Name = "btnSATrackS";
+      this.btnSATrackS.UseVisualStyleBackColor = false;
+      // 
+      // lbL2Track
+      // 
+      resources.ApplyResources(this.lbL2Track, "lbL2Track");
+      this.lbL2Track.Name = "lbL2Track";
+      // 
+      // lbRSTip
+      // 
+      resources.ApplyResources(this.lbRSTip, "lbRSTip");
+      this.lbRSTip.Name = "lbRSTip";
+      // 
+      // lbInputDelay
+      // 
+      resources.ApplyResources(this.lbInputDelay, "lbInputDelay");
+      this.lbInputDelay.Name = "lbInputDelay";
+      // 
+      // lbR2Track
+      // 
+      resources.ApplyResources(this.lbR2Track, "lbR2Track");
+      this.lbR2Track.Name = "lbR2Track";
+      // 
+      // lbLSTip
+      // 
+      resources.ApplyResources(this.lbLSTip, "lbLSTip");
+      this.lbLSTip.Name = "lbLSTip";
+      // 
+      // lbSATip
+      // 
+      resources.ApplyResources(this.lbSATip, "lbSATip");
+      this.lbSATip.Name = "lbSATip";
+      this.lbSATip.Click += new System.EventHandler(this.lbSATip_Click);
+      // 
+      // tBR2
+      // 
+      resources.ApplyResources(this.tBR2, "tBR2");
+      this.tBR2.BackColor = System.Drawing.SystemColors.ControlLightLight;
+      this.tBR2.Maximum = 255;
+      this.tBR2.Name = "tBR2";
+      this.tBR2.TickFrequency = 0;
+      this.tBR2.TickStyle = System.Windows.Forms.TickStyle.None;
+      // 
+      // tBL2
+      // 
+      resources.ApplyResources(this.tBL2, "tBL2");
+      this.tBL2.BackColor = System.Drawing.SystemColors.ControlLightLight;
+      this.tBL2.Maximum = 255;
+      this.tBL2.Name = "tBL2";
+      this.tBL2.TickFrequency = 127;
+      this.tBL2.TickStyle = System.Windows.Forms.TickStyle.None;
+      // 
+      // pnlSixaxis
+      // 
+      this.pnlSixaxis.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+      this.pnlSixaxis.Controls.Add(this.tBsixaxisAccelX);
+      this.pnlSixaxis.Controls.Add(this.lb6Accel);
+      this.pnlSixaxis.Controls.Add(this.tBsixaxisGyroX);
+      this.pnlSixaxis.Controls.Add(this.lb6Gryo);
+      this.pnlSixaxis.Controls.Add(this.tBsixaxisGyroY);
+      this.pnlSixaxis.Controls.Add(this.tBsixaxisGyroZ);
+      this.pnlSixaxis.Controls.Add(this.tBsixaxisAccelY);
+      this.pnlSixaxis.Controls.Add(this.tBsixaxisAccelZ);
+      resources.ApplyResources(this.pnlSixaxis, "pnlSixaxis");
+      this.pnlSixaxis.Name = "pnlSixaxis";
+      this.pnlSixaxis.Click += new System.EventHandler(this.SixaxisPanel_Click);
+      // 
+      // tBsixaxisAccelX
+      // 
+      resources.ApplyResources(this.tBsixaxisAccelX, "tBsixaxisAccelX");
+      this.tBsixaxisAccelX.BackColor = System.Drawing.SystemColors.ControlLightLight;
+      this.tBsixaxisAccelX.Maximum = 100;
+      this.tBsixaxisAccelX.Minimum = -100;
+      this.tBsixaxisAccelX.Name = "tBsixaxisAccelX";
+      this.tBsixaxisAccelX.TickFrequency = 4750;
+      // 
+      // lb6Accel
+      // 
+      resources.ApplyResources(this.lb6Accel, "lb6Accel");
+      this.lb6Accel.Name = "lb6Accel";
+      // 
+      // tBsixaxisGyroX
+      // 
+      resources.ApplyResources(this.tBsixaxisGyroX, "tBsixaxisGyroX");
+      this.tBsixaxisGyroX.BackColor = System.Drawing.SystemColors.ControlLightLight;
+      this.tBsixaxisGyroX.Maximum = 127;
+      this.tBsixaxisGyroX.Minimum = -127;
+      this.tBsixaxisGyroX.Name = "tBsixaxisGyroX";
+      this.tBsixaxisGyroX.TickFrequency = 4750;
+      // 
+      // lb6Gryo
+      // 
+      resources.ApplyResources(this.lb6Gryo, "lb6Gryo");
+      this.lb6Gryo.Name = "lb6Gryo";
+      // 
+      // tBsixaxisGyroY
+      // 
+      resources.ApplyResources(this.tBsixaxisGyroY, "tBsixaxisGyroY");
+      this.tBsixaxisGyroY.BackColor = System.Drawing.SystemColors.ControlLightLight;
+      this.tBsixaxisGyroY.Maximum = 127;
+      this.tBsixaxisGyroY.Minimum = -127;
+      this.tBsixaxisGyroY.Name = "tBsixaxisGyroY";
+      this.tBsixaxisGyroY.TickFrequency = 4750;
+      // 
+      // tBsixaxisGyroZ
+      // 
+      resources.ApplyResources(this.tBsixaxisGyroZ, "tBsixaxisGyroZ");
+      this.tBsixaxisGyroZ.BackColor = System.Drawing.SystemColors.ControlLightLight;
+      this.tBsixaxisGyroZ.Maximum = 127;
+      this.tBsixaxisGyroZ.Minimum = -127;
+      this.tBsixaxisGyroZ.Name = "tBsixaxisGyroZ";
+      this.tBsixaxisGyroZ.TickFrequency = 4750;
+      // 
+      // tBsixaxisAccelY
+      // 
+      resources.ApplyResources(this.tBsixaxisAccelY, "tBsixaxisAccelY");
+      this.tBsixaxisAccelY.BackColor = System.Drawing.SystemColors.ControlLightLight;
+      this.tBsixaxisAccelY.Maximum = 100;
+      this.tBsixaxisAccelY.Minimum = -100;
+      this.tBsixaxisAccelY.Name = "tBsixaxisAccelY";
+      this.tBsixaxisAccelY.TickFrequency = 4750;
+      // 
+      // tBsixaxisAccelZ
+      // 
+      resources.ApplyResources(this.tBsixaxisAccelZ, "tBsixaxisAccelZ");
+      this.tBsixaxisAccelZ.BackColor = System.Drawing.SystemColors.ControlLightLight;
+      this.tBsixaxisAccelZ.Maximum = 100;
+      this.tBsixaxisAccelZ.Minimum = -100;
+      this.tBsixaxisAccelZ.Name = "tBsixaxisAccelZ";
+      this.tBsixaxisAccelZ.TickFrequency = 4750;
+      // 
+      // pnlLSTrack
+      // 
+      this.pnlLSTrack.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+      this.pnlLSTrack.Controls.Add(this.btnLSTrack);
+      this.pnlLSTrack.Controls.Add(this.btnLSTrackS);
+      resources.ApplyResources(this.pnlLSTrack, "pnlLSTrack");
+      this.pnlLSTrack.Name = "pnlLSTrack";
+      this.pnlLSTrack.Paint += new System.Windows.Forms.PaintEventHandler(this.pnlLSTrack_Paint);
+      // 
+      // btnLSTrack
+      // 
+      this.btnLSTrack.BackColor = System.Drawing.Color.Black;
+      resources.ApplyResources(this.btnLSTrack, "btnLSTrack");
+      this.btnLSTrack.Name = "btnLSTrack";
+      this.btnLSTrack.UseVisualStyleBackColor = false;
+      // 
+      // btnLSTrackS
+      // 
+      this.btnLSTrackS.BackColor = System.Drawing.Color.DimGray;
+      resources.ApplyResources(this.btnLSTrackS, "btnLSTrackS");
+      this.btnLSTrackS.ForeColor = System.Drawing.SystemColors.ControlDark;
+      this.btnLSTrackS.Name = "btnLSTrackS";
+      this.btnLSTrackS.UseVisualStyleBackColor = false;
+      // 
+      // pnlRSTrack
+      // 
+      this.pnlRSTrack.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+      this.pnlRSTrack.Controls.Add(this.btnRSTrackS);
+      this.pnlRSTrack.Controls.Add(this.btnRSTrack);
+      resources.ApplyResources(this.pnlRSTrack, "pnlRSTrack");
+      this.pnlRSTrack.Name = "pnlRSTrack";
+      this.pnlRSTrack.Paint += new System.Windows.Forms.PaintEventHandler(this.pnlRSTrack_Paint);
+      // 
+      // btnRSTrackS
+      // 
+      this.btnRSTrackS.BackColor = System.Drawing.Color.DimGray;
+      resources.ApplyResources(this.btnRSTrackS, "btnRSTrackS");
+      this.btnRSTrackS.ForeColor = System.Drawing.SystemColors.ControlDark;
+      this.btnRSTrackS.Name = "btnRSTrackS";
+      this.btnRSTrackS.UseVisualStyleBackColor = false;
+      // 
+      // btnRSTrack
+      // 
+      this.btnRSTrack.BackColor = System.Drawing.Color.Black;
+      resources.ApplyResources(this.btnRSTrack, "btnRSTrack");
+      this.btnRSTrack.Name = "btnRSTrack";
+      this.btnRSTrack.UseVisualStyleBackColor = false;
+      // 
+      // fLPTiltControls
+      // 
+      this.fLPTiltControls.Controls.Add(this.bnGyroZN);
+      this.fLPTiltControls.Controls.Add(this.lbGyroZN);
+      this.fLPTiltControls.Controls.Add(this.bnGyroZP);
+      this.fLPTiltControls.Controls.Add(this.lbGyroZP);
+      this.fLPTiltControls.Controls.Add(this.bnGyroXP);
+      this.fLPTiltControls.Controls.Add(this.lbGyroXP);
+      this.fLPTiltControls.Controls.Add(this.bnGyroXN);
+      this.fLPTiltControls.Controls.Add(this.lbGyroXN);
+      this.fLPTiltControls.Controls.Add(this.lblSteeringWheelEmulationAxis);
+      this.fLPTiltControls.Controls.Add(this.cBSteeringWheelEmulationAxis);
+      this.fLPTiltControls.Controls.Add(this.lblSteeringWheelEmulationRange);
+      this.fLPTiltControls.Controls.Add(this.cBSteeringWheelEmulationRange);
+      this.fLPTiltControls.Controls.Add(this.btnSteeringWheelEmulationCalibrate);
+      resources.ApplyResources(this.fLPTiltControls, "fLPTiltControls");
+      this.fLPTiltControls.Name = "fLPTiltControls";
+      // 
+      // bnGyroZN
+      // 
+      this.bnGyroZN.ContextMenuStrip = this.cMSPresets;
+      resources.ApplyResources(this.bnGyroZN, "bnGyroZN");
+      this.bnGyroZN.Name = "bnGyroZN";
+      this.bnGyroZN.UseVisualStyleBackColor = true;
+      this.bnGyroZN.Click += new System.EventHandler(this.Show_ControlsBn);
+      // 
+      // lbGyroZN
+      // 
+      resources.ApplyResources(this.lbGyroZN, "lbGyroZN");
+      this.lbGyroZN.Name = "lbGyroZN";
+      // 
+      // bnGyroZP
+      // 
+      this.bnGyroZP.ContextMenuStrip = this.cMSPresets;
+      resources.ApplyResources(this.bnGyroZP, "bnGyroZP");
+      this.bnGyroZP.Name = "bnGyroZP";
+      this.bnGyroZP.UseVisualStyleBackColor = true;
+      this.bnGyroZP.Click += new System.EventHandler(this.Show_ControlsBn);
+      // 
+      // lbGyroZP
+      // 
+      resources.ApplyResources(this.lbGyroZP, "lbGyroZP");
+      this.lbGyroZP.Name = "lbGyroZP";
+      // 
+      // bnGyroXP
+      // 
+      this.bnGyroXP.ContextMenuStrip = this.cMSPresets;
+      resources.ApplyResources(this.bnGyroXP, "bnGyroXP");
+      this.bnGyroXP.Name = "bnGyroXP";
+      this.bnGyroXP.UseVisualStyleBackColor = true;
+      this.bnGyroXP.Click += new System.EventHandler(this.Show_ControlsBn);
+      // 
+      // lbGyroXP
+      // 
+      resources.ApplyResources(this.lbGyroXP, "lbGyroXP");
+      this.lbGyroXP.Name = "lbGyroXP";
+      // 
+      // bnGyroXN
+      // 
+      this.bnGyroXN.ContextMenuStrip = this.cMSPresets;
+      resources.ApplyResources(this.bnGyroXN, "bnGyroXN");
+      this.bnGyroXN.Name = "bnGyroXN";
+      this.bnGyroXN.UseVisualStyleBackColor = true;
+      this.bnGyroXN.Click += new System.EventHandler(this.Show_ControlsBn);
+      // 
+      // lbGyroXN
+      // 
+      resources.ApplyResources(this.lbGyroXN, "lbGyroXN");
+      this.lbGyroXN.Name = "lbGyroXN";
+      // 
+      // lblSteeringWheelEmulationAxis
+      // 
+      resources.ApplyResources(this.lblSteeringWheelEmulationAxis, "lblSteeringWheelEmulationAxis");
+      this.lblSteeringWheelEmulationAxis.Name = "lblSteeringWheelEmulationAxis";
+      // 
+      // cBSteeringWheelEmulationAxis
+      // 
+      this.cBSteeringWheelEmulationAxis.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+      this.cBSteeringWheelEmulationAxis.FormattingEnabled = true;
+      this.cBSteeringWheelEmulationAxis.Items.AddRange(new object[] {
             resources.GetString("cBSteeringWheelEmulationAxis.Items"),
             resources.GetString("cBSteeringWheelEmulationAxis.Items1"),
             resources.GetString("cBSteeringWheelEmulationAxis.Items2"),
@@ -1969,20 +1972,20 @@
             resources.GetString("cBSteeringWheelEmulationAxis.Items9"),
             resources.GetString("cBSteeringWheelEmulationAxis.Items10"),
             resources.GetString("cBSteeringWheelEmulationAxis.Items11")});
-            resources.ApplyResources(this.cBSteeringWheelEmulationAxis, "cBSteeringWheelEmulationAxis");
-            this.cBSteeringWheelEmulationAxis.Name = "cBSteeringWheelEmulationAxis";
-            this.cBSteeringWheelEmulationAxis.SelectedIndexChanged += new System.EventHandler(this.cBSteeringWheelEmulationAxis_SelectedIndexChanged);
-            // 
-            // lblSteeringWheelEmulationRange
-            // 
-            resources.ApplyResources(this.lblSteeringWheelEmulationRange, "lblSteeringWheelEmulationRange");
-            this.lblSteeringWheelEmulationRange.Name = "lblSteeringWheelEmulationRange";
-            // 
-            // cBSteeringWheelEmulationRange
-            // 
-            this.cBSteeringWheelEmulationRange.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cBSteeringWheelEmulationRange.FormattingEnabled = true;
-            this.cBSteeringWheelEmulationRange.Items.AddRange(new object[] {
+      resources.ApplyResources(this.cBSteeringWheelEmulationAxis, "cBSteeringWheelEmulationAxis");
+      this.cBSteeringWheelEmulationAxis.Name = "cBSteeringWheelEmulationAxis";
+      this.cBSteeringWheelEmulationAxis.SelectedIndexChanged += new System.EventHandler(this.cBSteeringWheelEmulationAxis_SelectedIndexChanged);
+      // 
+      // lblSteeringWheelEmulationRange
+      // 
+      resources.ApplyResources(this.lblSteeringWheelEmulationRange, "lblSteeringWheelEmulationRange");
+      this.lblSteeringWheelEmulationRange.Name = "lblSteeringWheelEmulationRange";
+      // 
+      // cBSteeringWheelEmulationRange
+      // 
+      this.cBSteeringWheelEmulationRange.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+      this.cBSteeringWheelEmulationRange.FormattingEnabled = true;
+      this.cBSteeringWheelEmulationRange.Items.AddRange(new object[] {
             resources.GetString("cBSteeringWheelEmulationRange.Items"),
             resources.GetString("cBSteeringWheelEmulationRange.Items1"),
             resources.GetString("cBSteeringWheelEmulationRange.Items2"),
@@ -1992,42 +1995,42 @@
             resources.GetString("cBSteeringWheelEmulationRange.Items6"),
             resources.GetString("cBSteeringWheelEmulationRange.Items7"),
             resources.GetString("cBSteeringWheelEmulationRange.Items8")});
-            resources.ApplyResources(this.cBSteeringWheelEmulationRange, "cBSteeringWheelEmulationRange");
-            this.cBSteeringWheelEmulationRange.Name = "cBSteeringWheelEmulationRange";
-            this.cBSteeringWheelEmulationRange.SelectedIndexChanged += new System.EventHandler(this.cBSteeringWheelEmulationRange_SelectedIndexChanged);
-            // 
-            // btnSteeringWheelEmulationCalibrate
-            // 
-            resources.ApplyResources(this.btnSteeringWheelEmulationCalibrate, "btnSteeringWheelEmulationCalibrate");
-            this.btnSteeringWheelEmulationCalibrate.Name = "btnSteeringWheelEmulationCalibrate";
-            this.btnSteeringWheelEmulationCalibrate.UseVisualStyleBackColor = true;
-            this.btnSteeringWheelEmulationCalibrate.Click += new System.EventHandler(this.btnSteeringWheelEmulationCalibrate_Click);
-            // 
-            // tCControls
-            // 
-            this.tCControls.Controls.Add(this.tPControls);
-            this.tCControls.Controls.Add(this.tPSpecial);
-            this.tCControls.Controls.Add(this.lbL2TrackS);
-            resources.ApplyResources(this.tCControls, "tCControls");
-            this.tCControls.Name = "tCControls";
-            this.tCControls.SelectedIndex = 0;
-            this.tCControls.SelectedIndexChanged += new System.EventHandler(this.tabControls_SelectedIndexChanged);
-            // 
-            // tPControls
-            // 
-            resources.ApplyResources(this.tPControls, "tPControls");
-            this.tPControls.BackColor = System.Drawing.Color.DimGray;
-            this.tPControls.Controls.Add(this.lBControls);
-            this.tPControls.Controls.Add(this.gBTouchpad);
-            this.tPControls.Controls.Add(this.lbControlTip);
-            this.tPControls.Controls.Add(this.pnlController);
-            this.tPControls.Name = "tPControls";
-            // 
-            // lBControls
-            // 
-            resources.ApplyResources(this.lBControls, "lBControls");
-            this.lBControls.FormattingEnabled = true;
-            this.lBControls.Items.AddRange(new object[] {
+      resources.ApplyResources(this.cBSteeringWheelEmulationRange, "cBSteeringWheelEmulationRange");
+      this.cBSteeringWheelEmulationRange.Name = "cBSteeringWheelEmulationRange";
+      this.cBSteeringWheelEmulationRange.SelectedIndexChanged += new System.EventHandler(this.cBSteeringWheelEmulationRange_SelectedIndexChanged);
+      // 
+      // btnSteeringWheelEmulationCalibrate
+      // 
+      resources.ApplyResources(this.btnSteeringWheelEmulationCalibrate, "btnSteeringWheelEmulationCalibrate");
+      this.btnSteeringWheelEmulationCalibrate.Name = "btnSteeringWheelEmulationCalibrate";
+      this.btnSteeringWheelEmulationCalibrate.UseVisualStyleBackColor = true;
+      this.btnSteeringWheelEmulationCalibrate.Click += new System.EventHandler(this.btnSteeringWheelEmulationCalibrate_Click);
+      // 
+      // tCControls
+      // 
+      this.tCControls.Controls.Add(this.tPControls);
+      this.tCControls.Controls.Add(this.tPSpecial);
+      this.tCControls.Controls.Add(this.lbL2TrackS);
+      resources.ApplyResources(this.tCControls, "tCControls");
+      this.tCControls.Name = "tCControls";
+      this.tCControls.SelectedIndex = 0;
+      this.tCControls.SelectedIndexChanged += new System.EventHandler(this.tabControls_SelectedIndexChanged);
+      // 
+      // tPControls
+      // 
+      resources.ApplyResources(this.tPControls, "tPControls");
+      this.tPControls.BackColor = System.Drawing.Color.DimGray;
+      this.tPControls.Controls.Add(this.lBControls);
+      this.tPControls.Controls.Add(this.gBTouchpad);
+      this.tPControls.Controls.Add(this.lbControlTip);
+      this.tPControls.Controls.Add(this.pnlController);
+      this.tPControls.Name = "tPControls";
+      // 
+      // lBControls
+      // 
+      resources.ApplyResources(this.lBControls, "lBControls");
+      this.lBControls.FormattingEnabled = true;
+      this.lBControls.Items.AddRange(new object[] {
             resources.GetString("lBControls.Items"),
             resources.GetString("lBControls.Items1"),
             resources.GetString("lBControls.Items2"),
@@ -2061,1879 +2064,1903 @@
             resources.GetString("lBControls.Items30"),
             resources.GetString("lBControls.Items31"),
             resources.GetString("lBControls.Items32")});
-            this.lBControls.Name = "lBControls";
-            this.lBControls.SelectedIndexChanged += new System.EventHandler(this.lBControls_SelectedIndexChanged);
-            this.lBControls.DoubleClick += new System.EventHandler(this.Show_ControlsList);
-            this.lBControls.KeyDown += new System.Windows.Forms.KeyEventHandler(this.List_KeyDown);
-            // 
-            // lbControlTip
-            // 
-            this.lbControlTip.BackColor = System.Drawing.Color.Transparent;
-            this.lbControlTip.ForeColor = System.Drawing.SystemColors.ControlLightLight;
-            resources.ApplyResources(this.lbControlTip, "lbControlTip");
-            this.lbControlTip.Name = "lbControlTip";
-            // 
-            // pnlController
-            // 
-            this.pnlController.BackColor = System.Drawing.Color.DimGray;
-            this.pnlController.BackgroundImage = global::DS4Windows.Properties.Resources.DS4_Config;
-            resources.ApplyResources(this.pnlController, "pnlController");
-            this.pnlController.Controls.Add(this.pBHoveredButton);
-            this.pnlController.Controls.Add(this.lbLRS);
-            this.pnlController.Controls.Add(this.lbLLS);
-            this.pnlController.Controls.Add(this.bnRSDown);
-            this.pnlController.Controls.Add(this.lbLTouchUpper);
-            this.pnlController.Controls.Add(this.lbLTouchRight);
-            this.pnlController.Controls.Add(this.bnL3);
-            this.pnlController.Controls.Add(this.lbLTouchLM);
-            this.pnlController.Controls.Add(this.bnRSUp);
-            this.pnlController.Controls.Add(this.lbLR2);
-            this.pnlController.Controls.Add(this.bnRSRight);
-            this.pnlController.Controls.Add(this.lbLL2);
-            this.pnlController.Controls.Add(this.bnR3);
-            this.pnlController.Controls.Add(this.lbLR1);
-            this.pnlController.Controls.Add(this.bnRSLeft);
-            this.pnlController.Controls.Add(this.lbLL1);
-            this.pnlController.Controls.Add(this.bnLSLeft);
-            this.pnlController.Controls.Add(this.lbLPS);
-            this.pnlController.Controls.Add(this.bnLSUp);
-            this.pnlController.Controls.Add(this.lbLLeft);
-            this.pnlController.Controls.Add(this.bnLSRight);
-            this.pnlController.Controls.Add(this.lbLright);
-            this.pnlController.Controls.Add(this.bnLSDown);
-            this.pnlController.Controls.Add(this.lbLDown);
-            this.pnlController.Controls.Add(this.bnR2);
-            this.pnlController.Controls.Add(this.bnUp);
-            this.pnlController.Controls.Add(this.bnDown);
-            this.pnlController.Controls.Add(this.bnTriangle);
-            this.pnlController.Controls.Add(this.bnR1);
-            this.pnlController.Controls.Add(this.bnSquare);
-            this.pnlController.Controls.Add(this.bnRight);
-            this.pnlController.Controls.Add(this.lbLUp);
-            this.pnlController.Controls.Add(this.bnLeft);
-            this.pnlController.Controls.Add(this.lbLShare);
-            this.pnlController.Controls.Add(this.bnOptions);
-            this.pnlController.Controls.Add(this.bnShare);
-            this.pnlController.Controls.Add(this.lbLOptions);
-            this.pnlController.Controls.Add(this.bnL1);
-            this.pnlController.Controls.Add(this.bnTouchRight);
-            this.pnlController.Controls.Add(this.bnL2);
-            this.pnlController.Controls.Add(this.lbLTriangle);
-            this.pnlController.Controls.Add(this.bnTouchLeft);
-            this.pnlController.Controls.Add(this.lbLSquare);
-            this.pnlController.Controls.Add(this.bnTouchMulti);
-            this.pnlController.Controls.Add(this.lbLCircle);
-            this.pnlController.Controls.Add(this.lbLCross);
-            this.pnlController.Controls.Add(this.bnTouchUpper);
-            this.pnlController.Controls.Add(this.btnLightbar);
-            this.pnlController.Controls.Add(this.bnPS);
-            this.pnlController.Controls.Add(this.bnCross);
-            this.pnlController.Controls.Add(this.bnCircle);
-            this.pnlController.Controls.Add(this.lbControlName);
-            this.pnlController.Name = "pnlController";
-            this.pnlController.Paint += new System.Windows.Forms.PaintEventHandler(this.pnlController_Paint);
-            // 
-            // pBHoveredButton
-            // 
-            this.pBHoveredButton.BackColor = System.Drawing.Color.Transparent;
-            resources.ApplyResources(this.pBHoveredButton, "pBHoveredButton");
-            this.pBHoveredButton.Image = global::DS4Windows.Properties.Resources.DS4_Config_RS;
-            this.pBHoveredButton.Name = "pBHoveredButton";
-            this.pBHoveredButton.TabStop = false;
-            // 
-            // lbLRS
-            // 
-            this.lbLRS.BackColor = System.Drawing.SystemColors.ControlLightLight;
-            this.lbLRS.ForeColor = System.Drawing.SystemColors.ControlLightLight;
-            resources.ApplyResources(this.lbLRS, "lbLRS");
-            this.lbLRS.Name = "lbLRS";
-            // 
-            // lbLLS
-            // 
-            this.lbLLS.BackColor = System.Drawing.SystemColors.ControlLightLight;
-            this.lbLLS.ForeColor = System.Drawing.SystemColors.ControlLightLight;
-            resources.ApplyResources(this.lbLLS, "lbLLS");
-            this.lbLLS.Name = "lbLLS";
-            // 
-            // bnRSDown
-            // 
-            this.bnRSDown.BackColor = System.Drawing.Color.Transparent;
-            resources.ApplyResources(this.bnRSDown, "bnRSDown");
-            this.bnRSDown.ContextMenuStrip = this.cMSPresets;
-            this.bnRSDown.Cursor = System.Windows.Forms.Cursors.Default;
-            this.bnRSDown.FlatAppearance.BorderColor = System.Drawing.Color.White;
-            this.bnRSDown.FlatAppearance.BorderSize = 0;
-            this.bnRSDown.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
-            this.bnRSDown.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
-            this.bnRSDown.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
-            this.bnRSDown.ForeColor = System.Drawing.SystemColors.WindowText;
-            this.bnRSDown.Name = "bnRSDown";
-            this.bnRSDown.UseVisualStyleBackColor = false;
-            this.bnRSDown.Click += new System.EventHandler(this.Show_ControlsBn);
-            // 
-            // lbLTouchUpper
-            // 
-            this.lbLTouchUpper.BackColor = System.Drawing.SystemColors.ControlLightLight;
-            this.lbLTouchUpper.ForeColor = System.Drawing.SystemColors.ControlLightLight;
-            resources.ApplyResources(this.lbLTouchUpper, "lbLTouchUpper");
-            this.lbLTouchUpper.Name = "lbLTouchUpper";
-            // 
-            // lbLTouchRight
-            // 
-            this.lbLTouchRight.BackColor = System.Drawing.SystemColors.ControlLightLight;
-            this.lbLTouchRight.ForeColor = System.Drawing.SystemColors.ControlLightLight;
-            resources.ApplyResources(this.lbLTouchRight, "lbLTouchRight");
-            this.lbLTouchRight.Name = "lbLTouchRight";
-            // 
-            // bnL3
-            // 
-            this.bnL3.BackColor = System.Drawing.Color.Transparent;
-            resources.ApplyResources(this.bnL3, "bnL3");
-            this.bnL3.ContextMenuStrip = this.cMSPresets;
-            this.bnL3.Cursor = System.Windows.Forms.Cursors.Default;
-            this.bnL3.FlatAppearance.BorderColor = System.Drawing.Color.White;
-            this.bnL3.FlatAppearance.BorderSize = 0;
-            this.bnL3.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
-            this.bnL3.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
-            this.bnL3.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
-            this.bnL3.ForeColor = System.Drawing.SystemColors.WindowText;
-            this.bnL3.Name = "bnL3";
-            this.bnL3.UseVisualStyleBackColor = false;
-            this.bnL3.Click += new System.EventHandler(this.Show_ControlsBn);
-            // 
-            // lbLTouchLM
-            // 
-            this.lbLTouchLM.BackColor = System.Drawing.SystemColors.ControlLightLight;
-            this.lbLTouchLM.ForeColor = System.Drawing.SystemColors.ControlLightLight;
-            resources.ApplyResources(this.lbLTouchLM, "lbLTouchLM");
-            this.lbLTouchLM.Name = "lbLTouchLM";
-            // 
-            // bnRSUp
-            // 
-            this.bnRSUp.BackColor = System.Drawing.Color.Transparent;
-            resources.ApplyResources(this.bnRSUp, "bnRSUp");
-            this.bnRSUp.ContextMenuStrip = this.cMSPresets;
-            this.bnRSUp.Cursor = System.Windows.Forms.Cursors.Default;
-            this.bnRSUp.FlatAppearance.BorderColor = System.Drawing.Color.White;
-            this.bnRSUp.FlatAppearance.BorderSize = 0;
-            this.bnRSUp.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
-            this.bnRSUp.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
-            this.bnRSUp.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
-            this.bnRSUp.ForeColor = System.Drawing.SystemColors.WindowText;
-            this.bnRSUp.Name = "bnRSUp";
-            this.bnRSUp.UseVisualStyleBackColor = false;
-            this.bnRSUp.Click += new System.EventHandler(this.Show_ControlsBn);
-            // 
-            // lbLR2
-            // 
-            this.lbLR2.BackColor = System.Drawing.SystemColors.ControlLightLight;
-            this.lbLR2.ForeColor = System.Drawing.SystemColors.ControlLightLight;
-            resources.ApplyResources(this.lbLR2, "lbLR2");
-            this.lbLR2.Name = "lbLR2";
-            // 
-            // bnRSRight
-            // 
-            this.bnRSRight.BackColor = System.Drawing.Color.Transparent;
-            resources.ApplyResources(this.bnRSRight, "bnRSRight");
-            this.bnRSRight.ContextMenuStrip = this.cMSPresets;
-            this.bnRSRight.Cursor = System.Windows.Forms.Cursors.Default;
-            this.bnRSRight.FlatAppearance.BorderColor = System.Drawing.Color.White;
-            this.bnRSRight.FlatAppearance.BorderSize = 0;
-            this.bnRSRight.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
-            this.bnRSRight.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
-            this.bnRSRight.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
-            this.bnRSRight.ForeColor = System.Drawing.SystemColors.WindowText;
-            this.bnRSRight.Name = "bnRSRight";
-            this.bnRSRight.UseVisualStyleBackColor = false;
-            this.bnRSRight.Click += new System.EventHandler(this.Show_ControlsBn);
-            // 
-            // lbLL2
-            // 
-            this.lbLL2.BackColor = System.Drawing.SystemColors.ControlLightLight;
-            this.lbLL2.ForeColor = System.Drawing.SystemColors.ControlLightLight;
-            resources.ApplyResources(this.lbLL2, "lbLL2");
-            this.lbLL2.Name = "lbLL2";
-            // 
-            // bnR3
-            // 
-            this.bnR3.BackColor = System.Drawing.Color.Transparent;
-            resources.ApplyResources(this.bnR3, "bnR3");
-            this.bnR3.ContextMenuStrip = this.cMSPresets;
-            this.bnR3.Cursor = System.Windows.Forms.Cursors.Default;
-            this.bnR3.FlatAppearance.BorderColor = System.Drawing.Color.White;
-            this.bnR3.FlatAppearance.BorderSize = 0;
-            this.bnR3.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
-            this.bnR3.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
-            this.bnR3.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
-            this.bnR3.ForeColor = System.Drawing.SystemColors.WindowText;
-            this.bnR3.Name = "bnR3";
-            this.bnR3.UseVisualStyleBackColor = false;
-            this.bnR3.Click += new System.EventHandler(this.Show_ControlsBn);
-            // 
-            // lbLR1
-            // 
-            this.lbLR1.BackColor = System.Drawing.SystemColors.ControlLightLight;
-            this.lbLR1.ForeColor = System.Drawing.SystemColors.ControlLightLight;
-            resources.ApplyResources(this.lbLR1, "lbLR1");
-            this.lbLR1.Name = "lbLR1";
-            // 
-            // bnRSLeft
-            // 
-            this.bnRSLeft.BackColor = System.Drawing.Color.Transparent;
-            resources.ApplyResources(this.bnRSLeft, "bnRSLeft");
-            this.bnRSLeft.ContextMenuStrip = this.cMSPresets;
-            this.bnRSLeft.Cursor = System.Windows.Forms.Cursors.Default;
-            this.bnRSLeft.FlatAppearance.BorderColor = System.Drawing.Color.White;
-            this.bnRSLeft.FlatAppearance.BorderSize = 0;
-            this.bnRSLeft.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
-            this.bnRSLeft.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
-            this.bnRSLeft.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
-            this.bnRSLeft.ForeColor = System.Drawing.SystemColors.WindowText;
-            this.bnRSLeft.Name = "bnRSLeft";
-            this.bnRSLeft.UseVisualStyleBackColor = false;
-            this.bnRSLeft.Click += new System.EventHandler(this.Show_ControlsBn);
-            // 
-            // lbLL1
-            // 
-            this.lbLL1.BackColor = System.Drawing.SystemColors.ControlLightLight;
-            this.lbLL1.ForeColor = System.Drawing.SystemColors.ControlLightLight;
-            resources.ApplyResources(this.lbLL1, "lbLL1");
-            this.lbLL1.Name = "lbLL1";
-            // 
-            // bnLSLeft
-            // 
-            this.bnLSLeft.BackColor = System.Drawing.Color.Transparent;
-            resources.ApplyResources(this.bnLSLeft, "bnLSLeft");
-            this.bnLSLeft.ContextMenuStrip = this.cMSPresets;
-            this.bnLSLeft.Cursor = System.Windows.Forms.Cursors.Default;
-            this.bnLSLeft.FlatAppearance.BorderColor = System.Drawing.Color.White;
-            this.bnLSLeft.FlatAppearance.BorderSize = 0;
-            this.bnLSLeft.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
-            this.bnLSLeft.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
-            this.bnLSLeft.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
-            this.bnLSLeft.ForeColor = System.Drawing.SystemColors.WindowText;
-            this.bnLSLeft.Name = "bnLSLeft";
-            this.bnLSLeft.UseVisualStyleBackColor = false;
-            this.bnLSLeft.Click += new System.EventHandler(this.Show_ControlsBn);
-            // 
-            // lbLPS
-            // 
-            this.lbLPS.BackColor = System.Drawing.SystemColors.ControlLightLight;
-            this.lbLPS.ForeColor = System.Drawing.SystemColors.ControlLightLight;
-            resources.ApplyResources(this.lbLPS, "lbLPS");
-            this.lbLPS.Name = "lbLPS";
-            // 
-            // bnLSUp
-            // 
-            this.bnLSUp.BackColor = System.Drawing.Color.Transparent;
-            resources.ApplyResources(this.bnLSUp, "bnLSUp");
-            this.bnLSUp.ContextMenuStrip = this.cMSPresets;
-            this.bnLSUp.Cursor = System.Windows.Forms.Cursors.Default;
-            this.bnLSUp.FlatAppearance.BorderColor = System.Drawing.Color.White;
-            this.bnLSUp.FlatAppearance.BorderSize = 0;
-            this.bnLSUp.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
-            this.bnLSUp.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
-            this.bnLSUp.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
-            this.bnLSUp.ForeColor = System.Drawing.SystemColors.WindowText;
-            this.bnLSUp.Name = "bnLSUp";
-            this.bnLSUp.UseVisualStyleBackColor = false;
-            this.bnLSUp.Click += new System.EventHandler(this.Show_ControlsBn);
-            // 
-            // lbLLeft
-            // 
-            this.lbLLeft.BackColor = System.Drawing.SystemColors.ControlLightLight;
-            this.lbLLeft.ForeColor = System.Drawing.SystemColors.ControlLightLight;
-            resources.ApplyResources(this.lbLLeft, "lbLLeft");
-            this.lbLLeft.Name = "lbLLeft";
-            // 
-            // bnLSRight
-            // 
-            this.bnLSRight.BackColor = System.Drawing.Color.Transparent;
-            resources.ApplyResources(this.bnLSRight, "bnLSRight");
-            this.bnLSRight.ContextMenuStrip = this.cMSPresets;
-            this.bnLSRight.Cursor = System.Windows.Forms.Cursors.Default;
-            this.bnLSRight.FlatAppearance.BorderColor = System.Drawing.Color.White;
-            this.bnLSRight.FlatAppearance.BorderSize = 0;
-            this.bnLSRight.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
-            this.bnLSRight.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
-            this.bnLSRight.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
-            this.bnLSRight.ForeColor = System.Drawing.SystemColors.WindowText;
-            this.bnLSRight.Name = "bnLSRight";
-            this.bnLSRight.UseVisualStyleBackColor = false;
-            this.bnLSRight.Click += new System.EventHandler(this.Show_ControlsBn);
-            // 
-            // lbLright
-            // 
-            this.lbLright.BackColor = System.Drawing.SystemColors.ControlLightLight;
-            this.lbLright.ForeColor = System.Drawing.SystemColors.ControlLightLight;
-            resources.ApplyResources(this.lbLright, "lbLright");
-            this.lbLright.Name = "lbLright";
-            // 
-            // bnLSDown
-            // 
-            this.bnLSDown.BackColor = System.Drawing.Color.Transparent;
-            resources.ApplyResources(this.bnLSDown, "bnLSDown");
-            this.bnLSDown.ContextMenuStrip = this.cMSPresets;
-            this.bnLSDown.Cursor = System.Windows.Forms.Cursors.Default;
-            this.bnLSDown.FlatAppearance.BorderColor = System.Drawing.Color.White;
-            this.bnLSDown.FlatAppearance.BorderSize = 0;
-            this.bnLSDown.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
-            this.bnLSDown.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
-            this.bnLSDown.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
-            this.bnLSDown.ForeColor = System.Drawing.SystemColors.WindowText;
-            this.bnLSDown.Name = "bnLSDown";
-            this.bnLSDown.UseVisualStyleBackColor = false;
-            this.bnLSDown.Click += new System.EventHandler(this.Show_ControlsBn);
-            // 
-            // lbLDown
-            // 
-            this.lbLDown.BackColor = System.Drawing.SystemColors.ControlLightLight;
-            this.lbLDown.ForeColor = System.Drawing.SystemColors.ControlLightLight;
-            resources.ApplyResources(this.lbLDown, "lbLDown");
-            this.lbLDown.Name = "lbLDown";
-            // 
-            // bnR2
-            // 
-            this.bnR2.BackColor = System.Drawing.Color.Transparent;
-            resources.ApplyResources(this.bnR2, "bnR2");
-            this.bnR2.Cursor = System.Windows.Forms.Cursors.Default;
-            this.bnR2.FlatAppearance.BorderColor = System.Drawing.Color.White;
-            this.bnR2.FlatAppearance.BorderSize = 0;
-            this.bnR2.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
-            this.bnR2.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
-            this.bnR2.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
-            this.bnR2.ForeColor = System.Drawing.SystemColors.WindowText;
-            this.bnR2.Name = "bnR2";
-            this.bnR2.UseVisualStyleBackColor = false;
-            this.bnR2.Click += new System.EventHandler(this.Show_ControlsBn);
-            // 
-            // bnUp
-            // 
-            this.bnUp.BackColor = System.Drawing.Color.Transparent;
-            resources.ApplyResources(this.bnUp, "bnUp");
-            this.bnUp.ContextMenuStrip = this.cMSPresets;
-            this.bnUp.Cursor = System.Windows.Forms.Cursors.Default;
-            this.bnUp.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.bnUp.FlatAppearance.BorderColor = System.Drawing.Color.White;
-            this.bnUp.FlatAppearance.BorderSize = 0;
-            this.bnUp.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
-            this.bnUp.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
-            this.bnUp.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
-            this.bnUp.ForeColor = System.Drawing.SystemColors.WindowText;
-            this.bnUp.Name = "bnUp";
-            this.bnUp.UseVisualStyleBackColor = false;
-            this.bnUp.Click += new System.EventHandler(this.Show_ControlsBn);
-            // 
-            // bnDown
-            // 
-            this.bnDown.BackColor = System.Drawing.Color.Transparent;
-            resources.ApplyResources(this.bnDown, "bnDown");
-            this.bnDown.ContextMenuStrip = this.cMSPresets;
-            this.bnDown.Cursor = System.Windows.Forms.Cursors.Default;
-            this.bnDown.FlatAppearance.BorderColor = System.Drawing.Color.White;
-            this.bnDown.FlatAppearance.BorderSize = 0;
-            this.bnDown.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
-            this.bnDown.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
-            this.bnDown.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
-            this.bnDown.ForeColor = System.Drawing.SystemColors.WindowText;
-            this.bnDown.Name = "bnDown";
-            this.bnDown.UseVisualStyleBackColor = false;
-            this.bnDown.Click += new System.EventHandler(this.Show_ControlsBn);
-            // 
-            // bnTriangle
-            // 
-            this.bnTriangle.BackColor = System.Drawing.Color.Transparent;
-            resources.ApplyResources(this.bnTriangle, "bnTriangle");
-            this.bnTriangle.ContextMenuStrip = this.cMSPresets;
-            this.bnTriangle.Cursor = System.Windows.Forms.Cursors.Default;
-            this.bnTriangle.FlatAppearance.BorderColor = System.Drawing.Color.White;
-            this.bnTriangle.FlatAppearance.BorderSize = 0;
-            this.bnTriangle.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
-            this.bnTriangle.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
-            this.bnTriangle.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
-            this.bnTriangle.ForeColor = System.Drawing.SystemColors.WindowText;
-            this.bnTriangle.Name = "bnTriangle";
-            this.bnTriangle.UseVisualStyleBackColor = false;
-            this.bnTriangle.Click += new System.EventHandler(this.Show_ControlsBn);
-            // 
-            // bnR1
-            // 
-            this.bnR1.BackColor = System.Drawing.Color.Transparent;
-            resources.ApplyResources(this.bnR1, "bnR1");
-            this.bnR1.Cursor = System.Windows.Forms.Cursors.Default;
-            this.bnR1.FlatAppearance.BorderColor = System.Drawing.Color.White;
-            this.bnR1.FlatAppearance.BorderSize = 0;
-            this.bnR1.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
-            this.bnR1.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
-            this.bnR1.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
-            this.bnR1.ForeColor = System.Drawing.SystemColors.WindowText;
-            this.bnR1.Name = "bnR1";
-            this.bnR1.UseVisualStyleBackColor = false;
-            this.bnR1.Click += new System.EventHandler(this.Show_ControlsBn);
-            // 
-            // bnSquare
-            // 
-            this.bnSquare.BackColor = System.Drawing.Color.Transparent;
-            resources.ApplyResources(this.bnSquare, "bnSquare");
-            this.bnSquare.ContextMenuStrip = this.cMSPresets;
-            this.bnSquare.Cursor = System.Windows.Forms.Cursors.Default;
-            this.bnSquare.FlatAppearance.BorderColor = System.Drawing.Color.White;
-            this.bnSquare.FlatAppearance.BorderSize = 0;
-            this.bnSquare.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
-            this.bnSquare.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
-            this.bnSquare.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
-            this.bnSquare.ForeColor = System.Drawing.SystemColors.WindowText;
-            this.bnSquare.Name = "bnSquare";
-            this.bnSquare.UseVisualStyleBackColor = false;
-            this.bnSquare.Click += new System.EventHandler(this.Show_ControlsBn);
-            // 
-            // bnRight
-            // 
-            this.bnRight.BackColor = System.Drawing.Color.Transparent;
-            resources.ApplyResources(this.bnRight, "bnRight");
-            this.bnRight.ContextMenuStrip = this.cMSPresets;
-            this.bnRight.Cursor = System.Windows.Forms.Cursors.Default;
-            this.bnRight.FlatAppearance.BorderColor = System.Drawing.Color.White;
-            this.bnRight.FlatAppearance.BorderSize = 0;
-            this.bnRight.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
-            this.bnRight.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
-            this.bnRight.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
-            this.bnRight.ForeColor = System.Drawing.SystemColors.WindowText;
-            this.bnRight.Name = "bnRight";
-            this.bnRight.UseVisualStyleBackColor = false;
-            this.bnRight.Click += new System.EventHandler(this.Show_ControlsBn);
-            // 
-            // lbLUp
-            // 
-            this.lbLUp.BackColor = System.Drawing.SystemColors.ControlLightLight;
-            this.lbLUp.ForeColor = System.Drawing.SystemColors.ControlLightLight;
-            resources.ApplyResources(this.lbLUp, "lbLUp");
-            this.lbLUp.Name = "lbLUp";
-            // 
-            // bnLeft
-            // 
-            this.bnLeft.BackColor = System.Drawing.Color.Transparent;
-            resources.ApplyResources(this.bnLeft, "bnLeft");
-            this.bnLeft.ContextMenuStrip = this.cMSPresets;
-            this.bnLeft.Cursor = System.Windows.Forms.Cursors.Default;
-            this.bnLeft.FlatAppearance.BorderColor = System.Drawing.Color.White;
-            this.bnLeft.FlatAppearance.BorderSize = 0;
-            this.bnLeft.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
-            this.bnLeft.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
-            this.bnLeft.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
-            this.bnLeft.ForeColor = System.Drawing.SystemColors.WindowText;
-            this.bnLeft.Name = "bnLeft";
-            this.bnLeft.UseVisualStyleBackColor = false;
-            this.bnLeft.Click += new System.EventHandler(this.Show_ControlsBn);
-            // 
-            // lbLShare
-            // 
-            this.lbLShare.BackColor = System.Drawing.SystemColors.ControlLightLight;
-            this.lbLShare.ForeColor = System.Drawing.SystemColors.ControlLightLight;
-            resources.ApplyResources(this.lbLShare, "lbLShare");
-            this.lbLShare.Name = "lbLShare";
-            // 
-            // bnOptions
-            // 
-            this.bnOptions.BackColor = System.Drawing.Color.Transparent;
-            resources.ApplyResources(this.bnOptions, "bnOptions");
-            this.bnOptions.Cursor = System.Windows.Forms.Cursors.Default;
-            this.bnOptions.FlatAppearance.BorderColor = System.Drawing.Color.White;
-            this.bnOptions.FlatAppearance.BorderSize = 0;
-            this.bnOptions.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
-            this.bnOptions.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
-            this.bnOptions.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
-            this.bnOptions.ForeColor = System.Drawing.SystemColors.WindowText;
-            this.bnOptions.Name = "bnOptions";
-            this.bnOptions.UseVisualStyleBackColor = false;
-            this.bnOptions.Click += new System.EventHandler(this.Show_ControlsBn);
-            // 
-            // bnShare
-            // 
-            this.bnShare.BackColor = System.Drawing.Color.Transparent;
-            resources.ApplyResources(this.bnShare, "bnShare");
-            this.bnShare.Cursor = System.Windows.Forms.Cursors.Default;
-            this.bnShare.FlatAppearance.BorderColor = System.Drawing.Color.White;
-            this.bnShare.FlatAppearance.BorderSize = 0;
-            this.bnShare.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
-            this.bnShare.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
-            this.bnShare.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
-            this.bnShare.ForeColor = System.Drawing.SystemColors.WindowText;
-            this.bnShare.Name = "bnShare";
-            this.bnShare.UseVisualStyleBackColor = false;
-            this.bnShare.Click += new System.EventHandler(this.Show_ControlsBn);
-            // 
-            // lbLOptions
-            // 
-            this.lbLOptions.BackColor = System.Drawing.SystemColors.ControlLightLight;
-            this.lbLOptions.ForeColor = System.Drawing.SystemColors.ControlLightLight;
-            resources.ApplyResources(this.lbLOptions, "lbLOptions");
-            this.lbLOptions.Name = "lbLOptions";
-            // 
-            // bnL1
-            // 
-            this.bnL1.BackColor = System.Drawing.Color.Transparent;
-            resources.ApplyResources(this.bnL1, "bnL1");
-            this.bnL1.Cursor = System.Windows.Forms.Cursors.Default;
-            this.bnL1.FlatAppearance.BorderColor = System.Drawing.Color.White;
-            this.bnL1.FlatAppearance.BorderSize = 0;
-            this.bnL1.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
-            this.bnL1.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
-            this.bnL1.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
-            this.bnL1.ForeColor = System.Drawing.SystemColors.WindowText;
-            this.bnL1.Name = "bnL1";
-            this.bnL1.UseVisualStyleBackColor = false;
-            this.bnL1.Click += new System.EventHandler(this.Show_ControlsBn);
-            // 
-            // bnTouchRight
-            // 
-            this.bnTouchRight.BackColor = System.Drawing.Color.Transparent;
-            resources.ApplyResources(this.bnTouchRight, "bnTouchRight");
-            this.bnTouchRight.Cursor = System.Windows.Forms.Cursors.Default;
-            this.bnTouchRight.FlatAppearance.BorderColor = System.Drawing.Color.White;
-            this.bnTouchRight.FlatAppearance.BorderSize = 0;
-            this.bnTouchRight.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
-            this.bnTouchRight.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
-            this.bnTouchRight.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
-            this.bnTouchRight.ForeColor = System.Drawing.SystemColors.WindowText;
-            this.bnTouchRight.Name = "bnTouchRight";
-            this.bnTouchRight.UseVisualStyleBackColor = false;
-            this.bnTouchRight.Click += new System.EventHandler(this.Show_ControlsBn);
-            // 
-            // bnL2
-            // 
-            this.bnL2.BackColor = System.Drawing.Color.Transparent;
-            resources.ApplyResources(this.bnL2, "bnL2");
-            this.bnL2.Cursor = System.Windows.Forms.Cursors.Default;
-            this.bnL2.FlatAppearance.BorderColor = System.Drawing.Color.White;
-            this.bnL2.FlatAppearance.BorderSize = 0;
-            this.bnL2.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
-            this.bnL2.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
-            this.bnL2.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
-            this.bnL2.ForeColor = System.Drawing.SystemColors.WindowText;
-            this.bnL2.Name = "bnL2";
-            this.bnL2.UseVisualStyleBackColor = false;
-            this.bnL2.Click += new System.EventHandler(this.Show_ControlsBn);
-            // 
-            // lbLTriangle
-            // 
-            this.lbLTriangle.BackColor = System.Drawing.SystemColors.ControlLightLight;
-            this.lbLTriangle.ForeColor = System.Drawing.SystemColors.ControlLightLight;
-            resources.ApplyResources(this.lbLTriangle, "lbLTriangle");
-            this.lbLTriangle.Name = "lbLTriangle";
-            // 
-            // bnTouchLeft
-            // 
-            this.bnTouchLeft.BackColor = System.Drawing.Color.Transparent;
-            resources.ApplyResources(this.bnTouchLeft, "bnTouchLeft");
-            this.bnTouchLeft.Cursor = System.Windows.Forms.Cursors.Default;
-            this.bnTouchLeft.FlatAppearance.BorderColor = System.Drawing.Color.White;
-            this.bnTouchLeft.FlatAppearance.BorderSize = 0;
-            this.bnTouchLeft.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
-            this.bnTouchLeft.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
-            this.bnTouchLeft.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
-            this.bnTouchLeft.ForeColor = System.Drawing.SystemColors.WindowText;
-            this.bnTouchLeft.Name = "bnTouchLeft";
-            this.bnTouchLeft.UseVisualStyleBackColor = false;
-            this.bnTouchLeft.Click += new System.EventHandler(this.Show_ControlsBn);
-            // 
-            // lbLSquare
-            // 
-            this.lbLSquare.BackColor = System.Drawing.SystemColors.ControlLightLight;
-            this.lbLSquare.ForeColor = System.Drawing.SystemColors.ControlLightLight;
-            resources.ApplyResources(this.lbLSquare, "lbLSquare");
-            this.lbLSquare.Name = "lbLSquare";
-            // 
-            // bnTouchMulti
-            // 
-            this.bnTouchMulti.BackColor = System.Drawing.Color.Transparent;
-            resources.ApplyResources(this.bnTouchMulti, "bnTouchMulti");
-            this.bnTouchMulti.Cursor = System.Windows.Forms.Cursors.Default;
-            this.bnTouchMulti.FlatAppearance.BorderColor = System.Drawing.Color.White;
-            this.bnTouchMulti.FlatAppearance.BorderSize = 0;
-            this.bnTouchMulti.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
-            this.bnTouchMulti.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
-            this.bnTouchMulti.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
-            this.bnTouchMulti.ForeColor = System.Drawing.SystemColors.WindowText;
-            this.bnTouchMulti.Name = "bnTouchMulti";
-            this.bnTouchMulti.UseVisualStyleBackColor = false;
-            this.bnTouchMulti.Click += new System.EventHandler(this.Show_ControlsBn);
-            // 
-            // lbLCircle
-            // 
-            this.lbLCircle.BackColor = System.Drawing.SystemColors.ControlLightLight;
-            this.lbLCircle.ForeColor = System.Drawing.SystemColors.ControlLightLight;
-            resources.ApplyResources(this.lbLCircle, "lbLCircle");
-            this.lbLCircle.Name = "lbLCircle";
-            // 
-            // lbLCross
-            // 
-            this.lbLCross.BackColor = System.Drawing.SystemColors.ControlLightLight;
-            this.lbLCross.ForeColor = System.Drawing.SystemColors.ControlLightLight;
-            resources.ApplyResources(this.lbLCross, "lbLCross");
-            this.lbLCross.Name = "lbLCross";
-            // 
-            // bnTouchUpper
-            // 
-            this.bnTouchUpper.BackColor = System.Drawing.Color.Transparent;
-            resources.ApplyResources(this.bnTouchUpper, "bnTouchUpper");
-            this.bnTouchUpper.Cursor = System.Windows.Forms.Cursors.Default;
-            this.bnTouchUpper.FlatAppearance.BorderColor = System.Drawing.Color.White;
-            this.bnTouchUpper.FlatAppearance.BorderSize = 0;
-            this.bnTouchUpper.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
-            this.bnTouchUpper.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
-            this.bnTouchUpper.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
-            this.bnTouchUpper.ForeColor = System.Drawing.SystemColors.WindowText;
-            this.bnTouchUpper.Name = "bnTouchUpper";
-            this.bnTouchUpper.UseVisualStyleBackColor = false;
-            this.bnTouchUpper.Click += new System.EventHandler(this.Show_ControlsBn);
-            // 
-            // btnLightbar
-            // 
-            this.btnLightbar.BackColor = System.Drawing.Color.Transparent;
-            this.btnLightbar.BackgroundImage = global::DS4Windows.Properties.Resources.DS4_lightbar;
-            resources.ApplyResources(this.btnLightbar, "btnLightbar");
-            this.btnLightbar.Cursor = System.Windows.Forms.Cursors.Default;
-            this.btnLightbar.FlatAppearance.BorderColor = System.Drawing.Color.Red;
-            this.btnLightbar.FlatAppearance.BorderSize = 0;
-            this.btnLightbar.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
-            this.btnLightbar.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
-            this.btnLightbar.ForeColor = System.Drawing.SystemColors.WindowText;
-            this.btnLightbar.Name = "btnLightbar";
-            this.btnLightbar.UseVisualStyleBackColor = false;
-            this.btnLightbar.Click += new System.EventHandler(this.btnLightbar_Click);
-            this.btnLightbar.Paint += new System.Windows.Forms.PaintEventHandler(this.btnLightbar_Paint);
-            this.btnLightbar.MouseHover += new System.EventHandler(this.btnLightbar_MouseHover);
-            // 
-            // bnPS
-            // 
-            this.bnPS.BackColor = System.Drawing.Color.Transparent;
-            resources.ApplyResources(this.bnPS, "bnPS");
-            this.bnPS.Cursor = System.Windows.Forms.Cursors.Default;
-            this.bnPS.FlatAppearance.BorderColor = System.Drawing.Color.White;
-            this.bnPS.FlatAppearance.BorderSize = 0;
-            this.bnPS.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
-            this.bnPS.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
-            this.bnPS.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
-            this.bnPS.ForeColor = System.Drawing.SystemColors.WindowText;
-            this.bnPS.Name = "bnPS";
-            this.bnPS.UseVisualStyleBackColor = false;
-            this.bnPS.Click += new System.EventHandler(this.Show_ControlsBn);
-            // 
-            // bnCross
-            // 
-            this.bnCross.BackColor = System.Drawing.Color.Transparent;
-            resources.ApplyResources(this.bnCross, "bnCross");
-            this.bnCross.ContextMenuStrip = this.cMSPresets;
-            this.bnCross.Cursor = System.Windows.Forms.Cursors.Default;
-            this.bnCross.FlatAppearance.BorderColor = System.Drawing.Color.White;
-            this.bnCross.FlatAppearance.BorderSize = 0;
-            this.bnCross.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
-            this.bnCross.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
-            this.bnCross.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
-            this.bnCross.ForeColor = System.Drawing.SystemColors.WindowText;
-            this.bnCross.Name = "bnCross";
-            this.bnCross.UseVisualStyleBackColor = false;
-            this.bnCross.Click += new System.EventHandler(this.Show_ControlsBn);
-            // 
-            // bnCircle
-            // 
-            this.bnCircle.BackColor = System.Drawing.Color.Transparent;
-            resources.ApplyResources(this.bnCircle, "bnCircle");
-            this.bnCircle.ContextMenuStrip = this.cMSPresets;
-            this.bnCircle.Cursor = System.Windows.Forms.Cursors.Default;
-            this.bnCircle.FlatAppearance.BorderColor = System.Drawing.Color.White;
-            this.bnCircle.FlatAppearance.BorderSize = 0;
-            this.bnCircle.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
-            this.bnCircle.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
-            this.bnCircle.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
-            this.bnCircle.ForeColor = System.Drawing.SystemColors.WindowText;
-            this.bnCircle.Name = "bnCircle";
-            this.bnCircle.UseVisualStyleBackColor = false;
-            this.bnCircle.Click += new System.EventHandler(this.Show_ControlsBn);
-            // 
-            // lbControlName
-            // 
-            this.lbControlName.BackColor = System.Drawing.Color.Transparent;
-            this.lbControlName.ForeColor = System.Drawing.SystemColors.ControlLightLight;
-            resources.ApplyResources(this.lbControlName, "lbControlName");
-            this.lbControlName.Name = "lbControlName";
-            this.lbControlName.Click += new System.EventHandler(this.Show_ControlsList);
-            // 
-            // tPSpecial
-            // 
-            this.tPSpecial.Controls.Add(this.pnlActions);
-            resources.ApplyResources(this.tPSpecial, "tPSpecial");
-            this.tPSpecial.Name = "tPSpecial";
-            this.tPSpecial.UseVisualStyleBackColor = true;
-            // 
-            // pnlActions
-            // 
-            this.pnlActions.Controls.Add(this.lVActions);
-            this.pnlActions.Controls.Add(this.panel2);
-            resources.ApplyResources(this.pnlActions, "pnlActions");
-            this.pnlActions.Name = "pnlActions";
-            // 
-            // lVActions
-            // 
-            this.lVActions.CheckBoxes = true;
-            this.lVActions.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+      this.lBControls.Name = "lBControls";
+      this.lBControls.SelectedIndexChanged += new System.EventHandler(this.lBControls_SelectedIndexChanged);
+      this.lBControls.DoubleClick += new System.EventHandler(this.Show_ControlsList);
+      this.lBControls.KeyDown += new System.Windows.Forms.KeyEventHandler(this.List_KeyDown);
+      // 
+      // lbControlTip
+      // 
+      this.lbControlTip.BackColor = System.Drawing.Color.Transparent;
+      this.lbControlTip.ForeColor = System.Drawing.SystemColors.ControlLightLight;
+      resources.ApplyResources(this.lbControlTip, "lbControlTip");
+      this.lbControlTip.Name = "lbControlTip";
+      // 
+      // pnlController
+      // 
+      this.pnlController.BackColor = System.Drawing.Color.DimGray;
+      this.pnlController.BackgroundImage = global::DS4Windows.Properties.Resources.DS4_Config;
+      resources.ApplyResources(this.pnlController, "pnlController");
+      this.pnlController.Controls.Add(this.pBHoveredButton);
+      this.pnlController.Controls.Add(this.lbLRS);
+      this.pnlController.Controls.Add(this.lbLLS);
+      this.pnlController.Controls.Add(this.bnRSDown);
+      this.pnlController.Controls.Add(this.lbLTouchUpper);
+      this.pnlController.Controls.Add(this.lbLTouchRight);
+      this.pnlController.Controls.Add(this.bnL3);
+      this.pnlController.Controls.Add(this.lbLTouchLM);
+      this.pnlController.Controls.Add(this.bnRSUp);
+      this.pnlController.Controls.Add(this.lbLR2);
+      this.pnlController.Controls.Add(this.bnRSRight);
+      this.pnlController.Controls.Add(this.lbLL2);
+      this.pnlController.Controls.Add(this.bnR3);
+      this.pnlController.Controls.Add(this.lbLR1);
+      this.pnlController.Controls.Add(this.bnRSLeft);
+      this.pnlController.Controls.Add(this.lbLL1);
+      this.pnlController.Controls.Add(this.bnLSLeft);
+      this.pnlController.Controls.Add(this.lbLPS);
+      this.pnlController.Controls.Add(this.bnLSUp);
+      this.pnlController.Controls.Add(this.lbLLeft);
+      this.pnlController.Controls.Add(this.bnLSRight);
+      this.pnlController.Controls.Add(this.lbLright);
+      this.pnlController.Controls.Add(this.bnLSDown);
+      this.pnlController.Controls.Add(this.lbLDown);
+      this.pnlController.Controls.Add(this.bnR2);
+      this.pnlController.Controls.Add(this.bnUp);
+      this.pnlController.Controls.Add(this.bnDown);
+      this.pnlController.Controls.Add(this.bnTriangle);
+      this.pnlController.Controls.Add(this.bnR1);
+      this.pnlController.Controls.Add(this.bnSquare);
+      this.pnlController.Controls.Add(this.bnRight);
+      this.pnlController.Controls.Add(this.lbLUp);
+      this.pnlController.Controls.Add(this.bnLeft);
+      this.pnlController.Controls.Add(this.lbLShare);
+      this.pnlController.Controls.Add(this.bnOptions);
+      this.pnlController.Controls.Add(this.bnShare);
+      this.pnlController.Controls.Add(this.lbLOptions);
+      this.pnlController.Controls.Add(this.bnL1);
+      this.pnlController.Controls.Add(this.bnTouchRight);
+      this.pnlController.Controls.Add(this.bnL2);
+      this.pnlController.Controls.Add(this.lbLTriangle);
+      this.pnlController.Controls.Add(this.bnTouchLeft);
+      this.pnlController.Controls.Add(this.lbLSquare);
+      this.pnlController.Controls.Add(this.bnTouchMulti);
+      this.pnlController.Controls.Add(this.lbLCircle);
+      this.pnlController.Controls.Add(this.lbLCross);
+      this.pnlController.Controls.Add(this.bnTouchUpper);
+      this.pnlController.Controls.Add(this.btnLightbar);
+      this.pnlController.Controls.Add(this.bnPS);
+      this.pnlController.Controls.Add(this.bnCross);
+      this.pnlController.Controls.Add(this.bnCircle);
+      this.pnlController.Controls.Add(this.lbControlName);
+      this.pnlController.Name = "pnlController";
+      this.pnlController.Paint += new System.Windows.Forms.PaintEventHandler(this.pnlController_Paint);
+      // 
+      // pBHoveredButton
+      // 
+      this.pBHoveredButton.BackColor = System.Drawing.Color.Transparent;
+      resources.ApplyResources(this.pBHoveredButton, "pBHoveredButton");
+      this.pBHoveredButton.Image = global::DS4Windows.Properties.Resources.DS4_Config_RS;
+      this.pBHoveredButton.Name = "pBHoveredButton";
+      this.pBHoveredButton.TabStop = false;
+      // 
+      // lbLRS
+      // 
+      this.lbLRS.BackColor = System.Drawing.SystemColors.ControlLightLight;
+      this.lbLRS.ForeColor = System.Drawing.SystemColors.ControlLightLight;
+      resources.ApplyResources(this.lbLRS, "lbLRS");
+      this.lbLRS.Name = "lbLRS";
+      // 
+      // lbLLS
+      // 
+      this.lbLLS.BackColor = System.Drawing.SystemColors.ControlLightLight;
+      this.lbLLS.ForeColor = System.Drawing.SystemColors.ControlLightLight;
+      resources.ApplyResources(this.lbLLS, "lbLLS");
+      this.lbLLS.Name = "lbLLS";
+      // 
+      // bnRSDown
+      // 
+      this.bnRSDown.BackColor = System.Drawing.Color.Transparent;
+      resources.ApplyResources(this.bnRSDown, "bnRSDown");
+      this.bnRSDown.ContextMenuStrip = this.cMSPresets;
+      this.bnRSDown.Cursor = System.Windows.Forms.Cursors.Default;
+      this.bnRSDown.FlatAppearance.BorderColor = System.Drawing.Color.White;
+      this.bnRSDown.FlatAppearance.BorderSize = 0;
+      this.bnRSDown.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
+      this.bnRSDown.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
+      this.bnRSDown.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
+      this.bnRSDown.ForeColor = System.Drawing.SystemColors.WindowText;
+      this.bnRSDown.Name = "bnRSDown";
+      this.bnRSDown.UseVisualStyleBackColor = false;
+      this.bnRSDown.Click += new System.EventHandler(this.Show_ControlsBn);
+      // 
+      // lbLTouchUpper
+      // 
+      this.lbLTouchUpper.BackColor = System.Drawing.SystemColors.ControlLightLight;
+      this.lbLTouchUpper.ForeColor = System.Drawing.SystemColors.ControlLightLight;
+      resources.ApplyResources(this.lbLTouchUpper, "lbLTouchUpper");
+      this.lbLTouchUpper.Name = "lbLTouchUpper";
+      // 
+      // lbLTouchRight
+      // 
+      this.lbLTouchRight.BackColor = System.Drawing.SystemColors.ControlLightLight;
+      this.lbLTouchRight.ForeColor = System.Drawing.SystemColors.ControlLightLight;
+      resources.ApplyResources(this.lbLTouchRight, "lbLTouchRight");
+      this.lbLTouchRight.Name = "lbLTouchRight";
+      // 
+      // bnL3
+      // 
+      this.bnL3.BackColor = System.Drawing.Color.Transparent;
+      resources.ApplyResources(this.bnL3, "bnL3");
+      this.bnL3.ContextMenuStrip = this.cMSPresets;
+      this.bnL3.Cursor = System.Windows.Forms.Cursors.Default;
+      this.bnL3.FlatAppearance.BorderColor = System.Drawing.Color.White;
+      this.bnL3.FlatAppearance.BorderSize = 0;
+      this.bnL3.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
+      this.bnL3.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
+      this.bnL3.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
+      this.bnL3.ForeColor = System.Drawing.SystemColors.WindowText;
+      this.bnL3.Name = "bnL3";
+      this.bnL3.UseVisualStyleBackColor = false;
+      this.bnL3.Click += new System.EventHandler(this.Show_ControlsBn);
+      // 
+      // lbLTouchLM
+      // 
+      this.lbLTouchLM.BackColor = System.Drawing.SystemColors.ControlLightLight;
+      this.lbLTouchLM.ForeColor = System.Drawing.SystemColors.ControlLightLight;
+      resources.ApplyResources(this.lbLTouchLM, "lbLTouchLM");
+      this.lbLTouchLM.Name = "lbLTouchLM";
+      // 
+      // bnRSUp
+      // 
+      this.bnRSUp.BackColor = System.Drawing.Color.Transparent;
+      resources.ApplyResources(this.bnRSUp, "bnRSUp");
+      this.bnRSUp.ContextMenuStrip = this.cMSPresets;
+      this.bnRSUp.Cursor = System.Windows.Forms.Cursors.Default;
+      this.bnRSUp.FlatAppearance.BorderColor = System.Drawing.Color.White;
+      this.bnRSUp.FlatAppearance.BorderSize = 0;
+      this.bnRSUp.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
+      this.bnRSUp.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
+      this.bnRSUp.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
+      this.bnRSUp.ForeColor = System.Drawing.SystemColors.WindowText;
+      this.bnRSUp.Name = "bnRSUp";
+      this.bnRSUp.UseVisualStyleBackColor = false;
+      this.bnRSUp.Click += new System.EventHandler(this.Show_ControlsBn);
+      // 
+      // lbLR2
+      // 
+      this.lbLR2.BackColor = System.Drawing.SystemColors.ControlLightLight;
+      this.lbLR2.ForeColor = System.Drawing.SystemColors.ControlLightLight;
+      resources.ApplyResources(this.lbLR2, "lbLR2");
+      this.lbLR2.Name = "lbLR2";
+      // 
+      // bnRSRight
+      // 
+      this.bnRSRight.BackColor = System.Drawing.Color.Transparent;
+      resources.ApplyResources(this.bnRSRight, "bnRSRight");
+      this.bnRSRight.ContextMenuStrip = this.cMSPresets;
+      this.bnRSRight.Cursor = System.Windows.Forms.Cursors.Default;
+      this.bnRSRight.FlatAppearance.BorderColor = System.Drawing.Color.White;
+      this.bnRSRight.FlatAppearance.BorderSize = 0;
+      this.bnRSRight.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
+      this.bnRSRight.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
+      this.bnRSRight.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
+      this.bnRSRight.ForeColor = System.Drawing.SystemColors.WindowText;
+      this.bnRSRight.Name = "bnRSRight";
+      this.bnRSRight.UseVisualStyleBackColor = false;
+      this.bnRSRight.Click += new System.EventHandler(this.Show_ControlsBn);
+      // 
+      // lbLL2
+      // 
+      this.lbLL2.BackColor = System.Drawing.SystemColors.ControlLightLight;
+      this.lbLL2.ForeColor = System.Drawing.SystemColors.ControlLightLight;
+      resources.ApplyResources(this.lbLL2, "lbLL2");
+      this.lbLL2.Name = "lbLL2";
+      // 
+      // bnR3
+      // 
+      this.bnR3.BackColor = System.Drawing.Color.Transparent;
+      resources.ApplyResources(this.bnR3, "bnR3");
+      this.bnR3.ContextMenuStrip = this.cMSPresets;
+      this.bnR3.Cursor = System.Windows.Forms.Cursors.Default;
+      this.bnR3.FlatAppearance.BorderColor = System.Drawing.Color.White;
+      this.bnR3.FlatAppearance.BorderSize = 0;
+      this.bnR3.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
+      this.bnR3.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
+      this.bnR3.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
+      this.bnR3.ForeColor = System.Drawing.SystemColors.WindowText;
+      this.bnR3.Name = "bnR3";
+      this.bnR3.UseVisualStyleBackColor = false;
+      this.bnR3.Click += new System.EventHandler(this.Show_ControlsBn);
+      // 
+      // lbLR1
+      // 
+      this.lbLR1.BackColor = System.Drawing.SystemColors.ControlLightLight;
+      this.lbLR1.ForeColor = System.Drawing.SystemColors.ControlLightLight;
+      resources.ApplyResources(this.lbLR1, "lbLR1");
+      this.lbLR1.Name = "lbLR1";
+      // 
+      // bnRSLeft
+      // 
+      this.bnRSLeft.BackColor = System.Drawing.Color.Transparent;
+      resources.ApplyResources(this.bnRSLeft, "bnRSLeft");
+      this.bnRSLeft.ContextMenuStrip = this.cMSPresets;
+      this.bnRSLeft.Cursor = System.Windows.Forms.Cursors.Default;
+      this.bnRSLeft.FlatAppearance.BorderColor = System.Drawing.Color.White;
+      this.bnRSLeft.FlatAppearance.BorderSize = 0;
+      this.bnRSLeft.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
+      this.bnRSLeft.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
+      this.bnRSLeft.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
+      this.bnRSLeft.ForeColor = System.Drawing.SystemColors.WindowText;
+      this.bnRSLeft.Name = "bnRSLeft";
+      this.bnRSLeft.UseVisualStyleBackColor = false;
+      this.bnRSLeft.Click += new System.EventHandler(this.Show_ControlsBn);
+      // 
+      // lbLL1
+      // 
+      this.lbLL1.BackColor = System.Drawing.SystemColors.ControlLightLight;
+      this.lbLL1.ForeColor = System.Drawing.SystemColors.ControlLightLight;
+      resources.ApplyResources(this.lbLL1, "lbLL1");
+      this.lbLL1.Name = "lbLL1";
+      // 
+      // bnLSLeft
+      // 
+      this.bnLSLeft.BackColor = System.Drawing.Color.Transparent;
+      resources.ApplyResources(this.bnLSLeft, "bnLSLeft");
+      this.bnLSLeft.ContextMenuStrip = this.cMSPresets;
+      this.bnLSLeft.Cursor = System.Windows.Forms.Cursors.Default;
+      this.bnLSLeft.FlatAppearance.BorderColor = System.Drawing.Color.White;
+      this.bnLSLeft.FlatAppearance.BorderSize = 0;
+      this.bnLSLeft.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
+      this.bnLSLeft.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
+      this.bnLSLeft.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
+      this.bnLSLeft.ForeColor = System.Drawing.SystemColors.WindowText;
+      this.bnLSLeft.Name = "bnLSLeft";
+      this.bnLSLeft.UseVisualStyleBackColor = false;
+      this.bnLSLeft.Click += new System.EventHandler(this.Show_ControlsBn);
+      // 
+      // lbLPS
+      // 
+      this.lbLPS.BackColor = System.Drawing.SystemColors.ControlLightLight;
+      this.lbLPS.ForeColor = System.Drawing.SystemColors.ControlLightLight;
+      resources.ApplyResources(this.lbLPS, "lbLPS");
+      this.lbLPS.Name = "lbLPS";
+      // 
+      // bnLSUp
+      // 
+      this.bnLSUp.BackColor = System.Drawing.Color.Transparent;
+      resources.ApplyResources(this.bnLSUp, "bnLSUp");
+      this.bnLSUp.ContextMenuStrip = this.cMSPresets;
+      this.bnLSUp.Cursor = System.Windows.Forms.Cursors.Default;
+      this.bnLSUp.FlatAppearance.BorderColor = System.Drawing.Color.White;
+      this.bnLSUp.FlatAppearance.BorderSize = 0;
+      this.bnLSUp.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
+      this.bnLSUp.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
+      this.bnLSUp.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
+      this.bnLSUp.ForeColor = System.Drawing.SystemColors.WindowText;
+      this.bnLSUp.Name = "bnLSUp";
+      this.bnLSUp.UseVisualStyleBackColor = false;
+      this.bnLSUp.Click += new System.EventHandler(this.Show_ControlsBn);
+      // 
+      // lbLLeft
+      // 
+      this.lbLLeft.BackColor = System.Drawing.SystemColors.ControlLightLight;
+      this.lbLLeft.ForeColor = System.Drawing.SystemColors.ControlLightLight;
+      resources.ApplyResources(this.lbLLeft, "lbLLeft");
+      this.lbLLeft.Name = "lbLLeft";
+      // 
+      // bnLSRight
+      // 
+      this.bnLSRight.BackColor = System.Drawing.Color.Transparent;
+      resources.ApplyResources(this.bnLSRight, "bnLSRight");
+      this.bnLSRight.ContextMenuStrip = this.cMSPresets;
+      this.bnLSRight.Cursor = System.Windows.Forms.Cursors.Default;
+      this.bnLSRight.FlatAppearance.BorderColor = System.Drawing.Color.White;
+      this.bnLSRight.FlatAppearance.BorderSize = 0;
+      this.bnLSRight.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
+      this.bnLSRight.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
+      this.bnLSRight.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
+      this.bnLSRight.ForeColor = System.Drawing.SystemColors.WindowText;
+      this.bnLSRight.Name = "bnLSRight";
+      this.bnLSRight.UseVisualStyleBackColor = false;
+      this.bnLSRight.Click += new System.EventHandler(this.Show_ControlsBn);
+      // 
+      // lbLright
+      // 
+      this.lbLright.BackColor = System.Drawing.SystemColors.ControlLightLight;
+      this.lbLright.ForeColor = System.Drawing.SystemColors.ControlLightLight;
+      resources.ApplyResources(this.lbLright, "lbLright");
+      this.lbLright.Name = "lbLright";
+      // 
+      // bnLSDown
+      // 
+      this.bnLSDown.BackColor = System.Drawing.Color.Transparent;
+      resources.ApplyResources(this.bnLSDown, "bnLSDown");
+      this.bnLSDown.ContextMenuStrip = this.cMSPresets;
+      this.bnLSDown.Cursor = System.Windows.Forms.Cursors.Default;
+      this.bnLSDown.FlatAppearance.BorderColor = System.Drawing.Color.White;
+      this.bnLSDown.FlatAppearance.BorderSize = 0;
+      this.bnLSDown.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
+      this.bnLSDown.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
+      this.bnLSDown.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
+      this.bnLSDown.ForeColor = System.Drawing.SystemColors.WindowText;
+      this.bnLSDown.Name = "bnLSDown";
+      this.bnLSDown.UseVisualStyleBackColor = false;
+      this.bnLSDown.Click += new System.EventHandler(this.Show_ControlsBn);
+      // 
+      // lbLDown
+      // 
+      this.lbLDown.BackColor = System.Drawing.SystemColors.ControlLightLight;
+      this.lbLDown.ForeColor = System.Drawing.SystemColors.ControlLightLight;
+      resources.ApplyResources(this.lbLDown, "lbLDown");
+      this.lbLDown.Name = "lbLDown";
+      // 
+      // bnR2
+      // 
+      this.bnR2.BackColor = System.Drawing.Color.Transparent;
+      resources.ApplyResources(this.bnR2, "bnR2");
+      this.bnR2.Cursor = System.Windows.Forms.Cursors.Default;
+      this.bnR2.FlatAppearance.BorderColor = System.Drawing.Color.White;
+      this.bnR2.FlatAppearance.BorderSize = 0;
+      this.bnR2.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
+      this.bnR2.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
+      this.bnR2.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
+      this.bnR2.ForeColor = System.Drawing.SystemColors.WindowText;
+      this.bnR2.Name = "bnR2";
+      this.bnR2.UseVisualStyleBackColor = false;
+      this.bnR2.Click += new System.EventHandler(this.Show_ControlsBn);
+      // 
+      // bnUp
+      // 
+      this.bnUp.BackColor = System.Drawing.Color.Transparent;
+      resources.ApplyResources(this.bnUp, "bnUp");
+      this.bnUp.ContextMenuStrip = this.cMSPresets;
+      this.bnUp.Cursor = System.Windows.Forms.Cursors.Default;
+      this.bnUp.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+      this.bnUp.FlatAppearance.BorderColor = System.Drawing.Color.White;
+      this.bnUp.FlatAppearance.BorderSize = 0;
+      this.bnUp.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
+      this.bnUp.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
+      this.bnUp.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
+      this.bnUp.ForeColor = System.Drawing.SystemColors.WindowText;
+      this.bnUp.Name = "bnUp";
+      this.bnUp.UseVisualStyleBackColor = false;
+      this.bnUp.Click += new System.EventHandler(this.Show_ControlsBn);
+      // 
+      // bnDown
+      // 
+      this.bnDown.BackColor = System.Drawing.Color.Transparent;
+      resources.ApplyResources(this.bnDown, "bnDown");
+      this.bnDown.ContextMenuStrip = this.cMSPresets;
+      this.bnDown.Cursor = System.Windows.Forms.Cursors.Default;
+      this.bnDown.FlatAppearance.BorderColor = System.Drawing.Color.White;
+      this.bnDown.FlatAppearance.BorderSize = 0;
+      this.bnDown.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
+      this.bnDown.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
+      this.bnDown.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
+      this.bnDown.ForeColor = System.Drawing.SystemColors.WindowText;
+      this.bnDown.Name = "bnDown";
+      this.bnDown.UseVisualStyleBackColor = false;
+      this.bnDown.Click += new System.EventHandler(this.Show_ControlsBn);
+      // 
+      // bnTriangle
+      // 
+      this.bnTriangle.BackColor = System.Drawing.Color.Transparent;
+      resources.ApplyResources(this.bnTriangle, "bnTriangle");
+      this.bnTriangle.ContextMenuStrip = this.cMSPresets;
+      this.bnTriangle.Cursor = System.Windows.Forms.Cursors.Default;
+      this.bnTriangle.FlatAppearance.BorderColor = System.Drawing.Color.White;
+      this.bnTriangle.FlatAppearance.BorderSize = 0;
+      this.bnTriangle.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
+      this.bnTriangle.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
+      this.bnTriangle.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
+      this.bnTriangle.ForeColor = System.Drawing.SystemColors.WindowText;
+      this.bnTriangle.Name = "bnTriangle";
+      this.bnTriangle.UseVisualStyleBackColor = false;
+      this.bnTriangle.Click += new System.EventHandler(this.Show_ControlsBn);
+      // 
+      // bnR1
+      // 
+      this.bnR1.BackColor = System.Drawing.Color.Transparent;
+      resources.ApplyResources(this.bnR1, "bnR1");
+      this.bnR1.Cursor = System.Windows.Forms.Cursors.Default;
+      this.bnR1.FlatAppearance.BorderColor = System.Drawing.Color.White;
+      this.bnR1.FlatAppearance.BorderSize = 0;
+      this.bnR1.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
+      this.bnR1.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
+      this.bnR1.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
+      this.bnR1.ForeColor = System.Drawing.SystemColors.WindowText;
+      this.bnR1.Name = "bnR1";
+      this.bnR1.UseVisualStyleBackColor = false;
+      this.bnR1.Click += new System.EventHandler(this.Show_ControlsBn);
+      // 
+      // bnSquare
+      // 
+      this.bnSquare.BackColor = System.Drawing.Color.Transparent;
+      resources.ApplyResources(this.bnSquare, "bnSquare");
+      this.bnSquare.ContextMenuStrip = this.cMSPresets;
+      this.bnSquare.Cursor = System.Windows.Forms.Cursors.Default;
+      this.bnSquare.FlatAppearance.BorderColor = System.Drawing.Color.White;
+      this.bnSquare.FlatAppearance.BorderSize = 0;
+      this.bnSquare.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
+      this.bnSquare.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
+      this.bnSquare.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
+      this.bnSquare.ForeColor = System.Drawing.SystemColors.WindowText;
+      this.bnSquare.Name = "bnSquare";
+      this.bnSquare.UseVisualStyleBackColor = false;
+      this.bnSquare.Click += new System.EventHandler(this.Show_ControlsBn);
+      // 
+      // bnRight
+      // 
+      this.bnRight.BackColor = System.Drawing.Color.Transparent;
+      resources.ApplyResources(this.bnRight, "bnRight");
+      this.bnRight.ContextMenuStrip = this.cMSPresets;
+      this.bnRight.Cursor = System.Windows.Forms.Cursors.Default;
+      this.bnRight.FlatAppearance.BorderColor = System.Drawing.Color.White;
+      this.bnRight.FlatAppearance.BorderSize = 0;
+      this.bnRight.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
+      this.bnRight.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
+      this.bnRight.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
+      this.bnRight.ForeColor = System.Drawing.SystemColors.WindowText;
+      this.bnRight.Name = "bnRight";
+      this.bnRight.UseVisualStyleBackColor = false;
+      this.bnRight.Click += new System.EventHandler(this.Show_ControlsBn);
+      // 
+      // lbLUp
+      // 
+      this.lbLUp.BackColor = System.Drawing.SystemColors.ControlLightLight;
+      this.lbLUp.ForeColor = System.Drawing.SystemColors.ControlLightLight;
+      resources.ApplyResources(this.lbLUp, "lbLUp");
+      this.lbLUp.Name = "lbLUp";
+      // 
+      // bnLeft
+      // 
+      this.bnLeft.BackColor = System.Drawing.Color.Transparent;
+      resources.ApplyResources(this.bnLeft, "bnLeft");
+      this.bnLeft.ContextMenuStrip = this.cMSPresets;
+      this.bnLeft.Cursor = System.Windows.Forms.Cursors.Default;
+      this.bnLeft.FlatAppearance.BorderColor = System.Drawing.Color.White;
+      this.bnLeft.FlatAppearance.BorderSize = 0;
+      this.bnLeft.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
+      this.bnLeft.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
+      this.bnLeft.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
+      this.bnLeft.ForeColor = System.Drawing.SystemColors.WindowText;
+      this.bnLeft.Name = "bnLeft";
+      this.bnLeft.UseVisualStyleBackColor = false;
+      this.bnLeft.Click += new System.EventHandler(this.Show_ControlsBn);
+      // 
+      // lbLShare
+      // 
+      this.lbLShare.BackColor = System.Drawing.SystemColors.ControlLightLight;
+      this.lbLShare.ForeColor = System.Drawing.SystemColors.ControlLightLight;
+      resources.ApplyResources(this.lbLShare, "lbLShare");
+      this.lbLShare.Name = "lbLShare";
+      // 
+      // bnOptions
+      // 
+      this.bnOptions.BackColor = System.Drawing.Color.Transparent;
+      resources.ApplyResources(this.bnOptions, "bnOptions");
+      this.bnOptions.Cursor = System.Windows.Forms.Cursors.Default;
+      this.bnOptions.FlatAppearance.BorderColor = System.Drawing.Color.White;
+      this.bnOptions.FlatAppearance.BorderSize = 0;
+      this.bnOptions.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
+      this.bnOptions.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
+      this.bnOptions.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
+      this.bnOptions.ForeColor = System.Drawing.SystemColors.WindowText;
+      this.bnOptions.Name = "bnOptions";
+      this.bnOptions.UseVisualStyleBackColor = false;
+      this.bnOptions.Click += new System.EventHandler(this.Show_ControlsBn);
+      // 
+      // bnShare
+      // 
+      this.bnShare.BackColor = System.Drawing.Color.Transparent;
+      resources.ApplyResources(this.bnShare, "bnShare");
+      this.bnShare.Cursor = System.Windows.Forms.Cursors.Default;
+      this.bnShare.FlatAppearance.BorderColor = System.Drawing.Color.White;
+      this.bnShare.FlatAppearance.BorderSize = 0;
+      this.bnShare.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
+      this.bnShare.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
+      this.bnShare.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
+      this.bnShare.ForeColor = System.Drawing.SystemColors.WindowText;
+      this.bnShare.Name = "bnShare";
+      this.bnShare.UseVisualStyleBackColor = false;
+      this.bnShare.Click += new System.EventHandler(this.Show_ControlsBn);
+      // 
+      // lbLOptions
+      // 
+      this.lbLOptions.BackColor = System.Drawing.SystemColors.ControlLightLight;
+      this.lbLOptions.ForeColor = System.Drawing.SystemColors.ControlLightLight;
+      resources.ApplyResources(this.lbLOptions, "lbLOptions");
+      this.lbLOptions.Name = "lbLOptions";
+      // 
+      // bnL1
+      // 
+      this.bnL1.BackColor = System.Drawing.Color.Transparent;
+      resources.ApplyResources(this.bnL1, "bnL1");
+      this.bnL1.Cursor = System.Windows.Forms.Cursors.Default;
+      this.bnL1.FlatAppearance.BorderColor = System.Drawing.Color.White;
+      this.bnL1.FlatAppearance.BorderSize = 0;
+      this.bnL1.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
+      this.bnL1.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
+      this.bnL1.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
+      this.bnL1.ForeColor = System.Drawing.SystemColors.WindowText;
+      this.bnL1.Name = "bnL1";
+      this.bnL1.UseVisualStyleBackColor = false;
+      this.bnL1.Click += new System.EventHandler(this.Show_ControlsBn);
+      // 
+      // bnTouchRight
+      // 
+      this.bnTouchRight.BackColor = System.Drawing.Color.Transparent;
+      resources.ApplyResources(this.bnTouchRight, "bnTouchRight");
+      this.bnTouchRight.Cursor = System.Windows.Forms.Cursors.Default;
+      this.bnTouchRight.FlatAppearance.BorderColor = System.Drawing.Color.White;
+      this.bnTouchRight.FlatAppearance.BorderSize = 0;
+      this.bnTouchRight.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
+      this.bnTouchRight.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
+      this.bnTouchRight.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
+      this.bnTouchRight.ForeColor = System.Drawing.SystemColors.WindowText;
+      this.bnTouchRight.Name = "bnTouchRight";
+      this.bnTouchRight.UseVisualStyleBackColor = false;
+      this.bnTouchRight.Click += new System.EventHandler(this.Show_ControlsBn);
+      // 
+      // bnL2
+      // 
+      this.bnL2.BackColor = System.Drawing.Color.Transparent;
+      resources.ApplyResources(this.bnL2, "bnL2");
+      this.bnL2.Cursor = System.Windows.Forms.Cursors.Default;
+      this.bnL2.FlatAppearance.BorderColor = System.Drawing.Color.White;
+      this.bnL2.FlatAppearance.BorderSize = 0;
+      this.bnL2.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
+      this.bnL2.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
+      this.bnL2.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
+      this.bnL2.ForeColor = System.Drawing.SystemColors.WindowText;
+      this.bnL2.Name = "bnL2";
+      this.bnL2.UseVisualStyleBackColor = false;
+      this.bnL2.Click += new System.EventHandler(this.Show_ControlsBn);
+      // 
+      // lbLTriangle
+      // 
+      this.lbLTriangle.BackColor = System.Drawing.SystemColors.ControlLightLight;
+      this.lbLTriangle.ForeColor = System.Drawing.SystemColors.ControlLightLight;
+      resources.ApplyResources(this.lbLTriangle, "lbLTriangle");
+      this.lbLTriangle.Name = "lbLTriangle";
+      // 
+      // bnTouchLeft
+      // 
+      this.bnTouchLeft.BackColor = System.Drawing.Color.Transparent;
+      resources.ApplyResources(this.bnTouchLeft, "bnTouchLeft");
+      this.bnTouchLeft.Cursor = System.Windows.Forms.Cursors.Default;
+      this.bnTouchLeft.FlatAppearance.BorderColor = System.Drawing.Color.White;
+      this.bnTouchLeft.FlatAppearance.BorderSize = 0;
+      this.bnTouchLeft.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
+      this.bnTouchLeft.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
+      this.bnTouchLeft.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
+      this.bnTouchLeft.ForeColor = System.Drawing.SystemColors.WindowText;
+      this.bnTouchLeft.Name = "bnTouchLeft";
+      this.bnTouchLeft.UseVisualStyleBackColor = false;
+      this.bnTouchLeft.Click += new System.EventHandler(this.Show_ControlsBn);
+      // 
+      // lbLSquare
+      // 
+      this.lbLSquare.BackColor = System.Drawing.SystemColors.ControlLightLight;
+      this.lbLSquare.ForeColor = System.Drawing.SystemColors.ControlLightLight;
+      resources.ApplyResources(this.lbLSquare, "lbLSquare");
+      this.lbLSquare.Name = "lbLSquare";
+      // 
+      // bnTouchMulti
+      // 
+      this.bnTouchMulti.BackColor = System.Drawing.Color.Transparent;
+      resources.ApplyResources(this.bnTouchMulti, "bnTouchMulti");
+      this.bnTouchMulti.Cursor = System.Windows.Forms.Cursors.Default;
+      this.bnTouchMulti.FlatAppearance.BorderColor = System.Drawing.Color.White;
+      this.bnTouchMulti.FlatAppearance.BorderSize = 0;
+      this.bnTouchMulti.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
+      this.bnTouchMulti.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
+      this.bnTouchMulti.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
+      this.bnTouchMulti.ForeColor = System.Drawing.SystemColors.WindowText;
+      this.bnTouchMulti.Name = "bnTouchMulti";
+      this.bnTouchMulti.UseVisualStyleBackColor = false;
+      this.bnTouchMulti.Click += new System.EventHandler(this.Show_ControlsBn);
+      // 
+      // lbLCircle
+      // 
+      this.lbLCircle.BackColor = System.Drawing.SystemColors.ControlLightLight;
+      this.lbLCircle.ForeColor = System.Drawing.SystemColors.ControlLightLight;
+      resources.ApplyResources(this.lbLCircle, "lbLCircle");
+      this.lbLCircle.Name = "lbLCircle";
+      // 
+      // lbLCross
+      // 
+      this.lbLCross.BackColor = System.Drawing.SystemColors.ControlLightLight;
+      this.lbLCross.ForeColor = System.Drawing.SystemColors.ControlLightLight;
+      resources.ApplyResources(this.lbLCross, "lbLCross");
+      this.lbLCross.Name = "lbLCross";
+      // 
+      // bnTouchUpper
+      // 
+      this.bnTouchUpper.BackColor = System.Drawing.Color.Transparent;
+      resources.ApplyResources(this.bnTouchUpper, "bnTouchUpper");
+      this.bnTouchUpper.Cursor = System.Windows.Forms.Cursors.Default;
+      this.bnTouchUpper.FlatAppearance.BorderColor = System.Drawing.Color.White;
+      this.bnTouchUpper.FlatAppearance.BorderSize = 0;
+      this.bnTouchUpper.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
+      this.bnTouchUpper.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
+      this.bnTouchUpper.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
+      this.bnTouchUpper.ForeColor = System.Drawing.SystemColors.WindowText;
+      this.bnTouchUpper.Name = "bnTouchUpper";
+      this.bnTouchUpper.UseVisualStyleBackColor = false;
+      this.bnTouchUpper.Click += new System.EventHandler(this.Show_ControlsBn);
+      // 
+      // btnLightbar
+      // 
+      this.btnLightbar.BackColor = System.Drawing.Color.Transparent;
+      this.btnLightbar.BackgroundImage = global::DS4Windows.Properties.Resources.DS4_lightbar;
+      resources.ApplyResources(this.btnLightbar, "btnLightbar");
+      this.btnLightbar.Cursor = System.Windows.Forms.Cursors.Default;
+      this.btnLightbar.FlatAppearance.BorderColor = System.Drawing.Color.Red;
+      this.btnLightbar.FlatAppearance.BorderSize = 0;
+      this.btnLightbar.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
+      this.btnLightbar.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
+      this.btnLightbar.ForeColor = System.Drawing.SystemColors.WindowText;
+      this.btnLightbar.Name = "btnLightbar";
+      this.btnLightbar.UseVisualStyleBackColor = false;
+      this.btnLightbar.Click += new System.EventHandler(this.btnLightbar_Click);
+      this.btnLightbar.Paint += new System.Windows.Forms.PaintEventHandler(this.btnLightbar_Paint);
+      this.btnLightbar.MouseHover += new System.EventHandler(this.btnLightbar_MouseHover);
+      // 
+      // bnPS
+      // 
+      this.bnPS.BackColor = System.Drawing.Color.Transparent;
+      resources.ApplyResources(this.bnPS, "bnPS");
+      this.bnPS.Cursor = System.Windows.Forms.Cursors.Default;
+      this.bnPS.FlatAppearance.BorderColor = System.Drawing.Color.White;
+      this.bnPS.FlatAppearance.BorderSize = 0;
+      this.bnPS.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
+      this.bnPS.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
+      this.bnPS.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
+      this.bnPS.ForeColor = System.Drawing.SystemColors.WindowText;
+      this.bnPS.Name = "bnPS";
+      this.bnPS.UseVisualStyleBackColor = false;
+      this.bnPS.Click += new System.EventHandler(this.Show_ControlsBn);
+      // 
+      // bnCross
+      // 
+      this.bnCross.BackColor = System.Drawing.Color.Transparent;
+      resources.ApplyResources(this.bnCross, "bnCross");
+      this.bnCross.ContextMenuStrip = this.cMSPresets;
+      this.bnCross.Cursor = System.Windows.Forms.Cursors.Default;
+      this.bnCross.FlatAppearance.BorderColor = System.Drawing.Color.White;
+      this.bnCross.FlatAppearance.BorderSize = 0;
+      this.bnCross.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
+      this.bnCross.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
+      this.bnCross.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
+      this.bnCross.ForeColor = System.Drawing.SystemColors.WindowText;
+      this.bnCross.Name = "bnCross";
+      this.bnCross.UseVisualStyleBackColor = false;
+      this.bnCross.Click += new System.EventHandler(this.Show_ControlsBn);
+      // 
+      // bnCircle
+      // 
+      this.bnCircle.BackColor = System.Drawing.Color.Transparent;
+      resources.ApplyResources(this.bnCircle, "bnCircle");
+      this.bnCircle.ContextMenuStrip = this.cMSPresets;
+      this.bnCircle.Cursor = System.Windows.Forms.Cursors.Default;
+      this.bnCircle.FlatAppearance.BorderColor = System.Drawing.Color.White;
+      this.bnCircle.FlatAppearance.BorderSize = 0;
+      this.bnCircle.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
+      this.bnCircle.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
+      this.bnCircle.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
+      this.bnCircle.ForeColor = System.Drawing.SystemColors.WindowText;
+      this.bnCircle.Name = "bnCircle";
+      this.bnCircle.UseVisualStyleBackColor = false;
+      this.bnCircle.Click += new System.EventHandler(this.Show_ControlsBn);
+      // 
+      // lbControlName
+      // 
+      this.lbControlName.BackColor = System.Drawing.Color.Transparent;
+      this.lbControlName.ForeColor = System.Drawing.SystemColors.ControlLightLight;
+      resources.ApplyResources(this.lbControlName, "lbControlName");
+      this.lbControlName.Name = "lbControlName";
+      this.lbControlName.Click += new System.EventHandler(this.Show_ControlsList);
+      // 
+      // tPSpecial
+      // 
+      this.tPSpecial.Controls.Add(this.pnlActions);
+      resources.ApplyResources(this.tPSpecial, "tPSpecial");
+      this.tPSpecial.Name = "tPSpecial";
+      this.tPSpecial.UseVisualStyleBackColor = true;
+      // 
+      // pnlActions
+      // 
+      this.pnlActions.Controls.Add(this.lVActions);
+      this.pnlActions.Controls.Add(this.panel2);
+      resources.ApplyResources(this.pnlActions, "pnlActions");
+      this.pnlActions.Name = "pnlActions";
+      // 
+      // lVActions
+      // 
+      this.lVActions.CheckBoxes = true;
+      this.lVActions.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
             this.cHName,
             this.cHTrigger,
             this.cHAction});
-            resources.ApplyResources(this.lVActions, "lVActions");
-            this.lVActions.FullRowSelect = true;
-            this.lVActions.HideSelection = false;
-            this.lVActions.MultiSelect = false;
-            this.lVActions.Name = "lVActions";
-            this.lVActions.ShowItemToolTips = true;
-            this.lVActions.UseCompatibleStateImageBehavior = false;
-            this.lVActions.View = System.Windows.Forms.View.Details;
-            // 
-            // cHName
-            // 
-            resources.ApplyResources(this.cHName, "cHName");
-            // 
-            // cHTrigger
-            // 
-            resources.ApplyResources(this.cHTrigger, "cHTrigger");
-            // 
-            // cHAction
-            // 
-            resources.ApplyResources(this.cHAction, "cHAction");
-            // 
-            // panel2
-            // 
-            this.panel2.Controls.Add(this.fLPActionButtons);
-            this.panel2.Controls.Add(this.lbActionsTip);
-            resources.ApplyResources(this.panel2, "panel2");
-            this.panel2.Name = "panel2";
-            // 
-            // fLPActionButtons
-            // 
-            this.fLPActionButtons.Controls.Add(this.btnNewAction);
-            this.fLPActionButtons.Controls.Add(this.btnEditAction);
-            this.fLPActionButtons.Controls.Add(this.btnRemAction);
-            resources.ApplyResources(this.fLPActionButtons, "fLPActionButtons");
-            this.fLPActionButtons.Name = "fLPActionButtons";
-            // 
-            // btnNewAction
-            // 
-            resources.ApplyResources(this.btnNewAction, "btnNewAction");
-            this.btnNewAction.Name = "btnNewAction";
-            this.btnNewAction.UseVisualStyleBackColor = true;
-            this.btnNewAction.Click += new System.EventHandler(this.btnAddAction_Click);
-            // 
-            // btnEditAction
-            // 
-            resources.ApplyResources(this.btnEditAction, "btnEditAction");
-            this.btnEditAction.Name = "btnEditAction";
-            this.btnEditAction.UseVisualStyleBackColor = true;
-            this.btnEditAction.Click += new System.EventHandler(this.btnEditAction_Click);
-            // 
-            // btnRemAction
-            // 
-            resources.ApplyResources(this.btnRemAction, "btnRemAction");
-            this.btnRemAction.Name = "btnRemAction";
-            this.btnRemAction.UseVisualStyleBackColor = true;
-            this.btnRemAction.Click += new System.EventHandler(this.btnRemAction_Click);
-            // 
-            // lbActionsTip
-            // 
-            resources.ApplyResources(this.lbActionsTip, "lbActionsTip");
-            this.lbActionsTip.Name = "lbActionsTip";
-            // 
-            // tCSens
-            // 
-            this.tCSens.Controls.Add(this.tPDeadzone);
-            this.tCSens.Controls.Add(this.antiDeadzoneTabPage);
-            this.tCSens.Controls.Add(this.maxZoneTabPage);
-            this.tCSens.Controls.Add(this.squStickTabPage);
-            this.tCSens.Controls.Add(this.tPOutCurve);
-            this.tCSens.Controls.Add(this.tPCurve);
-            this.tCSens.Controls.Add(this.tpRotation);
-            resources.ApplyResources(this.tCSens, "tCSens");
-            this.tCSens.Name = "tCSens";
-            this.tCSens.SelectedIndex = 0;
-            // 
-            // tPDeadzone
-            // 
-            this.tPDeadzone.BackColor = System.Drawing.SystemColors.Control;
-            this.tPDeadzone.Controls.Add(this.lbL2);
-            this.tPDeadzone.Controls.Add(this.nUDL2);
-            this.tPDeadzone.Controls.Add(this.nUDLS);
-            this.tPDeadzone.Controls.Add(this.lbSixaxisX);
-            this.tPDeadzone.Controls.Add(this.nUDR2);
-            this.tPDeadzone.Controls.Add(this.lbSixaxisZ);
-            this.tPDeadzone.Controls.Add(this.nUDRS);
-            this.tPDeadzone.Controls.Add(this.lbR2);
-            this.tPDeadzone.Controls.Add(this.nUDSX);
-            this.tPDeadzone.Controls.Add(this.lbRS);
-            this.tPDeadzone.Controls.Add(this.lbLS);
-            this.tPDeadzone.Controls.Add(this.nUDSZ);
-            resources.ApplyResources(this.tPDeadzone, "tPDeadzone");
-            this.tPDeadzone.Name = "tPDeadzone";
-            // 
-            // antiDeadzoneTabPage
-            // 
-            this.antiDeadzoneTabPage.BackColor = System.Drawing.SystemColors.Control;
-            this.antiDeadzoneTabPage.Controls.Add(this.nUDSixaxisZAntiDead);
-            this.antiDeadzoneTabPage.Controls.Add(this.nUDSixaxisXAntiDead);
-            this.antiDeadzoneTabPage.Controls.Add(this.label20);
-            this.antiDeadzoneTabPage.Controls.Add(this.label19);
-            this.antiDeadzoneTabPage.Controls.Add(this.nUDR2AntiDead);
-            this.antiDeadzoneTabPage.Controls.Add(this.label3);
-            this.antiDeadzoneTabPage.Controls.Add(this.nUDL2AntiDead);
-            this.antiDeadzoneTabPage.Controls.Add(this.label4);
-            this.antiDeadzoneTabPage.Controls.Add(this.nUDRSAntiDead);
-            this.antiDeadzoneTabPage.Controls.Add(this.label2);
-            this.antiDeadzoneTabPage.Controls.Add(this.nUDLSAntiDead);
-            this.antiDeadzoneTabPage.Controls.Add(this.label1);
-            resources.ApplyResources(this.antiDeadzoneTabPage, "antiDeadzoneTabPage");
-            this.antiDeadzoneTabPage.Name = "antiDeadzoneTabPage";
-            // 
-            // nUDSixaxisZAntiDead
-            // 
-            this.nUDSixaxisZAntiDead.DecimalPlaces = 2;
-            this.nUDSixaxisZAntiDead.Increment = new decimal(new int[] {
+      resources.ApplyResources(this.lVActions, "lVActions");
+      this.lVActions.FullRowSelect = true;
+      this.lVActions.HideSelection = false;
+      this.lVActions.MultiSelect = false;
+      this.lVActions.Name = "lVActions";
+      this.lVActions.ShowItemToolTips = true;
+      this.lVActions.UseCompatibleStateImageBehavior = false;
+      this.lVActions.View = System.Windows.Forms.View.Details;
+      // 
+      // cHName
+      // 
+      resources.ApplyResources(this.cHName, "cHName");
+      // 
+      // cHTrigger
+      // 
+      resources.ApplyResources(this.cHTrigger, "cHTrigger");
+      // 
+      // cHAction
+      // 
+      resources.ApplyResources(this.cHAction, "cHAction");
+      // 
+      // panel2
+      // 
+      this.panel2.Controls.Add(this.fLPActionButtons);
+      this.panel2.Controls.Add(this.lbActionsTip);
+      resources.ApplyResources(this.panel2, "panel2");
+      this.panel2.Name = "panel2";
+      // 
+      // fLPActionButtons
+      // 
+      this.fLPActionButtons.Controls.Add(this.btnNewAction);
+      this.fLPActionButtons.Controls.Add(this.btnEditAction);
+      this.fLPActionButtons.Controls.Add(this.btnRemAction);
+      resources.ApplyResources(this.fLPActionButtons, "fLPActionButtons");
+      this.fLPActionButtons.Name = "fLPActionButtons";
+      // 
+      // btnNewAction
+      // 
+      resources.ApplyResources(this.btnNewAction, "btnNewAction");
+      this.btnNewAction.Name = "btnNewAction";
+      this.btnNewAction.UseVisualStyleBackColor = true;
+      this.btnNewAction.Click += new System.EventHandler(this.btnAddAction_Click);
+      // 
+      // btnEditAction
+      // 
+      resources.ApplyResources(this.btnEditAction, "btnEditAction");
+      this.btnEditAction.Name = "btnEditAction";
+      this.btnEditAction.UseVisualStyleBackColor = true;
+      this.btnEditAction.Click += new System.EventHandler(this.btnEditAction_Click);
+      // 
+      // btnRemAction
+      // 
+      resources.ApplyResources(this.btnRemAction, "btnRemAction");
+      this.btnRemAction.Name = "btnRemAction";
+      this.btnRemAction.UseVisualStyleBackColor = true;
+      this.btnRemAction.Click += new System.EventHandler(this.btnRemAction_Click);
+      // 
+      // lbActionsTip
+      // 
+      resources.ApplyResources(this.lbActionsTip, "lbActionsTip");
+      this.lbActionsTip.Name = "lbActionsTip";
+      // 
+      // tCSens
+      // 
+      this.tCSens.Controls.Add(this.tPDeadzone);
+      this.tCSens.Controls.Add(this.antiDeadzoneTabPage);
+      this.tCSens.Controls.Add(this.maxZoneTabPage);
+      this.tCSens.Controls.Add(this.squStickTabPage);
+      this.tCSens.Controls.Add(this.tPOutCurve);
+      this.tCSens.Controls.Add(this.tPCurve);
+      this.tCSens.Controls.Add(this.tpRotation);
+      resources.ApplyResources(this.tCSens, "tCSens");
+      this.tCSens.Name = "tCSens";
+      this.tCSens.SelectedIndex = 0;
+      // 
+      // tPDeadzone
+      // 
+      this.tPDeadzone.BackColor = System.Drawing.SystemColors.Control;
+      this.tPDeadzone.Controls.Add(this.lbL2);
+      this.tPDeadzone.Controls.Add(this.nUDL2);
+      this.tPDeadzone.Controls.Add(this.nUDLS);
+      this.tPDeadzone.Controls.Add(this.lbSixaxisX);
+      this.tPDeadzone.Controls.Add(this.nUDR2);
+      this.tPDeadzone.Controls.Add(this.lbSixaxisZ);
+      this.tPDeadzone.Controls.Add(this.nUDRS);
+      this.tPDeadzone.Controls.Add(this.lbR2);
+      this.tPDeadzone.Controls.Add(this.nUDSX);
+      this.tPDeadzone.Controls.Add(this.lbRS);
+      this.tPDeadzone.Controls.Add(this.lbLS);
+      this.tPDeadzone.Controls.Add(this.nUDSZ);
+      resources.ApplyResources(this.tPDeadzone, "tPDeadzone");
+      this.tPDeadzone.Name = "tPDeadzone";
+      // 
+      // antiDeadzoneTabPage
+      // 
+      this.antiDeadzoneTabPage.BackColor = System.Drawing.SystemColors.Control;
+      this.antiDeadzoneTabPage.Controls.Add(this.nUDSixaxisZAntiDead);
+      this.antiDeadzoneTabPage.Controls.Add(this.nUDSixaxisXAntiDead);
+      this.antiDeadzoneTabPage.Controls.Add(this.label20);
+      this.antiDeadzoneTabPage.Controls.Add(this.label19);
+      this.antiDeadzoneTabPage.Controls.Add(this.nUDR2AntiDead);
+      this.antiDeadzoneTabPage.Controls.Add(this.label3);
+      this.antiDeadzoneTabPage.Controls.Add(this.nUDL2AntiDead);
+      this.antiDeadzoneTabPage.Controls.Add(this.label4);
+      this.antiDeadzoneTabPage.Controls.Add(this.nUDRSAntiDead);
+      this.antiDeadzoneTabPage.Controls.Add(this.label2);
+      this.antiDeadzoneTabPage.Controls.Add(this.nUDLSAntiDead);
+      this.antiDeadzoneTabPage.Controls.Add(this.label1);
+      resources.ApplyResources(this.antiDeadzoneTabPage, "antiDeadzoneTabPage");
+      this.antiDeadzoneTabPage.Name = "antiDeadzoneTabPage";
+      // 
+      // nUDSixaxisZAntiDead
+      // 
+      this.nUDSixaxisZAntiDead.DecimalPlaces = 2;
+      this.nUDSixaxisZAntiDead.Increment = new decimal(new int[] {
             1,
             0,
             0,
             65536});
-            resources.ApplyResources(this.nUDSixaxisZAntiDead, "nUDSixaxisZAntiDead");
-            this.nUDSixaxisZAntiDead.Maximum = new decimal(new int[] {
+      resources.ApplyResources(this.nUDSixaxisZAntiDead, "nUDSixaxisZAntiDead");
+      this.nUDSixaxisZAntiDead.Maximum = new decimal(new int[] {
             1,
             0,
             0,
             0});
-            this.nUDSixaxisZAntiDead.Name = "nUDSixaxisZAntiDead";
-            this.nUDSixaxisZAntiDead.ValueChanged += new System.EventHandler(this.nUDSixaxisZAntiDead_ValueChanged);
-            // 
-            // nUDSixaxisXAntiDead
-            // 
-            this.nUDSixaxisXAntiDead.DecimalPlaces = 2;
-            this.nUDSixaxisXAntiDead.Increment = new decimal(new int[] {
+      this.nUDSixaxisZAntiDead.Name = "nUDSixaxisZAntiDead";
+      this.nUDSixaxisZAntiDead.ValueChanged += new System.EventHandler(this.nUDSixaxisZAntiDead_ValueChanged);
+      // 
+      // nUDSixaxisXAntiDead
+      // 
+      this.nUDSixaxisXAntiDead.DecimalPlaces = 2;
+      this.nUDSixaxisXAntiDead.Increment = new decimal(new int[] {
             1,
             0,
             0,
             65536});
-            resources.ApplyResources(this.nUDSixaxisXAntiDead, "nUDSixaxisXAntiDead");
-            this.nUDSixaxisXAntiDead.Maximum = new decimal(new int[] {
+      resources.ApplyResources(this.nUDSixaxisXAntiDead, "nUDSixaxisXAntiDead");
+      this.nUDSixaxisXAntiDead.Maximum = new decimal(new int[] {
             1,
             0,
             0,
             0});
-            this.nUDSixaxisXAntiDead.Name = "nUDSixaxisXAntiDead";
-            this.nUDSixaxisXAntiDead.ValueChanged += new System.EventHandler(this.nUDSixaxisXAntiDead_ValueChanged);
-            // 
-            // label20
-            // 
-            resources.ApplyResources(this.label20, "label20");
-            this.label20.Name = "label20";
-            // 
-            // label19
-            // 
-            resources.ApplyResources(this.label19, "label19");
-            this.label19.Name = "label19";
-            // 
-            // nUDR2AntiDead
-            // 
-            this.nUDR2AntiDead.DecimalPlaces = 2;
-            this.nUDR2AntiDead.Increment = new decimal(new int[] {
+      this.nUDSixaxisXAntiDead.Name = "nUDSixaxisXAntiDead";
+      this.nUDSixaxisXAntiDead.ValueChanged += new System.EventHandler(this.nUDSixaxisXAntiDead_ValueChanged);
+      // 
+      // label20
+      // 
+      resources.ApplyResources(this.label20, "label20");
+      this.label20.Name = "label20";
+      // 
+      // label19
+      // 
+      resources.ApplyResources(this.label19, "label19");
+      this.label19.Name = "label19";
+      // 
+      // nUDR2AntiDead
+      // 
+      this.nUDR2AntiDead.DecimalPlaces = 2;
+      this.nUDR2AntiDead.Increment = new decimal(new int[] {
             1,
             0,
             0,
             65536});
-            resources.ApplyResources(this.nUDR2AntiDead, "nUDR2AntiDead");
-            this.nUDR2AntiDead.Maximum = new decimal(new int[] {
+      resources.ApplyResources(this.nUDR2AntiDead, "nUDR2AntiDead");
+      this.nUDR2AntiDead.Maximum = new decimal(new int[] {
             1,
             0,
             0,
             0});
-            this.nUDR2AntiDead.Name = "nUDR2AntiDead";
-            this.nUDR2AntiDead.ValueChanged += new System.EventHandler(this.nUDR2AntiDead_ValueChanged);
-            // 
-            // label3
-            // 
-            resources.ApplyResources(this.label3, "label3");
-            this.label3.Name = "label3";
-            // 
-            // nUDL2AntiDead
-            // 
-            this.nUDL2AntiDead.DecimalPlaces = 2;
-            this.nUDL2AntiDead.Increment = new decimal(new int[] {
+      this.nUDR2AntiDead.Name = "nUDR2AntiDead";
+      this.nUDR2AntiDead.ValueChanged += new System.EventHandler(this.nUDR2AntiDead_ValueChanged);
+      // 
+      // label3
+      // 
+      resources.ApplyResources(this.label3, "label3");
+      this.label3.Name = "label3";
+      // 
+      // nUDL2AntiDead
+      // 
+      this.nUDL2AntiDead.DecimalPlaces = 2;
+      this.nUDL2AntiDead.Increment = new decimal(new int[] {
             1,
             0,
             0,
             65536});
-            resources.ApplyResources(this.nUDL2AntiDead, "nUDL2AntiDead");
-            this.nUDL2AntiDead.Maximum = new decimal(new int[] {
+      resources.ApplyResources(this.nUDL2AntiDead, "nUDL2AntiDead");
+      this.nUDL2AntiDead.Maximum = new decimal(new int[] {
             1,
             0,
             0,
             0});
-            this.nUDL2AntiDead.Name = "nUDL2AntiDead";
-            this.nUDL2AntiDead.ValueChanged += new System.EventHandler(this.nUDL2AntiDead_ValueChanged);
-            // 
-            // label4
-            // 
-            resources.ApplyResources(this.label4, "label4");
-            this.label4.Name = "label4";
-            // 
-            // nUDRSAntiDead
-            // 
-            this.nUDRSAntiDead.DecimalPlaces = 2;
-            this.nUDRSAntiDead.Increment = new decimal(new int[] {
+      this.nUDL2AntiDead.Name = "nUDL2AntiDead";
+      this.nUDL2AntiDead.ValueChanged += new System.EventHandler(this.nUDL2AntiDead_ValueChanged);
+      // 
+      // label4
+      // 
+      resources.ApplyResources(this.label4, "label4");
+      this.label4.Name = "label4";
+      // 
+      // nUDRSAntiDead
+      // 
+      this.nUDRSAntiDead.DecimalPlaces = 2;
+      this.nUDRSAntiDead.Increment = new decimal(new int[] {
             1,
             0,
             0,
             65536});
-            resources.ApplyResources(this.nUDRSAntiDead, "nUDRSAntiDead");
-            this.nUDRSAntiDead.Maximum = new decimal(new int[] {
+      resources.ApplyResources(this.nUDRSAntiDead, "nUDRSAntiDead");
+      this.nUDRSAntiDead.Maximum = new decimal(new int[] {
             1,
             0,
             0,
             0});
-            this.nUDRSAntiDead.Name = "nUDRSAntiDead";
-            this.nUDRSAntiDead.ValueChanged += new System.EventHandler(this.nUDRSAntiDead_ValueChanged);
-            // 
-            // label2
-            // 
-            resources.ApplyResources(this.label2, "label2");
-            this.label2.Name = "label2";
-            // 
-            // nUDLSAntiDead
-            // 
-            this.nUDLSAntiDead.DecimalPlaces = 2;
-            this.nUDLSAntiDead.Increment = new decimal(new int[] {
+      this.nUDRSAntiDead.Name = "nUDRSAntiDead";
+      this.nUDRSAntiDead.ValueChanged += new System.EventHandler(this.nUDRSAntiDead_ValueChanged);
+      // 
+      // label2
+      // 
+      resources.ApplyResources(this.label2, "label2");
+      this.label2.Name = "label2";
+      // 
+      // nUDLSAntiDead
+      // 
+      this.nUDLSAntiDead.DecimalPlaces = 2;
+      this.nUDLSAntiDead.Increment = new decimal(new int[] {
             1,
             0,
             0,
             65536});
-            resources.ApplyResources(this.nUDLSAntiDead, "nUDLSAntiDead");
-            this.nUDLSAntiDead.Maximum = new decimal(new int[] {
+      resources.ApplyResources(this.nUDLSAntiDead, "nUDLSAntiDead");
+      this.nUDLSAntiDead.Maximum = new decimal(new int[] {
             1,
             0,
             0,
             0});
-            this.nUDLSAntiDead.Name = "nUDLSAntiDead";
-            this.nUDLSAntiDead.ValueChanged += new System.EventHandler(this.nUDLSAntiDead_ValueChanged);
-            // 
-            // label1
-            // 
-            resources.ApplyResources(this.label1, "label1");
-            this.label1.Name = "label1";
-            // 
-            // maxZoneTabPage
-            // 
-            this.maxZoneTabPage.BackColor = System.Drawing.SystemColors.Control;
-            this.maxZoneTabPage.Controls.Add(this.nUDSixAxisZMaxZone);
-            this.maxZoneTabPage.Controls.Add(this.nUDSixAxisXMaxZone);
-            this.maxZoneTabPage.Controls.Add(this.label18);
-            this.maxZoneTabPage.Controls.Add(this.label17);
-            this.maxZoneTabPage.Controls.Add(this.nUDR2Maxzone);
-            this.maxZoneTabPage.Controls.Add(this.nUDL2Maxzone);
-            this.maxZoneTabPage.Controls.Add(this.label8);
-            this.maxZoneTabPage.Controls.Add(this.label7);
-            this.maxZoneTabPage.Controls.Add(this.nUDRSMaxZone);
-            this.maxZoneTabPage.Controls.Add(this.label6);
-            this.maxZoneTabPage.Controls.Add(this.nUDLSMaxZone);
-            this.maxZoneTabPage.Controls.Add(this.label5);
-            resources.ApplyResources(this.maxZoneTabPage, "maxZoneTabPage");
-            this.maxZoneTabPage.Name = "maxZoneTabPage";
-            // 
-            // nUDSixAxisZMaxZone
-            // 
-            this.nUDSixAxisZMaxZone.DecimalPlaces = 2;
-            this.nUDSixAxisZMaxZone.Increment = new decimal(new int[] {
+      this.nUDLSAntiDead.Name = "nUDLSAntiDead";
+      this.nUDLSAntiDead.ValueChanged += new System.EventHandler(this.nUDLSAntiDead_ValueChanged);
+      // 
+      // label1
+      // 
+      resources.ApplyResources(this.label1, "label1");
+      this.label1.Name = "label1";
+      // 
+      // maxZoneTabPage
+      // 
+      this.maxZoneTabPage.BackColor = System.Drawing.SystemColors.Control;
+      this.maxZoneTabPage.Controls.Add(this.nUDSixAxisZMaxZone);
+      this.maxZoneTabPage.Controls.Add(this.nUDSixAxisXMaxZone);
+      this.maxZoneTabPage.Controls.Add(this.label18);
+      this.maxZoneTabPage.Controls.Add(this.label17);
+      this.maxZoneTabPage.Controls.Add(this.nUDR2Maxzone);
+      this.maxZoneTabPage.Controls.Add(this.nUDL2Maxzone);
+      this.maxZoneTabPage.Controls.Add(this.label8);
+      this.maxZoneTabPage.Controls.Add(this.label7);
+      this.maxZoneTabPage.Controls.Add(this.nUDRSMaxZone);
+      this.maxZoneTabPage.Controls.Add(this.label6);
+      this.maxZoneTabPage.Controls.Add(this.nUDLSMaxZone);
+      this.maxZoneTabPage.Controls.Add(this.label5);
+      resources.ApplyResources(this.maxZoneTabPage, "maxZoneTabPage");
+      this.maxZoneTabPage.Name = "maxZoneTabPage";
+      // 
+      // nUDSixAxisZMaxZone
+      // 
+      this.nUDSixAxisZMaxZone.DecimalPlaces = 2;
+      this.nUDSixAxisZMaxZone.Increment = new decimal(new int[] {
             1,
             0,
             0,
             65536});
-            resources.ApplyResources(this.nUDSixAxisZMaxZone, "nUDSixAxisZMaxZone");
-            this.nUDSixAxisZMaxZone.Maximum = new decimal(new int[] {
+      resources.ApplyResources(this.nUDSixAxisZMaxZone, "nUDSixAxisZMaxZone");
+      this.nUDSixAxisZMaxZone.Maximum = new decimal(new int[] {
             1,
             0,
             0,
             0});
-            this.nUDSixAxisZMaxZone.Name = "nUDSixAxisZMaxZone";
-            this.nUDSixAxisZMaxZone.Value = new decimal(new int[] {
+      this.nUDSixAxisZMaxZone.Name = "nUDSixAxisZMaxZone";
+      this.nUDSixAxisZMaxZone.Value = new decimal(new int[] {
             1,
             0,
             0,
             0});
-            this.nUDSixAxisZMaxZone.ValueChanged += new System.EventHandler(this.nUDSixAxisZMaxZone_ValueChanged);
-            // 
-            // nUDSixAxisXMaxZone
-            // 
-            this.nUDSixAxisXMaxZone.DecimalPlaces = 2;
-            this.nUDSixAxisXMaxZone.Increment = new decimal(new int[] {
+      this.nUDSixAxisZMaxZone.ValueChanged += new System.EventHandler(this.nUDSixAxisZMaxZone_ValueChanged);
+      // 
+      // nUDSixAxisXMaxZone
+      // 
+      this.nUDSixAxisXMaxZone.DecimalPlaces = 2;
+      this.nUDSixAxisXMaxZone.Increment = new decimal(new int[] {
             1,
             0,
             0,
             65536});
-            resources.ApplyResources(this.nUDSixAxisXMaxZone, "nUDSixAxisXMaxZone");
-            this.nUDSixAxisXMaxZone.Maximum = new decimal(new int[] {
+      resources.ApplyResources(this.nUDSixAxisXMaxZone, "nUDSixAxisXMaxZone");
+      this.nUDSixAxisXMaxZone.Maximum = new decimal(new int[] {
             1,
             0,
             0,
             0});
-            this.nUDSixAxisXMaxZone.Name = "nUDSixAxisXMaxZone";
-            this.nUDSixAxisXMaxZone.Value = new decimal(new int[] {
+      this.nUDSixAxisXMaxZone.Name = "nUDSixAxisXMaxZone";
+      this.nUDSixAxisXMaxZone.Value = new decimal(new int[] {
             1,
             0,
             0,
             0});
-            this.nUDSixAxisXMaxZone.ValueChanged += new System.EventHandler(this.nUDSixAxisXMaxZone_ValueChanged);
-            // 
-            // label18
-            // 
-            resources.ApplyResources(this.label18, "label18");
-            this.label18.Name = "label18";
-            // 
-            // label17
-            // 
-            resources.ApplyResources(this.label17, "label17");
-            this.label17.Name = "label17";
-            // 
-            // nUDR2Maxzone
-            // 
-            this.nUDR2Maxzone.DecimalPlaces = 2;
-            this.nUDR2Maxzone.Increment = new decimal(new int[] {
+      this.nUDSixAxisXMaxZone.ValueChanged += new System.EventHandler(this.nUDSixAxisXMaxZone_ValueChanged);
+      // 
+      // label18
+      // 
+      resources.ApplyResources(this.label18, "label18");
+      this.label18.Name = "label18";
+      // 
+      // label17
+      // 
+      resources.ApplyResources(this.label17, "label17");
+      this.label17.Name = "label17";
+      // 
+      // nUDR2Maxzone
+      // 
+      this.nUDR2Maxzone.DecimalPlaces = 2;
+      this.nUDR2Maxzone.Increment = new decimal(new int[] {
             1,
             0,
             0,
             65536});
-            resources.ApplyResources(this.nUDR2Maxzone, "nUDR2Maxzone");
-            this.nUDR2Maxzone.Maximum = new decimal(new int[] {
+      resources.ApplyResources(this.nUDR2Maxzone, "nUDR2Maxzone");
+      this.nUDR2Maxzone.Maximum = new decimal(new int[] {
             1,
             0,
             0,
             0});
-            this.nUDR2Maxzone.Name = "nUDR2Maxzone";
-            this.nUDR2Maxzone.Value = new decimal(new int[] {
+      this.nUDR2Maxzone.Name = "nUDR2Maxzone";
+      this.nUDR2Maxzone.Value = new decimal(new int[] {
             1,
             0,
             0,
             0});
-            this.nUDR2Maxzone.ValueChanged += new System.EventHandler(this.nUDR2Maxzone_ValueChanged);
-            // 
-            // nUDL2Maxzone
-            // 
-            this.nUDL2Maxzone.DecimalPlaces = 2;
-            this.nUDL2Maxzone.Increment = new decimal(new int[] {
+      this.nUDR2Maxzone.ValueChanged += new System.EventHandler(this.nUDR2Maxzone_ValueChanged);
+      // 
+      // nUDL2Maxzone
+      // 
+      this.nUDL2Maxzone.DecimalPlaces = 2;
+      this.nUDL2Maxzone.Increment = new decimal(new int[] {
             1,
             0,
             0,
             65536});
-            resources.ApplyResources(this.nUDL2Maxzone, "nUDL2Maxzone");
-            this.nUDL2Maxzone.Maximum = new decimal(new int[] {
+      resources.ApplyResources(this.nUDL2Maxzone, "nUDL2Maxzone");
+      this.nUDL2Maxzone.Maximum = new decimal(new int[] {
             1,
             0,
             0,
             0});
-            this.nUDL2Maxzone.Name = "nUDL2Maxzone";
-            this.nUDL2Maxzone.Value = new decimal(new int[] {
+      this.nUDL2Maxzone.Name = "nUDL2Maxzone";
+      this.nUDL2Maxzone.Value = new decimal(new int[] {
             1,
             0,
             0,
             0});
-            this.nUDL2Maxzone.ValueChanged += new System.EventHandler(this.nUDL2Maxzone_ValueChanged);
-            // 
-            // label8
-            // 
-            resources.ApplyResources(this.label8, "label8");
-            this.label8.Name = "label8";
-            // 
-            // label7
-            // 
-            resources.ApplyResources(this.label7, "label7");
-            this.label7.Name = "label7";
-            // 
-            // nUDRSMaxZone
-            // 
-            this.nUDRSMaxZone.DecimalPlaces = 2;
-            this.nUDRSMaxZone.Increment = new decimal(new int[] {
+      this.nUDL2Maxzone.ValueChanged += new System.EventHandler(this.nUDL2Maxzone_ValueChanged);
+      // 
+      // label8
+      // 
+      resources.ApplyResources(this.label8, "label8");
+      this.label8.Name = "label8";
+      // 
+      // label7
+      // 
+      resources.ApplyResources(this.label7, "label7");
+      this.label7.Name = "label7";
+      // 
+      // nUDRSMaxZone
+      // 
+      this.nUDRSMaxZone.DecimalPlaces = 2;
+      this.nUDRSMaxZone.Increment = new decimal(new int[] {
             1,
             0,
             0,
             65536});
-            resources.ApplyResources(this.nUDRSMaxZone, "nUDRSMaxZone");
-            this.nUDRSMaxZone.Maximum = new decimal(new int[] {
+      resources.ApplyResources(this.nUDRSMaxZone, "nUDRSMaxZone");
+      this.nUDRSMaxZone.Maximum = new decimal(new int[] {
             1,
             0,
             0,
             0});
-            this.nUDRSMaxZone.Name = "nUDRSMaxZone";
-            this.nUDRSMaxZone.Value = new decimal(new int[] {
+      this.nUDRSMaxZone.Name = "nUDRSMaxZone";
+      this.nUDRSMaxZone.Value = new decimal(new int[] {
             1,
             0,
             0,
             0});
-            this.nUDRSMaxZone.ValueChanged += new System.EventHandler(this.nUDRSMaxZone_ValueChanged);
-            // 
-            // label6
-            // 
-            resources.ApplyResources(this.label6, "label6");
-            this.label6.Name = "label6";
-            // 
-            // nUDLSMaxZone
-            // 
-            this.nUDLSMaxZone.DecimalPlaces = 2;
-            this.nUDLSMaxZone.Increment = new decimal(new int[] {
+      this.nUDRSMaxZone.ValueChanged += new System.EventHandler(this.nUDRSMaxZone_ValueChanged);
+      // 
+      // label6
+      // 
+      resources.ApplyResources(this.label6, "label6");
+      this.label6.Name = "label6";
+      // 
+      // nUDLSMaxZone
+      // 
+      this.nUDLSMaxZone.DecimalPlaces = 2;
+      this.nUDLSMaxZone.Increment = new decimal(new int[] {
             1,
             0,
             0,
             65536});
-            resources.ApplyResources(this.nUDLSMaxZone, "nUDLSMaxZone");
-            this.nUDLSMaxZone.Maximum = new decimal(new int[] {
+      resources.ApplyResources(this.nUDLSMaxZone, "nUDLSMaxZone");
+      this.nUDLSMaxZone.Maximum = new decimal(new int[] {
             1,
             0,
             0,
             0});
-            this.nUDLSMaxZone.Name = "nUDLSMaxZone";
-            this.nUDLSMaxZone.Value = new decimal(new int[] {
+      this.nUDLSMaxZone.Name = "nUDLSMaxZone";
+      this.nUDLSMaxZone.Value = new decimal(new int[] {
             1,
             0,
             0,
             0});
-            this.nUDLSMaxZone.ValueChanged += new System.EventHandler(this.nUDLSMaxZone_ValueChanged);
-            // 
-            // label5
-            // 
-            resources.ApplyResources(this.label5, "label5");
-            this.label5.Name = "label5";
-            // 
-            // squStickTabPage
-            // 
-            this.squStickTabPage.Controls.Add(this.rsSquStickCk);
-            this.squStickTabPage.Controls.Add(this.lsSquStickCk);
-            resources.ApplyResources(this.squStickTabPage, "squStickTabPage");
-            this.squStickTabPage.Name = "squStickTabPage";
-            this.squStickTabPage.UseVisualStyleBackColor = true;
-            // 
-            // rsSquStickCk
-            // 
-            resources.ApplyResources(this.rsSquStickCk, "rsSquStickCk");
-            this.rsSquStickCk.Name = "rsSquStickCk";
-            this.rsSquStickCk.UseVisualStyleBackColor = true;
-            this.rsSquStickCk.Click += new System.EventHandler(this.rsSquStickCk_Click);
-            // 
-            // lsSquStickCk
-            // 
-            resources.ApplyResources(this.lsSquStickCk, "lsSquStickCk");
-            this.lsSquStickCk.Name = "lsSquStickCk";
-            this.lsSquStickCk.UseVisualStyleBackColor = true;
-            this.lsSquStickCk.Click += new System.EventHandler(this.lsSquStickCk_Click);
-            // 
-            // tPOutCurve
-            // 
-            this.tPOutCurve.BackColor = System.Drawing.SystemColors.Control;
-            this.tPOutCurve.Controls.Add(this.cBSixaxisZOutputCurve);
-            this.tPOutCurve.Controls.Add(this.cBSixaxisXOutputCurve);
-            this.tPOutCurve.Controls.Add(this.label24);
-            this.tPOutCurve.Controls.Add(this.label23);
-            this.tPOutCurve.Controls.Add(this.cBR2OutputCurve);
-            this.tPOutCurve.Controls.Add(this.cBL2OutputCurve);
-            this.tPOutCurve.Controls.Add(this.label22);
-            this.tPOutCurve.Controls.Add(this.label21);
-            this.tPOutCurve.Controls.Add(this.rsOutCurveComboBox);
-            this.tPOutCurve.Controls.Add(this.lsOutCurveComboBox);
-            this.tPOutCurve.Controls.Add(this.label10);
-            this.tPOutCurve.Controls.Add(this.label9);
-            resources.ApplyResources(this.tPOutCurve, "tPOutCurve");
-            this.tPOutCurve.Name = "tPOutCurve";
-            // 
-            // cBSixaxisZOutputCurve
-            // 
-            this.cBSixaxisZOutputCurve.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cBSixaxisZOutputCurve.DropDownWidth = 70;
-            this.cBSixaxisZOutputCurve.FormattingEnabled = true;
-            this.cBSixaxisZOutputCurve.Items.AddRange(new object[] {
+      this.nUDLSMaxZone.ValueChanged += new System.EventHandler(this.nUDLSMaxZone_ValueChanged);
+      // 
+      // label5
+      // 
+      resources.ApplyResources(this.label5, "label5");
+      this.label5.Name = "label5";
+      // 
+      // squStickTabPage
+      // 
+      this.squStickTabPage.Controls.Add(this.RoundnessNUpDown);
+      this.squStickTabPage.Controls.Add(this.label28);
+      this.squStickTabPage.Controls.Add(this.rsSquStickCk);
+      this.squStickTabPage.Controls.Add(this.lsSquStickCk);
+      resources.ApplyResources(this.squStickTabPage, "squStickTabPage");
+      this.squStickTabPage.Name = "squStickTabPage";
+      this.squStickTabPage.UseVisualStyleBackColor = true;
+      // 
+      // RoundnessNUpDown
+      // 
+      this.RoundnessNUpDown.DecimalPlaces = 1;
+      this.RoundnessNUpDown.Increment = new decimal(new int[] {
+            1,
+            0,
+            0,
+            65536});
+      resources.ApplyResources(this.RoundnessNUpDown, "RoundnessNUpDown");
+      this.RoundnessNUpDown.Maximum = new decimal(new int[] {
+            5,
+            0,
+            0,
+            0});
+      this.RoundnessNUpDown.Name = "RoundnessNUpDown";
+      this.RoundnessNUpDown.ValueChanged += new System.EventHandler(this.RoundnessNUpDown_ValueChanged);
+      // 
+      // label28
+      // 
+      resources.ApplyResources(this.label28, "label28");
+      this.label28.Name = "label28";
+      // 
+      // rsSquStickCk
+      // 
+      resources.ApplyResources(this.rsSquStickCk, "rsSquStickCk");
+      this.rsSquStickCk.Name = "rsSquStickCk";
+      this.rsSquStickCk.UseVisualStyleBackColor = true;
+      this.rsSquStickCk.Click += new System.EventHandler(this.rsSquStickCk_Click);
+      // 
+      // lsSquStickCk
+      // 
+      resources.ApplyResources(this.lsSquStickCk, "lsSquStickCk");
+      this.lsSquStickCk.Name = "lsSquStickCk";
+      this.lsSquStickCk.UseVisualStyleBackColor = true;
+      this.lsSquStickCk.Click += new System.EventHandler(this.lsSquStickCk_Click);
+      // 
+      // tPOutCurve
+      // 
+      this.tPOutCurve.BackColor = System.Drawing.SystemColors.Control;
+      this.tPOutCurve.Controls.Add(this.cBSixaxisZOutputCurve);
+      this.tPOutCurve.Controls.Add(this.cBSixaxisXOutputCurve);
+      this.tPOutCurve.Controls.Add(this.label24);
+      this.tPOutCurve.Controls.Add(this.label23);
+      this.tPOutCurve.Controls.Add(this.cBR2OutputCurve);
+      this.tPOutCurve.Controls.Add(this.cBL2OutputCurve);
+      this.tPOutCurve.Controls.Add(this.label22);
+      this.tPOutCurve.Controls.Add(this.label21);
+      this.tPOutCurve.Controls.Add(this.rsOutCurveComboBox);
+      this.tPOutCurve.Controls.Add(this.lsOutCurveComboBox);
+      this.tPOutCurve.Controls.Add(this.label10);
+      this.tPOutCurve.Controls.Add(this.label9);
+      resources.ApplyResources(this.tPOutCurve, "tPOutCurve");
+      this.tPOutCurve.Name = "tPOutCurve";
+      // 
+      // cBSixaxisZOutputCurve
+      // 
+      this.cBSixaxisZOutputCurve.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+      this.cBSixaxisZOutputCurve.DropDownWidth = 70;
+      this.cBSixaxisZOutputCurve.FormattingEnabled = true;
+      this.cBSixaxisZOutputCurve.Items.AddRange(new object[] {
             resources.GetString("cBSixaxisZOutputCurve.Items"),
             resources.GetString("cBSixaxisZOutputCurve.Items1"),
             resources.GetString("cBSixaxisZOutputCurve.Items2"),
             resources.GetString("cBSixaxisZOutputCurve.Items3"),
             resources.GetString("cBSixaxisZOutputCurve.Items4")});
-            resources.ApplyResources(this.cBSixaxisZOutputCurve, "cBSixaxisZOutputCurve");
-            this.cBSixaxisZOutputCurve.Name = "cBSixaxisZOutputCurve";
-            this.cBSixaxisZOutputCurve.SelectedIndexChanged += new System.EventHandler(this.cBSixaxisZOutputCurve_SelectedIndexChanged);
-            // 
-            // cBSixaxisXOutputCurve
-            // 
-            this.cBSixaxisXOutputCurve.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cBSixaxisXOutputCurve.DropDownWidth = 70;
-            this.cBSixaxisXOutputCurve.FormattingEnabled = true;
-            this.cBSixaxisXOutputCurve.Items.AddRange(new object[] {
+      resources.ApplyResources(this.cBSixaxisZOutputCurve, "cBSixaxisZOutputCurve");
+      this.cBSixaxisZOutputCurve.Name = "cBSixaxisZOutputCurve";
+      this.cBSixaxisZOutputCurve.SelectedIndexChanged += new System.EventHandler(this.cBSixaxisZOutputCurve_SelectedIndexChanged);
+      // 
+      // cBSixaxisXOutputCurve
+      // 
+      this.cBSixaxisXOutputCurve.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+      this.cBSixaxisXOutputCurve.DropDownWidth = 70;
+      this.cBSixaxisXOutputCurve.FormattingEnabled = true;
+      this.cBSixaxisXOutputCurve.Items.AddRange(new object[] {
             resources.GetString("cBSixaxisXOutputCurve.Items"),
             resources.GetString("cBSixaxisXOutputCurve.Items1"),
             resources.GetString("cBSixaxisXOutputCurve.Items2"),
             resources.GetString("cBSixaxisXOutputCurve.Items3"),
             resources.GetString("cBSixaxisXOutputCurve.Items4")});
-            resources.ApplyResources(this.cBSixaxisXOutputCurve, "cBSixaxisXOutputCurve");
-            this.cBSixaxisXOutputCurve.Name = "cBSixaxisXOutputCurve";
-            this.cBSixaxisXOutputCurve.SelectedIndexChanged += new System.EventHandler(this.cBSixaxisXOutputCurve_SelectedIndexChanged);
-            // 
-            // label24
-            // 
-            resources.ApplyResources(this.label24, "label24");
-            this.label24.Name = "label24";
-            // 
-            // label23
-            // 
-            resources.ApplyResources(this.label23, "label23");
-            this.label23.Name = "label23";
-            // 
-            // cBR2OutputCurve
-            // 
-            this.cBR2OutputCurve.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cBR2OutputCurve.DropDownWidth = 70;
-            this.cBR2OutputCurve.FormattingEnabled = true;
-            this.cBR2OutputCurve.Items.AddRange(new object[] {
+      resources.ApplyResources(this.cBSixaxisXOutputCurve, "cBSixaxisXOutputCurve");
+      this.cBSixaxisXOutputCurve.Name = "cBSixaxisXOutputCurve";
+      this.cBSixaxisXOutputCurve.SelectedIndexChanged += new System.EventHandler(this.cBSixaxisXOutputCurve_SelectedIndexChanged);
+      // 
+      // label24
+      // 
+      resources.ApplyResources(this.label24, "label24");
+      this.label24.Name = "label24";
+      // 
+      // label23
+      // 
+      resources.ApplyResources(this.label23, "label23");
+      this.label23.Name = "label23";
+      // 
+      // cBR2OutputCurve
+      // 
+      this.cBR2OutputCurve.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+      this.cBR2OutputCurve.DropDownWidth = 70;
+      this.cBR2OutputCurve.FormattingEnabled = true;
+      this.cBR2OutputCurve.Items.AddRange(new object[] {
             resources.GetString("cBR2OutputCurve.Items"),
             resources.GetString("cBR2OutputCurve.Items1"),
             resources.GetString("cBR2OutputCurve.Items2"),
             resources.GetString("cBR2OutputCurve.Items3"),
             resources.GetString("cBR2OutputCurve.Items4")});
-            resources.ApplyResources(this.cBR2OutputCurve, "cBR2OutputCurve");
-            this.cBR2OutputCurve.Name = "cBR2OutputCurve";
-            this.cBR2OutputCurve.SelectedIndexChanged += new System.EventHandler(this.cBR2OutputCurve_SelectedIndexChanged);
-            // 
-            // cBL2OutputCurve
-            // 
-            this.cBL2OutputCurve.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cBL2OutputCurve.DropDownWidth = 70;
-            this.cBL2OutputCurve.FormattingEnabled = true;
-            this.cBL2OutputCurve.Items.AddRange(new object[] {
+      resources.ApplyResources(this.cBR2OutputCurve, "cBR2OutputCurve");
+      this.cBR2OutputCurve.Name = "cBR2OutputCurve";
+      this.cBR2OutputCurve.SelectedIndexChanged += new System.EventHandler(this.cBR2OutputCurve_SelectedIndexChanged);
+      // 
+      // cBL2OutputCurve
+      // 
+      this.cBL2OutputCurve.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+      this.cBL2OutputCurve.DropDownWidth = 70;
+      this.cBL2OutputCurve.FormattingEnabled = true;
+      this.cBL2OutputCurve.Items.AddRange(new object[] {
             resources.GetString("cBL2OutputCurve.Items"),
             resources.GetString("cBL2OutputCurve.Items1"),
             resources.GetString("cBL2OutputCurve.Items2"),
             resources.GetString("cBL2OutputCurve.Items3"),
             resources.GetString("cBL2OutputCurve.Items4")});
-            resources.ApplyResources(this.cBL2OutputCurve, "cBL2OutputCurve");
-            this.cBL2OutputCurve.Name = "cBL2OutputCurve";
-            this.cBL2OutputCurve.SelectedIndexChanged += new System.EventHandler(this.cBL2OutputCurve_SelectedIndexChanged);
-            // 
-            // label22
-            // 
-            resources.ApplyResources(this.label22, "label22");
-            this.label22.Name = "label22";
-            // 
-            // label21
-            // 
-            resources.ApplyResources(this.label21, "label21");
-            this.label21.Name = "label21";
-            // 
-            // rsOutCurveComboBox
-            // 
-            this.rsOutCurveComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.rsOutCurveComboBox.DropDownWidth = 120;
-            this.rsOutCurveComboBox.FormattingEnabled = true;
-            this.rsOutCurveComboBox.Items.AddRange(new object[] {
+      resources.ApplyResources(this.cBL2OutputCurve, "cBL2OutputCurve");
+      this.cBL2OutputCurve.Name = "cBL2OutputCurve";
+      this.cBL2OutputCurve.SelectedIndexChanged += new System.EventHandler(this.cBL2OutputCurve_SelectedIndexChanged);
+      // 
+      // label22
+      // 
+      resources.ApplyResources(this.label22, "label22");
+      this.label22.Name = "label22";
+      // 
+      // label21
+      // 
+      resources.ApplyResources(this.label21, "label21");
+      this.label21.Name = "label21";
+      // 
+      // rsOutCurveComboBox
+      // 
+      this.rsOutCurveComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+      this.rsOutCurveComboBox.DropDownWidth = 120;
+      this.rsOutCurveComboBox.FormattingEnabled = true;
+      this.rsOutCurveComboBox.Items.AddRange(new object[] {
             resources.GetString("rsOutCurveComboBox.Items"),
             resources.GetString("rsOutCurveComboBox.Items1"),
             resources.GetString("rsOutCurveComboBox.Items2"),
             resources.GetString("rsOutCurveComboBox.Items3"),
             resources.GetString("rsOutCurveComboBox.Items4"),
             resources.GetString("rsOutCurveComboBox.Items5")});
-            resources.ApplyResources(this.rsOutCurveComboBox, "rsOutCurveComboBox");
-            this.rsOutCurveComboBox.Name = "rsOutCurveComboBox";
-            this.rsOutCurveComboBox.SelectedIndexChanged += new System.EventHandler(this.rsOutCurveComboBox_SelectedIndexChanged);
-            // 
-            // lsOutCurveComboBox
-            // 
-            this.lsOutCurveComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.lsOutCurveComboBox.DropDownWidth = 120;
-            this.lsOutCurveComboBox.FormattingEnabled = true;
-            this.lsOutCurveComboBox.Items.AddRange(new object[] {
+      resources.ApplyResources(this.rsOutCurveComboBox, "rsOutCurveComboBox");
+      this.rsOutCurveComboBox.Name = "rsOutCurveComboBox";
+      this.rsOutCurveComboBox.SelectedIndexChanged += new System.EventHandler(this.rsOutCurveComboBox_SelectedIndexChanged);
+      // 
+      // lsOutCurveComboBox
+      // 
+      this.lsOutCurveComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+      this.lsOutCurveComboBox.DropDownWidth = 120;
+      this.lsOutCurveComboBox.FormattingEnabled = true;
+      this.lsOutCurveComboBox.Items.AddRange(new object[] {
             resources.GetString("lsOutCurveComboBox.Items"),
             resources.GetString("lsOutCurveComboBox.Items1"),
             resources.GetString("lsOutCurveComboBox.Items2"),
             resources.GetString("lsOutCurveComboBox.Items3"),
             resources.GetString("lsOutCurveComboBox.Items4"),
             resources.GetString("lsOutCurveComboBox.Items5")});
-            resources.ApplyResources(this.lsOutCurveComboBox, "lsOutCurveComboBox");
-            this.lsOutCurveComboBox.Name = "lsOutCurveComboBox";
-            this.lsOutCurveComboBox.SelectedIndexChanged += new System.EventHandler(this.lsOutCurveComboBox_SelectedIndexChanged);
-            // 
-            // label10
-            // 
-            resources.ApplyResources(this.label10, "label10");
-            this.label10.Name = "label10";
-            // 
-            // label9
-            // 
-            resources.ApplyResources(this.label9, "label9");
-            this.label9.Name = "label9";
-            // 
-            // tPCurve
-            // 
-            this.tPCurve.BackColor = System.Drawing.SystemColors.Control;
-            this.tPCurve.Controls.Add(this.nUDLSCurve);
-            this.tPCurve.Controls.Add(this.nUDRSCurve);
-            this.tPCurve.Controls.Add(this.lbRSCurve);
-            this.tPCurve.Controls.Add(this.lbRSCurvePercent);
-            this.tPCurve.Controls.Add(this.lbLSCurvePercent);
-            this.tPCurve.Controls.Add(this.lbLSCurve);
-            resources.ApplyResources(this.tPCurve, "tPCurve");
-            this.tPCurve.Name = "tPCurve";
-            // 
-            // nUDLSCurve
-            // 
-            this.nUDLSCurve.Increment = new decimal(new int[] {
+      resources.ApplyResources(this.lsOutCurveComboBox, "lsOutCurveComboBox");
+      this.lsOutCurveComboBox.Name = "lsOutCurveComboBox";
+      this.lsOutCurveComboBox.SelectedIndexChanged += new System.EventHandler(this.lsOutCurveComboBox_SelectedIndexChanged);
+      // 
+      // label10
+      // 
+      resources.ApplyResources(this.label10, "label10");
+      this.label10.Name = "label10";
+      // 
+      // label9
+      // 
+      resources.ApplyResources(this.label9, "label9");
+      this.label9.Name = "label9";
+      // 
+      // tPCurve
+      // 
+      this.tPCurve.BackColor = System.Drawing.SystemColors.Control;
+      this.tPCurve.Controls.Add(this.nUDLSCurve);
+      this.tPCurve.Controls.Add(this.nUDRSCurve);
+      this.tPCurve.Controls.Add(this.lbRSCurve);
+      this.tPCurve.Controls.Add(this.lbRSCurvePercent);
+      this.tPCurve.Controls.Add(this.lbLSCurvePercent);
+      this.tPCurve.Controls.Add(this.lbLSCurve);
+      resources.ApplyResources(this.tPCurve, "tPCurve");
+      this.tPCurve.Name = "tPCurve";
+      // 
+      // nUDLSCurve
+      // 
+      this.nUDLSCurve.Increment = new decimal(new int[] {
             10,
             0,
             0,
             0});
-            resources.ApplyResources(this.nUDLSCurve, "nUDLSCurve");
-            this.nUDLSCurve.Name = "nUDLSCurve";
-            this.nUDLSCurve.ValueChanged += new System.EventHandler(this.nUDLSCurve_ValueChanged);
-            // 
-            // nUDRSCurve
-            // 
-            this.nUDRSCurve.Increment = new decimal(new int[] {
+      resources.ApplyResources(this.nUDLSCurve, "nUDLSCurve");
+      this.nUDLSCurve.Name = "nUDLSCurve";
+      this.nUDLSCurve.ValueChanged += new System.EventHandler(this.nUDLSCurve_ValueChanged);
+      // 
+      // nUDRSCurve
+      // 
+      this.nUDRSCurve.Increment = new decimal(new int[] {
             10,
             0,
             0,
             0});
-            resources.ApplyResources(this.nUDRSCurve, "nUDRSCurve");
-            this.nUDRSCurve.Name = "nUDRSCurve";
-            this.nUDRSCurve.ValueChanged += new System.EventHandler(this.nUDRSCurve_ValueChanged);
-            // 
-            // lbRSCurve
-            // 
-            resources.ApplyResources(this.lbRSCurve, "lbRSCurve");
-            this.lbRSCurve.Name = "lbRSCurve";
-            // 
-            // lbRSCurvePercent
-            // 
-            resources.ApplyResources(this.lbRSCurvePercent, "lbRSCurvePercent");
-            this.lbRSCurvePercent.Name = "lbRSCurvePercent";
-            // 
-            // lbLSCurvePercent
-            // 
-            resources.ApplyResources(this.lbLSCurvePercent, "lbLSCurvePercent");
-            this.lbLSCurvePercent.Name = "lbLSCurvePercent";
-            // 
-            // lbLSCurve
-            // 
-            resources.ApplyResources(this.lbLSCurve, "lbLSCurve");
-            this.lbLSCurve.Name = "lbLSCurve";
-            // 
-            // tpRotation
-            // 
-            this.tpRotation.BackColor = System.Drawing.SystemColors.Control;
-            this.tpRotation.Controls.Add(this.nUDRSRotation);
-            this.tpRotation.Controls.Add(this.label14);
-            this.tpRotation.Controls.Add(this.nUDLSRotation);
-            this.tpRotation.Controls.Add(this.label13);
-            resources.ApplyResources(this.tpRotation, "tpRotation");
-            this.tpRotation.Name = "tpRotation";
-            // 
-            // nUDRSRotation
-            // 
-            resources.ApplyResources(this.nUDRSRotation, "nUDRSRotation");
-            this.nUDRSRotation.Maximum = new decimal(new int[] {
+      resources.ApplyResources(this.nUDRSCurve, "nUDRSCurve");
+      this.nUDRSCurve.Name = "nUDRSCurve";
+      this.nUDRSCurve.ValueChanged += new System.EventHandler(this.nUDRSCurve_ValueChanged);
+      // 
+      // lbRSCurve
+      // 
+      resources.ApplyResources(this.lbRSCurve, "lbRSCurve");
+      this.lbRSCurve.Name = "lbRSCurve";
+      // 
+      // lbRSCurvePercent
+      // 
+      resources.ApplyResources(this.lbRSCurvePercent, "lbRSCurvePercent");
+      this.lbRSCurvePercent.Name = "lbRSCurvePercent";
+      // 
+      // lbLSCurvePercent
+      // 
+      resources.ApplyResources(this.lbLSCurvePercent, "lbLSCurvePercent");
+      this.lbLSCurvePercent.Name = "lbLSCurvePercent";
+      // 
+      // lbLSCurve
+      // 
+      resources.ApplyResources(this.lbLSCurve, "lbLSCurve");
+      this.lbLSCurve.Name = "lbLSCurve";
+      // 
+      // tpRotation
+      // 
+      this.tpRotation.BackColor = System.Drawing.SystemColors.Control;
+      this.tpRotation.Controls.Add(this.nUDRSRotation);
+      this.tpRotation.Controls.Add(this.label14);
+      this.tpRotation.Controls.Add(this.nUDLSRotation);
+      this.tpRotation.Controls.Add(this.label13);
+      resources.ApplyResources(this.tpRotation, "tpRotation");
+      this.tpRotation.Name = "tpRotation";
+      // 
+      // nUDRSRotation
+      // 
+      resources.ApplyResources(this.nUDRSRotation, "nUDRSRotation");
+      this.nUDRSRotation.Maximum = new decimal(new int[] {
             180,
             0,
             0,
             0});
-            this.nUDRSRotation.Minimum = new decimal(new int[] {
+      this.nUDRSRotation.Minimum = new decimal(new int[] {
             180,
             0,
             0,
             -2147483648});
-            this.nUDRSRotation.Name = "nUDRSRotation";
-            this.nUDRSRotation.ValueChanged += new System.EventHandler(this.nUDRSRotation_ValueChanged);
-            // 
-            // label14
-            // 
-            resources.ApplyResources(this.label14, "label14");
-            this.label14.Name = "label14";
-            // 
-            // nUDLSRotation
-            // 
-            resources.ApplyResources(this.nUDLSRotation, "nUDLSRotation");
-            this.nUDLSRotation.Maximum = new decimal(new int[] {
+      this.nUDRSRotation.Name = "nUDRSRotation";
+      this.nUDRSRotation.ValueChanged += new System.EventHandler(this.nUDRSRotation_ValueChanged);
+      // 
+      // label14
+      // 
+      resources.ApplyResources(this.label14, "label14");
+      this.label14.Name = "label14";
+      // 
+      // nUDLSRotation
+      // 
+      resources.ApplyResources(this.nUDLSRotation, "nUDLSRotation");
+      this.nUDLSRotation.Maximum = new decimal(new int[] {
             180,
             0,
             0,
             0});
-            this.nUDLSRotation.Minimum = new decimal(new int[] {
+      this.nUDLSRotation.Minimum = new decimal(new int[] {
             180,
             0,
             0,
             -2147483648});
-            this.nUDLSRotation.Name = "nUDLSRotation";
-            this.nUDLSRotation.ValueChanged += new System.EventHandler(this.nUDLSRotation_ValueChanged);
-            // 
-            // label13
-            // 
-            resources.ApplyResources(this.label13, "label13");
-            this.label13.Name = "label13";
-            // 
-            // fLPSettings
-            // 
-            resources.ApplyResources(this.fLPSettings, "fLPSettings");
-            this.fLPSettings.BackColor = System.Drawing.SystemColors.Control;
-            this.fLPSettings.Controls.Add(this.gBLightbar);
-            this.fLPSettings.Controls.Add(this.gBGyro);
-            this.fLPSettings.Controls.Add(this.gBRumble);
-            this.fLPSettings.Controls.Add(this.tCSens);
-            this.fLPSettings.Controls.Add(this.gBSensitivity);
-            this.fLPSettings.Controls.Add(this.gBOther);
-            this.fLPSettings.Name = "fLPSettings";
-            // 
-            // gBGyro
-            // 
-            this.gBGyro.BackColor = System.Drawing.SystemColors.Control;
-            this.gBGyro.Controls.Add(this.rBSAControls);
-            this.gBGyro.Controls.Add(this.rBSAMouse);
-            this.gBGyro.Controls.Add(this.fLPTiltControls);
-            this.gBGyro.Controls.Add(this.pnlSAMouse);
-            resources.ApplyResources(this.gBGyro, "gBGyro");
-            this.gBGyro.Name = "gBGyro";
-            this.gBGyro.TabStop = false;
-            // 
-            // rBSAControls
-            // 
-            resources.ApplyResources(this.rBSAControls, "rBSAControls");
-            this.rBSAControls.Name = "rBSAControls";
-            this.rBSAControls.TabStop = true;
-            this.rBSAControls.UseVisualStyleBackColor = true;
-            this.rBSAControls.CheckedChanged += new System.EventHandler(this.useSAforMouse_CheckedChanged);
-            // 
-            // rBSAMouse
-            // 
-            resources.ApplyResources(this.rBSAMouse, "rBSAMouse");
-            this.rBSAMouse.Name = "rBSAMouse";
-            this.rBSAMouse.TabStop = true;
-            this.rBSAMouse.UseVisualStyleBackColor = true;
-            this.rBSAMouse.CheckedChanged += new System.EventHandler(this.useSAforMouse_CheckedChanged);
-            // 
-            // pnlSAMouse
-            // 
-            this.pnlSAMouse.Controls.Add(this.toggleGyroMCb);
-            this.pnlSAMouse.Controls.Add(this.label27);
-            this.pnlSAMouse.Controls.Add(this.gyroMouseDzNUD);
-            this.pnlSAMouse.Controls.Add(this.label26);
-            this.pnlSAMouse.Controls.Add(this.triggerCondAndCombo);
-            this.pnlSAMouse.Controls.Add(this.cBGyroMouseXAxis);
-            this.pnlSAMouse.Controls.Add(this.label16);
-            this.pnlSAMouse.Controls.Add(this.lbGyroSmooth);
-            this.pnlSAMouse.Controls.Add(this.cBGyroSmooth);
-            this.pnlSAMouse.Controls.Add(this.lbSmoothWeight);
-            this.pnlSAMouse.Controls.Add(this.nUDGyroSmoothWeight);
-            this.pnlSAMouse.Controls.Add(this.label12);
-            this.pnlSAMouse.Controls.Add(this.nUDGyroMouseVertScale);
-            this.pnlSAMouse.Controls.Add(this.label11);
-            this.pnlSAMouse.Controls.Add(this.gyroTriggerBehavior);
-            this.pnlSAMouse.Controls.Add(this.cBGyroInvertY);
-            this.pnlSAMouse.Controls.Add(this.cBGyroInvertX);
-            this.pnlSAMouse.Controls.Add(this.lbGyroInvert);
-            this.pnlSAMouse.Controls.Add(this.lbGyroTriggers);
-            this.pnlSAMouse.Controls.Add(this.btnGyroTriggers);
-            this.pnlSAMouse.Controls.Add(this.nUDGyroSensitivity);
-            this.pnlSAMouse.Controls.Add(this.lbGyroSens);
-            resources.ApplyResources(this.pnlSAMouse, "pnlSAMouse");
-            this.pnlSAMouse.Name = "pnlSAMouse";
-            // 
-            // toggleGyroMCb
-            // 
-            resources.ApplyResources(this.toggleGyroMCb, "toggleGyroMCb");
-            this.toggleGyroMCb.Name = "toggleGyroMCb";
-            this.toggleGyroMCb.UseVisualStyleBackColor = true;
-            this.toggleGyroMCb.Click += new System.EventHandler(this.toggleGyroMCb_Click);
-            // 
-            // label27
-            // 
-            resources.ApplyResources(this.label27, "label27");
-            this.label27.Name = "label27";
-            // 
-            // gyroMouseDzNUD
-            // 
-            resources.ApplyResources(this.gyroMouseDzNUD, "gyroMouseDzNUD");
-            this.gyroMouseDzNUD.Name = "gyroMouseDzNUD";
-            this.gyroMouseDzNUD.Value = new decimal(new int[] {
+      this.nUDLSRotation.Name = "nUDLSRotation";
+      this.nUDLSRotation.ValueChanged += new System.EventHandler(this.nUDLSRotation_ValueChanged);
+      // 
+      // label13
+      // 
+      resources.ApplyResources(this.label13, "label13");
+      this.label13.Name = "label13";
+      // 
+      // fLPSettings
+      // 
+      resources.ApplyResources(this.fLPSettings, "fLPSettings");
+      this.fLPSettings.BackColor = System.Drawing.SystemColors.Control;
+      this.fLPSettings.Controls.Add(this.gBLightbar);
+      this.fLPSettings.Controls.Add(this.gBGyro);
+      this.fLPSettings.Controls.Add(this.gBRumble);
+      this.fLPSettings.Controls.Add(this.tCSens);
+      this.fLPSettings.Controls.Add(this.gBSensitivity);
+      this.fLPSettings.Controls.Add(this.gBOther);
+      this.fLPSettings.Name = "fLPSettings";
+      // 
+      // gBGyro
+      // 
+      this.gBGyro.BackColor = System.Drawing.SystemColors.Control;
+      this.gBGyro.Controls.Add(this.rBSAControls);
+      this.gBGyro.Controls.Add(this.rBSAMouse);
+      this.gBGyro.Controls.Add(this.fLPTiltControls);
+      this.gBGyro.Controls.Add(this.pnlSAMouse);
+      resources.ApplyResources(this.gBGyro, "gBGyro");
+      this.gBGyro.Name = "gBGyro";
+      this.gBGyro.TabStop = false;
+      // 
+      // rBSAControls
+      // 
+      resources.ApplyResources(this.rBSAControls, "rBSAControls");
+      this.rBSAControls.Name = "rBSAControls";
+      this.rBSAControls.TabStop = true;
+      this.rBSAControls.UseVisualStyleBackColor = true;
+      this.rBSAControls.CheckedChanged += new System.EventHandler(this.useSAforMouse_CheckedChanged);
+      // 
+      // rBSAMouse
+      // 
+      resources.ApplyResources(this.rBSAMouse, "rBSAMouse");
+      this.rBSAMouse.Name = "rBSAMouse";
+      this.rBSAMouse.TabStop = true;
+      this.rBSAMouse.UseVisualStyleBackColor = true;
+      this.rBSAMouse.CheckedChanged += new System.EventHandler(this.useSAforMouse_CheckedChanged);
+      // 
+      // pnlSAMouse
+      // 
+      this.pnlSAMouse.Controls.Add(this.toggleGyroMCb);
+      this.pnlSAMouse.Controls.Add(this.label27);
+      this.pnlSAMouse.Controls.Add(this.gyroMouseDzNUD);
+      this.pnlSAMouse.Controls.Add(this.label26);
+      this.pnlSAMouse.Controls.Add(this.triggerCondAndCombo);
+      this.pnlSAMouse.Controls.Add(this.cBGyroMouseXAxis);
+      this.pnlSAMouse.Controls.Add(this.label16);
+      this.pnlSAMouse.Controls.Add(this.lbGyroSmooth);
+      this.pnlSAMouse.Controls.Add(this.cBGyroSmooth);
+      this.pnlSAMouse.Controls.Add(this.lbSmoothWeight);
+      this.pnlSAMouse.Controls.Add(this.nUDGyroSmoothWeight);
+      this.pnlSAMouse.Controls.Add(this.label12);
+      this.pnlSAMouse.Controls.Add(this.nUDGyroMouseVertScale);
+      this.pnlSAMouse.Controls.Add(this.label11);
+      this.pnlSAMouse.Controls.Add(this.gyroTriggerBehavior);
+      this.pnlSAMouse.Controls.Add(this.cBGyroInvertY);
+      this.pnlSAMouse.Controls.Add(this.cBGyroInvertX);
+      this.pnlSAMouse.Controls.Add(this.lbGyroInvert);
+      this.pnlSAMouse.Controls.Add(this.lbGyroTriggers);
+      this.pnlSAMouse.Controls.Add(this.btnGyroTriggers);
+      this.pnlSAMouse.Controls.Add(this.nUDGyroSensitivity);
+      this.pnlSAMouse.Controls.Add(this.lbGyroSens);
+      resources.ApplyResources(this.pnlSAMouse, "pnlSAMouse");
+      this.pnlSAMouse.Name = "pnlSAMouse";
+      // 
+      // toggleGyroMCb
+      // 
+      resources.ApplyResources(this.toggleGyroMCb, "toggleGyroMCb");
+      this.toggleGyroMCb.Name = "toggleGyroMCb";
+      this.toggleGyroMCb.UseVisualStyleBackColor = true;
+      this.toggleGyroMCb.Click += new System.EventHandler(this.toggleGyroMCb_Click);
+      // 
+      // label27
+      // 
+      resources.ApplyResources(this.label27, "label27");
+      this.label27.Name = "label27";
+      // 
+      // gyroMouseDzNUD
+      // 
+      resources.ApplyResources(this.gyroMouseDzNUD, "gyroMouseDzNUD");
+      this.gyroMouseDzNUD.Name = "gyroMouseDzNUD";
+      this.gyroMouseDzNUD.Value = new decimal(new int[] {
             10,
             0,
             0,
             0});
-            this.gyroMouseDzNUD.ValueChanged += new System.EventHandler(this.gyroMouseDzNUD_ValueChanged);
-            // 
-            // label26
-            // 
-            resources.ApplyResources(this.label26, "label26");
-            this.label26.Name = "label26";
-            // 
-            // triggerCondAndCombo
-            // 
-            this.triggerCondAndCombo.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.triggerCondAndCombo.FormattingEnabled = true;
-            this.triggerCondAndCombo.Items.AddRange(new object[] {
+      this.gyroMouseDzNUD.ValueChanged += new System.EventHandler(this.gyroMouseDzNUD_ValueChanged);
+      // 
+      // label26
+      // 
+      resources.ApplyResources(this.label26, "label26");
+      this.label26.Name = "label26";
+      // 
+      // triggerCondAndCombo
+      // 
+      this.triggerCondAndCombo.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+      this.triggerCondAndCombo.FormattingEnabled = true;
+      this.triggerCondAndCombo.Items.AddRange(new object[] {
             resources.GetString("triggerCondAndCombo.Items"),
             resources.GetString("triggerCondAndCombo.Items1")});
-            resources.ApplyResources(this.triggerCondAndCombo, "triggerCondAndCombo");
-            this.triggerCondAndCombo.Name = "triggerCondAndCombo";
-            // 
-            // cBGyroMouseXAxis
-            // 
-            this.cBGyroMouseXAxis.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cBGyroMouseXAxis.FormattingEnabled = true;
-            this.cBGyroMouseXAxis.Items.AddRange(new object[] {
+      resources.ApplyResources(this.triggerCondAndCombo, "triggerCondAndCombo");
+      this.triggerCondAndCombo.Name = "triggerCondAndCombo";
+      // 
+      // cBGyroMouseXAxis
+      // 
+      this.cBGyroMouseXAxis.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+      this.cBGyroMouseXAxis.FormattingEnabled = true;
+      this.cBGyroMouseXAxis.Items.AddRange(new object[] {
             resources.GetString("cBGyroMouseXAxis.Items"),
             resources.GetString("cBGyroMouseXAxis.Items1")});
-            resources.ApplyResources(this.cBGyroMouseXAxis, "cBGyroMouseXAxis");
-            this.cBGyroMouseXAxis.Name = "cBGyroMouseXAxis";
-            this.cBGyroMouseXAxis.SelectedIndexChanged += new System.EventHandler(this.cBGyroMouseXAxis_SelectedIndexChanged);
-            // 
-            // label16
-            // 
-            resources.ApplyResources(this.label16, "label16");
-            this.label16.Name = "label16";
-            // 
-            // lbGyroSmooth
-            // 
-            resources.ApplyResources(this.lbGyroSmooth, "lbGyroSmooth");
-            this.lbGyroSmooth.Name = "lbGyroSmooth";
-            // 
-            // cBGyroSmooth
-            // 
-            resources.ApplyResources(this.cBGyroSmooth, "cBGyroSmooth");
-            this.cBGyroSmooth.Name = "cBGyroSmooth";
-            this.cBGyroSmooth.UseVisualStyleBackColor = true;
-            this.cBGyroSmooth.CheckedChanged += new System.EventHandler(this.cBGyroSmooth_CheckedChanged);
-            // 
-            // lbSmoothWeight
-            // 
-            resources.ApplyResources(this.lbSmoothWeight, "lbSmoothWeight");
-            this.lbSmoothWeight.Name = "lbSmoothWeight";
-            // 
-            // nUDGyroSmoothWeight
-            // 
-            this.nUDGyroSmoothWeight.DecimalPlaces = 3;
-            resources.ApplyResources(this.nUDGyroSmoothWeight, "nUDGyroSmoothWeight");
-            this.nUDGyroSmoothWeight.Maximum = new decimal(new int[] {
+      resources.ApplyResources(this.cBGyroMouseXAxis, "cBGyroMouseXAxis");
+      this.cBGyroMouseXAxis.Name = "cBGyroMouseXAxis";
+      this.cBGyroMouseXAxis.SelectedIndexChanged += new System.EventHandler(this.cBGyroMouseXAxis_SelectedIndexChanged);
+      // 
+      // label16
+      // 
+      resources.ApplyResources(this.label16, "label16");
+      this.label16.Name = "label16";
+      // 
+      // lbGyroSmooth
+      // 
+      resources.ApplyResources(this.lbGyroSmooth, "lbGyroSmooth");
+      this.lbGyroSmooth.Name = "lbGyroSmooth";
+      // 
+      // cBGyroSmooth
+      // 
+      resources.ApplyResources(this.cBGyroSmooth, "cBGyroSmooth");
+      this.cBGyroSmooth.Name = "cBGyroSmooth";
+      this.cBGyroSmooth.UseVisualStyleBackColor = true;
+      this.cBGyroSmooth.CheckedChanged += new System.EventHandler(this.cBGyroSmooth_CheckedChanged);
+      // 
+      // lbSmoothWeight
+      // 
+      resources.ApplyResources(this.lbSmoothWeight, "lbSmoothWeight");
+      this.lbSmoothWeight.Name = "lbSmoothWeight";
+      // 
+      // nUDGyroSmoothWeight
+      // 
+      this.nUDGyroSmoothWeight.DecimalPlaces = 3;
+      resources.ApplyResources(this.nUDGyroSmoothWeight, "nUDGyroSmoothWeight");
+      this.nUDGyroSmoothWeight.Maximum = new decimal(new int[] {
             1,
             0,
             0,
             0});
-            this.nUDGyroSmoothWeight.Name = "nUDGyroSmoothWeight";
-            this.nUDGyroSmoothWeight.Value = new decimal(new int[] {
+      this.nUDGyroSmoothWeight.Name = "nUDGyroSmoothWeight";
+      this.nUDGyroSmoothWeight.Value = new decimal(new int[] {
             5,
             0,
             0,
             65536});
-            this.nUDGyroSmoothWeight.ValueChanged += new System.EventHandler(this.nUDGyroSmoothWeight_ValueChanged);
-            // 
-            // label12
-            // 
-            resources.ApplyResources(this.label12, "label12");
-            this.label12.Name = "label12";
-            // 
-            // nUDGyroMouseVertScale
-            // 
-            this.nUDGyroMouseVertScale.Increment = new decimal(new int[] {
+      this.nUDGyroSmoothWeight.ValueChanged += new System.EventHandler(this.nUDGyroSmoothWeight_ValueChanged);
+      // 
+      // label12
+      // 
+      resources.ApplyResources(this.label12, "label12");
+      this.label12.Name = "label12";
+      // 
+      // nUDGyroMouseVertScale
+      // 
+      this.nUDGyroMouseVertScale.Increment = new decimal(new int[] {
             1,
             0,
             0,
             65536});
-            resources.ApplyResources(this.nUDGyroMouseVertScale, "nUDGyroMouseVertScale");
-            this.nUDGyroMouseVertScale.Maximum = new decimal(new int[] {
+      resources.ApplyResources(this.nUDGyroMouseVertScale, "nUDGyroMouseVertScale");
+      this.nUDGyroMouseVertScale.Maximum = new decimal(new int[] {
             1000,
             0,
             0,
             0});
-            this.nUDGyroMouseVertScale.Name = "nUDGyroMouseVertScale";
-            this.nUDGyroMouseVertScale.Value = new decimal(new int[] {
+      this.nUDGyroMouseVertScale.Name = "nUDGyroMouseVertScale";
+      this.nUDGyroMouseVertScale.Value = new decimal(new int[] {
             100,
             0,
             0,
             0});
-            this.nUDGyroMouseVertScale.ValueChanged += new System.EventHandler(this.nUDGyroMouseVertScale_ValueChanged);
-            // 
-            // label11
-            // 
-            resources.ApplyResources(this.label11, "label11");
-            this.label11.Name = "label11";
-            // 
-            // gyroTriggerBehavior
-            // 
-            resources.ApplyResources(this.gyroTriggerBehavior, "gyroTriggerBehavior");
-            this.gyroTriggerBehavior.Checked = true;
-            this.gyroTriggerBehavior.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.gyroTriggerBehavior.Name = "gyroTriggerBehavior";
-            this.gyroTriggerBehavior.UseVisualStyleBackColor = true;
-            this.gyroTriggerBehavior.CheckedChanged += new System.EventHandler(this.gyroTriggerBehavior_CheckedChanged);
-            // 
-            // cBGyroInvertY
-            // 
-            resources.ApplyResources(this.cBGyroInvertY, "cBGyroInvertY");
-            this.cBGyroInvertY.Name = "cBGyroInvertY";
-            this.cBGyroInvertY.UseVisualStyleBackColor = true;
-            this.cBGyroInvertY.CheckedChanged += new System.EventHandler(this.cBGyroInvert_CheckChanged);
-            // 
-            // cBGyroInvertX
-            // 
-            resources.ApplyResources(this.cBGyroInvertX, "cBGyroInvertX");
-            this.cBGyroInvertX.Name = "cBGyroInvertX";
-            this.cBGyroInvertX.UseVisualStyleBackColor = true;
-            this.cBGyroInvertX.CheckedChanged += new System.EventHandler(this.cBGyroInvert_CheckChanged);
-            // 
-            // lbGyroInvert
-            // 
-            resources.ApplyResources(this.lbGyroInvert, "lbGyroInvert");
-            this.lbGyroInvert.Name = "lbGyroInvert";
-            // 
-            // lbGyroTriggers
-            // 
-            resources.ApplyResources(this.lbGyroTriggers, "lbGyroTriggers");
-            this.lbGyroTriggers.Name = "lbGyroTriggers";
-            // 
-            // btnGyroTriggers
-            // 
-            resources.ApplyResources(this.btnGyroTriggers, "btnGyroTriggers");
-            this.btnGyroTriggers.Name = "btnGyroTriggers";
-            this.btnGyroTriggers.UseVisualStyleBackColor = true;
-            this.btnGyroTriggers.Click += new System.EventHandler(this.btnGyroTriggers_Click);
-            // 
-            // nUDGyroSensitivity
-            // 
-            resources.ApplyResources(this.nUDGyroSensitivity, "nUDGyroSensitivity");
-            this.nUDGyroSensitivity.Maximum = new decimal(new int[] {
+      this.nUDGyroMouseVertScale.ValueChanged += new System.EventHandler(this.nUDGyroMouseVertScale_ValueChanged);
+      // 
+      // label11
+      // 
+      resources.ApplyResources(this.label11, "label11");
+      this.label11.Name = "label11";
+      // 
+      // gyroTriggerBehavior
+      // 
+      resources.ApplyResources(this.gyroTriggerBehavior, "gyroTriggerBehavior");
+      this.gyroTriggerBehavior.Checked = true;
+      this.gyroTriggerBehavior.CheckState = System.Windows.Forms.CheckState.Checked;
+      this.gyroTriggerBehavior.Name = "gyroTriggerBehavior";
+      this.gyroTriggerBehavior.UseVisualStyleBackColor = true;
+      this.gyroTriggerBehavior.CheckedChanged += new System.EventHandler(this.gyroTriggerBehavior_CheckedChanged);
+      // 
+      // cBGyroInvertY
+      // 
+      resources.ApplyResources(this.cBGyroInvertY, "cBGyroInvertY");
+      this.cBGyroInvertY.Name = "cBGyroInvertY";
+      this.cBGyroInvertY.UseVisualStyleBackColor = true;
+      this.cBGyroInvertY.CheckedChanged += new System.EventHandler(this.cBGyroInvert_CheckChanged);
+      // 
+      // cBGyroInvertX
+      // 
+      resources.ApplyResources(this.cBGyroInvertX, "cBGyroInvertX");
+      this.cBGyroInvertX.Name = "cBGyroInvertX";
+      this.cBGyroInvertX.UseVisualStyleBackColor = true;
+      this.cBGyroInvertX.CheckedChanged += new System.EventHandler(this.cBGyroInvert_CheckChanged);
+      // 
+      // lbGyroInvert
+      // 
+      resources.ApplyResources(this.lbGyroInvert, "lbGyroInvert");
+      this.lbGyroInvert.Name = "lbGyroInvert";
+      // 
+      // lbGyroTriggers
+      // 
+      resources.ApplyResources(this.lbGyroTriggers, "lbGyroTriggers");
+      this.lbGyroTriggers.Name = "lbGyroTriggers";
+      // 
+      // btnGyroTriggers
+      // 
+      resources.ApplyResources(this.btnGyroTriggers, "btnGyroTriggers");
+      this.btnGyroTriggers.Name = "btnGyroTriggers";
+      this.btnGyroTriggers.UseVisualStyleBackColor = true;
+      this.btnGyroTriggers.Click += new System.EventHandler(this.btnGyroTriggers_Click);
+      // 
+      // nUDGyroSensitivity
+      // 
+      resources.ApplyResources(this.nUDGyroSensitivity, "nUDGyroSensitivity");
+      this.nUDGyroSensitivity.Maximum = new decimal(new int[] {
             300,
             0,
             0,
             0});
-            this.nUDGyroSensitivity.Name = "nUDGyroSensitivity";
-            this.nUDGyroSensitivity.Value = new decimal(new int[] {
+      this.nUDGyroSensitivity.Name = "nUDGyroSensitivity";
+      this.nUDGyroSensitivity.Value = new decimal(new int[] {
             100,
             0,
             0,
             0});
-            this.nUDGyroSensitivity.ValueChanged += new System.EventHandler(this.nUDGyroSensitivity_ValueChanged);
-            // 
-            // lbGyroSens
-            // 
-            resources.ApplyResources(this.lbGyroSens, "lbGyroSens");
-            this.lbGyroSens.Name = "lbGyroSens";
-            // 
-            // gBSensitivity
-            // 
-            this.gBSensitivity.BackColor = System.Drawing.SystemColors.Control;
-            this.gBSensitivity.Controls.Add(this.lbL2S);
-            this.gBSensitivity.Controls.Add(this.nUDL2S);
-            this.gBSensitivity.Controls.Add(this.nUDLSS);
-            this.gBSensitivity.Controls.Add(this.lbSixaxisXS);
-            this.gBSensitivity.Controls.Add(this.nUDR2S);
-            this.gBSensitivity.Controls.Add(this.lbSixaxisZS);
-            this.gBSensitivity.Controls.Add(this.nUDRSS);
-            this.gBSensitivity.Controls.Add(this.lbR2LS);
-            this.gBSensitivity.Controls.Add(this.nUDSXS);
-            this.gBSensitivity.Controls.Add(this.lbRSS);
-            this.gBSensitivity.Controls.Add(this.lbLSS);
-            this.gBSensitivity.Controls.Add(this.nUDSZS);
-            resources.ApplyResources(this.gBSensitivity, "gBSensitivity");
-            this.gBSensitivity.Name = "gBSensitivity";
-            this.gBSensitivity.TabStop = false;
-            // 
-            // lbL2S
-            // 
-            resources.ApplyResources(this.lbL2S, "lbL2S");
-            this.lbL2S.Name = "lbL2S";
-            // 
-            // nUDL2S
-            // 
-            this.nUDL2S.DecimalPlaces = 2;
-            this.nUDL2S.Increment = new decimal(new int[] {
+      this.nUDGyroSensitivity.ValueChanged += new System.EventHandler(this.nUDGyroSensitivity_ValueChanged);
+      // 
+      // lbGyroSens
+      // 
+      resources.ApplyResources(this.lbGyroSens, "lbGyroSens");
+      this.lbGyroSens.Name = "lbGyroSens";
+      // 
+      // gBSensitivity
+      // 
+      this.gBSensitivity.BackColor = System.Drawing.SystemColors.Control;
+      this.gBSensitivity.Controls.Add(this.lbL2S);
+      this.gBSensitivity.Controls.Add(this.nUDL2S);
+      this.gBSensitivity.Controls.Add(this.nUDLSS);
+      this.gBSensitivity.Controls.Add(this.lbSixaxisXS);
+      this.gBSensitivity.Controls.Add(this.nUDR2S);
+      this.gBSensitivity.Controls.Add(this.lbSixaxisZS);
+      this.gBSensitivity.Controls.Add(this.nUDRSS);
+      this.gBSensitivity.Controls.Add(this.lbR2LS);
+      this.gBSensitivity.Controls.Add(this.nUDSXS);
+      this.gBSensitivity.Controls.Add(this.lbRSS);
+      this.gBSensitivity.Controls.Add(this.lbLSS);
+      this.gBSensitivity.Controls.Add(this.nUDSZS);
+      resources.ApplyResources(this.gBSensitivity, "gBSensitivity");
+      this.gBSensitivity.Name = "gBSensitivity";
+      this.gBSensitivity.TabStop = false;
+      // 
+      // lbL2S
+      // 
+      resources.ApplyResources(this.lbL2S, "lbL2S");
+      this.lbL2S.Name = "lbL2S";
+      // 
+      // nUDL2S
+      // 
+      this.nUDL2S.DecimalPlaces = 2;
+      this.nUDL2S.Increment = new decimal(new int[] {
             1,
             0,
             0,
             65536});
-            resources.ApplyResources(this.nUDL2S, "nUDL2S");
-            this.nUDL2S.Maximum = new decimal(new int[] {
+      resources.ApplyResources(this.nUDL2S, "nUDL2S");
+      this.nUDL2S.Maximum = new decimal(new int[] {
             10,
             0,
             0,
             0});
-            this.nUDL2S.Minimum = new decimal(new int[] {
+      this.nUDL2S.Minimum = new decimal(new int[] {
             1,
             0,
             0,
             65536});
-            this.nUDL2S.Name = "nUDL2S";
-            this.nUDL2S.Value = new decimal(new int[] {
+      this.nUDL2S.Name = "nUDL2S";
+      this.nUDL2S.Value = new decimal(new int[] {
             1,
             0,
             0,
             0});
-            this.nUDL2S.ValueChanged += new System.EventHandler(this.nUDL2Sens_ValueChanged);
-            // 
-            // nUDLSS
-            // 
-            this.nUDLSS.DecimalPlaces = 2;
-            this.nUDLSS.Increment = new decimal(new int[] {
+      this.nUDL2S.ValueChanged += new System.EventHandler(this.nUDL2Sens_ValueChanged);
+      // 
+      // nUDLSS
+      // 
+      this.nUDLSS.DecimalPlaces = 2;
+      this.nUDLSS.Increment = new decimal(new int[] {
             1,
             0,
             0,
             65536});
-            resources.ApplyResources(this.nUDLSS, "nUDLSS");
-            this.nUDLSS.Maximum = new decimal(new int[] {
+      resources.ApplyResources(this.nUDLSS, "nUDLSS");
+      this.nUDLSS.Maximum = new decimal(new int[] {
             5,
             0,
             0,
             0});
-            this.nUDLSS.Minimum = new decimal(new int[] {
+      this.nUDLSS.Minimum = new decimal(new int[] {
             5,
             0,
             0,
             65536});
-            this.nUDLSS.Name = "nUDLSS";
-            this.nUDLSS.Value = new decimal(new int[] {
+      this.nUDLSS.Name = "nUDLSS";
+      this.nUDLSS.Value = new decimal(new int[] {
             1,
             0,
             0,
             0});
-            this.nUDLSS.ValueChanged += new System.EventHandler(this.nUDLSSens_ValueChanged);
-            // 
-            // lbSixaxisXS
-            // 
-            resources.ApplyResources(this.lbSixaxisXS, "lbSixaxisXS");
-            this.lbSixaxisXS.Name = "lbSixaxisXS";
-            // 
-            // nUDR2S
-            // 
-            this.nUDR2S.DecimalPlaces = 2;
-            this.nUDR2S.Increment = new decimal(new int[] {
+      this.nUDLSS.ValueChanged += new System.EventHandler(this.nUDLSSens_ValueChanged);
+      // 
+      // lbSixaxisXS
+      // 
+      resources.ApplyResources(this.lbSixaxisXS, "lbSixaxisXS");
+      this.lbSixaxisXS.Name = "lbSixaxisXS";
+      // 
+      // nUDR2S
+      // 
+      this.nUDR2S.DecimalPlaces = 2;
+      this.nUDR2S.Increment = new decimal(new int[] {
             1,
             0,
             0,
             65536});
-            resources.ApplyResources(this.nUDR2S, "nUDR2S");
-            this.nUDR2S.Maximum = new decimal(new int[] {
+      resources.ApplyResources(this.nUDR2S, "nUDR2S");
+      this.nUDR2S.Maximum = new decimal(new int[] {
             10,
             0,
             0,
             0});
-            this.nUDR2S.Minimum = new decimal(new int[] {
+      this.nUDR2S.Minimum = new decimal(new int[] {
             1,
             0,
             0,
             65536});
-            this.nUDR2S.Name = "nUDR2S";
-            this.nUDR2S.Value = new decimal(new int[] {
+      this.nUDR2S.Name = "nUDR2S";
+      this.nUDR2S.Value = new decimal(new int[] {
             1,
             0,
             0,
             0});
-            this.nUDR2S.ValueChanged += new System.EventHandler(this.nUDR2Sens_ValueChanged);
-            // 
-            // lbSixaxisZS
-            // 
-            resources.ApplyResources(this.lbSixaxisZS, "lbSixaxisZS");
-            this.lbSixaxisZS.Name = "lbSixaxisZS";
-            // 
-            // nUDRSS
-            // 
-            this.nUDRSS.DecimalPlaces = 2;
-            this.nUDRSS.Increment = new decimal(new int[] {
+      this.nUDR2S.ValueChanged += new System.EventHandler(this.nUDR2Sens_ValueChanged);
+      // 
+      // lbSixaxisZS
+      // 
+      resources.ApplyResources(this.lbSixaxisZS, "lbSixaxisZS");
+      this.lbSixaxisZS.Name = "lbSixaxisZS";
+      // 
+      // nUDRSS
+      // 
+      this.nUDRSS.DecimalPlaces = 2;
+      this.nUDRSS.Increment = new decimal(new int[] {
             1,
             0,
             0,
             65536});
-            resources.ApplyResources(this.nUDRSS, "nUDRSS");
-            this.nUDRSS.Maximum = new decimal(new int[] {
+      resources.ApplyResources(this.nUDRSS, "nUDRSS");
+      this.nUDRSS.Maximum = new decimal(new int[] {
             5,
             0,
             0,
             0});
-            this.nUDRSS.Minimum = new decimal(new int[] {
+      this.nUDRSS.Minimum = new decimal(new int[] {
             5,
             0,
             0,
             65536});
-            this.nUDRSS.Name = "nUDRSS";
-            this.nUDRSS.Value = new decimal(new int[] {
+      this.nUDRSS.Name = "nUDRSS";
+      this.nUDRSS.Value = new decimal(new int[] {
             1,
             0,
             0,
             0});
-            this.nUDRSS.ValueChanged += new System.EventHandler(this.nUDRSSens_ValueChanged);
-            // 
-            // lbR2LS
-            // 
-            resources.ApplyResources(this.lbR2LS, "lbR2LS");
-            this.lbR2LS.Name = "lbR2LS";
-            // 
-            // nUDSXS
-            // 
-            this.nUDSXS.DecimalPlaces = 2;
-            this.nUDSXS.Increment = new decimal(new int[] {
-            1,
-            0,
-            0,
-            65536});
-            resources.ApplyResources(this.nUDSXS, "nUDSXS");
-            this.nUDSXS.Maximum = new decimal(new int[] {
-            5,
-            0,
-            0,
-            0});
-            this.nUDSXS.Minimum = new decimal(new int[] {
-            5,
-            0,
-            0,
-            65536});
-            this.nUDSXS.Name = "nUDSXS";
-            this.nUDSXS.Value = new decimal(new int[] {
-            1,
-            0,
-            0,
-            0});
-            this.nUDSXS.ValueChanged += new System.EventHandler(this.nUDSXSens_ValueChanged);
-            // 
-            // lbRSS
-            // 
-            resources.ApplyResources(this.lbRSS, "lbRSS");
-            this.lbRSS.Name = "lbRSS";
-            // 
-            // lbLSS
-            // 
-            resources.ApplyResources(this.lbLSS, "lbLSS");
-            this.lbLSS.Name = "lbLSS";
-            // 
-            // nUDSZS
-            // 
-            this.nUDSZS.DecimalPlaces = 2;
-            this.nUDSZS.Increment = new decimal(new int[] {
+      this.nUDRSS.ValueChanged += new System.EventHandler(this.nUDRSSens_ValueChanged);
+      // 
+      // lbR2LS
+      // 
+      resources.ApplyResources(this.lbR2LS, "lbR2LS");
+      this.lbR2LS.Name = "lbR2LS";
+      // 
+      // nUDSXS
+      // 
+      this.nUDSXS.DecimalPlaces = 2;
+      this.nUDSXS.Increment = new decimal(new int[] {
             1,
             0,
             0,
             65536});
-            resources.ApplyResources(this.nUDSZS, "nUDSZS");
-            this.nUDSZS.Maximum = new decimal(new int[] {
+      resources.ApplyResources(this.nUDSXS, "nUDSXS");
+      this.nUDSXS.Maximum = new decimal(new int[] {
             5,
             0,
             0,
             0});
-            this.nUDSZS.Minimum = new decimal(new int[] {
+      this.nUDSXS.Minimum = new decimal(new int[] {
             5,
             0,
             0,
             65536});
-            this.nUDSZS.Name = "nUDSZS";
-            this.nUDSZS.Value = new decimal(new int[] {
+      this.nUDSXS.Name = "nUDSXS";
+      this.nUDSXS.Value = new decimal(new int[] {
             1,
             0,
             0,
             0});
-            this.nUDSZS.ValueChanged += new System.EventHandler(this.nUDSZSens_ValueChanged);
-            // 
-            // cMGyroTriggers
-            // 
-            this.cMGyroTriggers.BackColor = System.Drawing.SystemColors.Control;
-            this.cMGyroTriggers.ImageScalingSize = new System.Drawing.Size(20, 20);
-            this.cMGyroTriggers.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+      this.nUDSXS.ValueChanged += new System.EventHandler(this.nUDSXSens_ValueChanged);
+      // 
+      // lbRSS
+      // 
+      resources.ApplyResources(this.lbRSS, "lbRSS");
+      this.lbRSS.Name = "lbRSS";
+      // 
+      // lbLSS
+      // 
+      resources.ApplyResources(this.lbLSS, "lbLSS");
+      this.lbLSS.Name = "lbLSS";
+      // 
+      // nUDSZS
+      // 
+      this.nUDSZS.DecimalPlaces = 2;
+      this.nUDSZS.Increment = new decimal(new int[] {
+            1,
+            0,
+            0,
+            65536});
+      resources.ApplyResources(this.nUDSZS, "nUDSZS");
+      this.nUDSZS.Maximum = new decimal(new int[] {
+            5,
+            0,
+            0,
+            0});
+      this.nUDSZS.Minimum = new decimal(new int[] {
+            5,
+            0,
+            0,
+            65536});
+      this.nUDSZS.Name = "nUDSZS";
+      this.nUDSZS.Value = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
+      this.nUDSZS.ValueChanged += new System.EventHandler(this.nUDSZSens_ValueChanged);
+      // 
+      // cMGyroTriggers
+      // 
+      this.cMGyroTriggers.BackColor = System.Drawing.SystemColors.Control;
+      this.cMGyroTriggers.ImageScalingSize = new System.Drawing.Size(20, 20);
+      this.cMGyroTriggers.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.crossToolStripMenuItem,
             this.circleToolStripMenuItem,
             this.squareToolStripMenuItem,
@@ -3954,173 +3981,173 @@
             this.shareToolStripMenuItem,
             this.pSToolStripMenuItem,
             this.alwaysOnToolStripMenuItem});
-            this.cMGyroTriggers.Name = "cMGyroTriggers";
-            this.cMGyroTriggers.ShowCheckMargin = true;
-            this.cMGyroTriggers.ShowImageMargin = false;
-            resources.ApplyResources(this.cMGyroTriggers, "cMGyroTriggers");
-            // 
-            // crossToolStripMenuItem
-            // 
-            this.crossToolStripMenuItem.CheckOnClick = true;
-            this.crossToolStripMenuItem.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.crossToolStripMenuItem.Name = "crossToolStripMenuItem";
-            resources.ApplyResources(this.crossToolStripMenuItem, "crossToolStripMenuItem");
-            this.crossToolStripMenuItem.CheckedChanged += new System.EventHandler(this.SATrigger_CheckedChanged);
-            // 
-            // circleToolStripMenuItem
-            // 
-            this.circleToolStripMenuItem.CheckOnClick = true;
-            this.circleToolStripMenuItem.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.circleToolStripMenuItem.Name = "circleToolStripMenuItem";
-            resources.ApplyResources(this.circleToolStripMenuItem, "circleToolStripMenuItem");
-            this.circleToolStripMenuItem.CheckedChanged += new System.EventHandler(this.SATrigger_CheckedChanged);
-            // 
-            // squareToolStripMenuItem
-            // 
-            this.squareToolStripMenuItem.CheckOnClick = true;
-            this.squareToolStripMenuItem.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.squareToolStripMenuItem.Name = "squareToolStripMenuItem";
-            resources.ApplyResources(this.squareToolStripMenuItem, "squareToolStripMenuItem");
-            this.squareToolStripMenuItem.CheckedChanged += new System.EventHandler(this.SATrigger_CheckedChanged);
-            // 
-            // triangleToolStripMenuItem
-            // 
-            this.triangleToolStripMenuItem.CheckOnClick = true;
-            this.triangleToolStripMenuItem.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.triangleToolStripMenuItem.Name = "triangleToolStripMenuItem";
-            resources.ApplyResources(this.triangleToolStripMenuItem, "triangleToolStripMenuItem");
-            this.triangleToolStripMenuItem.CheckedChanged += new System.EventHandler(this.SATrigger_CheckedChanged);
-            // 
-            // l1ToolStripMenuItem
-            // 
-            this.l1ToolStripMenuItem.CheckOnClick = true;
-            this.l1ToolStripMenuItem.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.l1ToolStripMenuItem.Name = "l1ToolStripMenuItem";
-            resources.ApplyResources(this.l1ToolStripMenuItem, "l1ToolStripMenuItem");
-            this.l1ToolStripMenuItem.CheckedChanged += new System.EventHandler(this.SATrigger_CheckedChanged);
-            // 
-            // l2ToolStripMenuItem
-            // 
-            this.l2ToolStripMenuItem.CheckOnClick = true;
-            this.l2ToolStripMenuItem.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.l2ToolStripMenuItem.Name = "l2ToolStripMenuItem";
-            resources.ApplyResources(this.l2ToolStripMenuItem, "l2ToolStripMenuItem");
-            this.l2ToolStripMenuItem.CheckedChanged += new System.EventHandler(this.SATrigger_CheckedChanged);
-            // 
-            // r1ToolStripMenuItem
-            // 
-            this.r1ToolStripMenuItem.CheckOnClick = true;
-            this.r1ToolStripMenuItem.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.r1ToolStripMenuItem.Name = "r1ToolStripMenuItem";
-            resources.ApplyResources(this.r1ToolStripMenuItem, "r1ToolStripMenuItem");
-            this.r1ToolStripMenuItem.CheckedChanged += new System.EventHandler(this.SATrigger_CheckedChanged);
-            // 
-            // r2ToolStripMenuItem
-            // 
-            this.r2ToolStripMenuItem.CheckOnClick = true;
-            this.r2ToolStripMenuItem.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.r2ToolStripMenuItem.Name = "r2ToolStripMenuItem";
-            resources.ApplyResources(this.r2ToolStripMenuItem, "r2ToolStripMenuItem");
-            this.r2ToolStripMenuItem.CheckedChanged += new System.EventHandler(this.SATrigger_CheckedChanged);
-            // 
-            // onTouchpadToolStripMenuItem
-            // 
-            this.onTouchpadToolStripMenuItem.CheckOnClick = true;
-            this.onTouchpadToolStripMenuItem.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.onTouchpadToolStripMenuItem.Name = "onTouchpadToolStripMenuItem";
-            resources.ApplyResources(this.onTouchpadToolStripMenuItem, "onTouchpadToolStripMenuItem");
-            this.onTouchpadToolStripMenuItem.CheckedChanged += new System.EventHandler(this.SATrigger_CheckedChanged);
-            // 
-            // downToolStripMenuItem
-            // 
-            this.downToolStripMenuItem.CheckOnClick = true;
-            this.downToolStripMenuItem.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.downToolStripMenuItem.Name = "downToolStripMenuItem";
-            resources.ApplyResources(this.downToolStripMenuItem, "downToolStripMenuItem");
-            this.downToolStripMenuItem.CheckedChanged += new System.EventHandler(this.SATrigger_CheckedChanged);
-            // 
-            // leftToolStripMenuItem
-            // 
-            this.leftToolStripMenuItem.CheckOnClick = true;
-            this.leftToolStripMenuItem.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.leftToolStripMenuItem.Name = "leftToolStripMenuItem";
-            resources.ApplyResources(this.leftToolStripMenuItem, "leftToolStripMenuItem");
-            this.leftToolStripMenuItem.CheckedChanged += new System.EventHandler(this.SATrigger_CheckedChanged);
-            // 
-            // rightToolStripMenuItem
-            // 
-            this.rightToolStripMenuItem.CheckOnClick = true;
-            this.rightToolStripMenuItem.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.rightToolStripMenuItem.Name = "rightToolStripMenuItem";
-            resources.ApplyResources(this.rightToolStripMenuItem, "rightToolStripMenuItem");
-            this.rightToolStripMenuItem.CheckedChanged += new System.EventHandler(this.SATrigger_CheckedChanged);
-            // 
-            // l3ToolStripMenuItem
-            // 
-            this.l3ToolStripMenuItem.CheckOnClick = true;
-            this.l3ToolStripMenuItem.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.l3ToolStripMenuItem.Name = "l3ToolStripMenuItem";
-            resources.ApplyResources(this.l3ToolStripMenuItem, "l3ToolStripMenuItem");
-            this.l3ToolStripMenuItem.CheckedChanged += new System.EventHandler(this.SATrigger_CheckedChanged);
-            // 
-            // r3ToolStripMenuItem
-            // 
-            this.r3ToolStripMenuItem.CheckOnClick = true;
-            this.r3ToolStripMenuItem.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.r3ToolStripMenuItem.Name = "r3ToolStripMenuItem";
-            resources.ApplyResources(this.r3ToolStripMenuItem, "r3ToolStripMenuItem");
-            this.r3ToolStripMenuItem.CheckedChanged += new System.EventHandler(this.SATrigger_CheckedChanged);
-            // 
-            // fingerOnTouchpadToolStripMenuItem
-            // 
-            this.fingerOnTouchpadToolStripMenuItem.CheckOnClick = true;
-            this.fingerOnTouchpadToolStripMenuItem.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.fingerOnTouchpadToolStripMenuItem.Name = "fingerOnTouchpadToolStripMenuItem";
-            resources.ApplyResources(this.fingerOnTouchpadToolStripMenuItem, "fingerOnTouchpadToolStripMenuItem");
-            this.fingerOnTouchpadToolStripMenuItem.CheckedChanged += new System.EventHandler(this.SATrigger_CheckedChanged);
-            // 
-            // fingersOnTouchpadToolStripMenuItem
-            // 
-            this.fingersOnTouchpadToolStripMenuItem.CheckOnClick = true;
-            this.fingersOnTouchpadToolStripMenuItem.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.fingersOnTouchpadToolStripMenuItem.Name = "fingersOnTouchpadToolStripMenuItem";
-            resources.ApplyResources(this.fingersOnTouchpadToolStripMenuItem, "fingersOnTouchpadToolStripMenuItem");
-            this.fingersOnTouchpadToolStripMenuItem.CheckedChanged += new System.EventHandler(this.SATrigger_CheckedChanged);
-            // 
-            // optionsToolStripMenuItem
-            // 
-            this.optionsToolStripMenuItem.CheckOnClick = true;
-            this.optionsToolStripMenuItem.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.optionsToolStripMenuItem.Name = "optionsToolStripMenuItem";
-            resources.ApplyResources(this.optionsToolStripMenuItem, "optionsToolStripMenuItem");
-            this.optionsToolStripMenuItem.CheckedChanged += new System.EventHandler(this.SATrigger_CheckedChanged);
-            // 
-            // shareToolStripMenuItem
-            // 
-            this.shareToolStripMenuItem.CheckOnClick = true;
-            this.shareToolStripMenuItem.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.shareToolStripMenuItem.Name = "shareToolStripMenuItem";
-            resources.ApplyResources(this.shareToolStripMenuItem, "shareToolStripMenuItem");
-            this.shareToolStripMenuItem.CheckedChanged += new System.EventHandler(this.SATrigger_CheckedChanged);
-            // 
-            // pSToolStripMenuItem
-            // 
-            this.pSToolStripMenuItem.CheckOnClick = true;
-            this.pSToolStripMenuItem.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.pSToolStripMenuItem.Name = "pSToolStripMenuItem";
-            resources.ApplyResources(this.pSToolStripMenuItem, "pSToolStripMenuItem");
-            this.pSToolStripMenuItem.CheckedChanged += new System.EventHandler(this.SATrigger_CheckedChanged);
-            // 
-            // alwaysOnToolStripMenuItem
-            // 
-            this.alwaysOnToolStripMenuItem.CheckOnClick = true;
-            this.alwaysOnToolStripMenuItem.Name = "alwaysOnToolStripMenuItem";
-            resources.ApplyResources(this.alwaysOnToolStripMenuItem, "alwaysOnToolStripMenuItem");
-            this.alwaysOnToolStripMenuItem.CheckedChanged += new System.EventHandler(this.SATrigger_CheckedChanged);
-            // 
-            // cMTouchDisableInvert
-            // 
-            this.cMTouchDisableInvert.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+      this.cMGyroTriggers.Name = "cMGyroTriggers";
+      this.cMGyroTriggers.ShowCheckMargin = true;
+      this.cMGyroTriggers.ShowImageMargin = false;
+      resources.ApplyResources(this.cMGyroTriggers, "cMGyroTriggers");
+      // 
+      // crossToolStripMenuItem
+      // 
+      this.crossToolStripMenuItem.CheckOnClick = true;
+      this.crossToolStripMenuItem.ForeColor = System.Drawing.SystemColors.ControlText;
+      this.crossToolStripMenuItem.Name = "crossToolStripMenuItem";
+      resources.ApplyResources(this.crossToolStripMenuItem, "crossToolStripMenuItem");
+      this.crossToolStripMenuItem.CheckedChanged += new System.EventHandler(this.SATrigger_CheckedChanged);
+      // 
+      // circleToolStripMenuItem
+      // 
+      this.circleToolStripMenuItem.CheckOnClick = true;
+      this.circleToolStripMenuItem.ForeColor = System.Drawing.SystemColors.ControlText;
+      this.circleToolStripMenuItem.Name = "circleToolStripMenuItem";
+      resources.ApplyResources(this.circleToolStripMenuItem, "circleToolStripMenuItem");
+      this.circleToolStripMenuItem.CheckedChanged += new System.EventHandler(this.SATrigger_CheckedChanged);
+      // 
+      // squareToolStripMenuItem
+      // 
+      this.squareToolStripMenuItem.CheckOnClick = true;
+      this.squareToolStripMenuItem.ForeColor = System.Drawing.SystemColors.ControlText;
+      this.squareToolStripMenuItem.Name = "squareToolStripMenuItem";
+      resources.ApplyResources(this.squareToolStripMenuItem, "squareToolStripMenuItem");
+      this.squareToolStripMenuItem.CheckedChanged += new System.EventHandler(this.SATrigger_CheckedChanged);
+      // 
+      // triangleToolStripMenuItem
+      // 
+      this.triangleToolStripMenuItem.CheckOnClick = true;
+      this.triangleToolStripMenuItem.ForeColor = System.Drawing.SystemColors.ControlText;
+      this.triangleToolStripMenuItem.Name = "triangleToolStripMenuItem";
+      resources.ApplyResources(this.triangleToolStripMenuItem, "triangleToolStripMenuItem");
+      this.triangleToolStripMenuItem.CheckedChanged += new System.EventHandler(this.SATrigger_CheckedChanged);
+      // 
+      // l1ToolStripMenuItem
+      // 
+      this.l1ToolStripMenuItem.CheckOnClick = true;
+      this.l1ToolStripMenuItem.ForeColor = System.Drawing.SystemColors.ControlText;
+      this.l1ToolStripMenuItem.Name = "l1ToolStripMenuItem";
+      resources.ApplyResources(this.l1ToolStripMenuItem, "l1ToolStripMenuItem");
+      this.l1ToolStripMenuItem.CheckedChanged += new System.EventHandler(this.SATrigger_CheckedChanged);
+      // 
+      // l2ToolStripMenuItem
+      // 
+      this.l2ToolStripMenuItem.CheckOnClick = true;
+      this.l2ToolStripMenuItem.ForeColor = System.Drawing.SystemColors.ControlText;
+      this.l2ToolStripMenuItem.Name = "l2ToolStripMenuItem";
+      resources.ApplyResources(this.l2ToolStripMenuItem, "l2ToolStripMenuItem");
+      this.l2ToolStripMenuItem.CheckedChanged += new System.EventHandler(this.SATrigger_CheckedChanged);
+      // 
+      // r1ToolStripMenuItem
+      // 
+      this.r1ToolStripMenuItem.CheckOnClick = true;
+      this.r1ToolStripMenuItem.ForeColor = System.Drawing.SystemColors.ControlText;
+      this.r1ToolStripMenuItem.Name = "r1ToolStripMenuItem";
+      resources.ApplyResources(this.r1ToolStripMenuItem, "r1ToolStripMenuItem");
+      this.r1ToolStripMenuItem.CheckedChanged += new System.EventHandler(this.SATrigger_CheckedChanged);
+      // 
+      // r2ToolStripMenuItem
+      // 
+      this.r2ToolStripMenuItem.CheckOnClick = true;
+      this.r2ToolStripMenuItem.ForeColor = System.Drawing.SystemColors.ControlText;
+      this.r2ToolStripMenuItem.Name = "r2ToolStripMenuItem";
+      resources.ApplyResources(this.r2ToolStripMenuItem, "r2ToolStripMenuItem");
+      this.r2ToolStripMenuItem.CheckedChanged += new System.EventHandler(this.SATrigger_CheckedChanged);
+      // 
+      // onTouchpadToolStripMenuItem
+      // 
+      this.onTouchpadToolStripMenuItem.CheckOnClick = true;
+      this.onTouchpadToolStripMenuItem.ForeColor = System.Drawing.SystemColors.ControlText;
+      this.onTouchpadToolStripMenuItem.Name = "onTouchpadToolStripMenuItem";
+      resources.ApplyResources(this.onTouchpadToolStripMenuItem, "onTouchpadToolStripMenuItem");
+      this.onTouchpadToolStripMenuItem.CheckedChanged += new System.EventHandler(this.SATrigger_CheckedChanged);
+      // 
+      // downToolStripMenuItem
+      // 
+      this.downToolStripMenuItem.CheckOnClick = true;
+      this.downToolStripMenuItem.ForeColor = System.Drawing.SystemColors.ControlText;
+      this.downToolStripMenuItem.Name = "downToolStripMenuItem";
+      resources.ApplyResources(this.downToolStripMenuItem, "downToolStripMenuItem");
+      this.downToolStripMenuItem.CheckedChanged += new System.EventHandler(this.SATrigger_CheckedChanged);
+      // 
+      // leftToolStripMenuItem
+      // 
+      this.leftToolStripMenuItem.CheckOnClick = true;
+      this.leftToolStripMenuItem.ForeColor = System.Drawing.SystemColors.ControlText;
+      this.leftToolStripMenuItem.Name = "leftToolStripMenuItem";
+      resources.ApplyResources(this.leftToolStripMenuItem, "leftToolStripMenuItem");
+      this.leftToolStripMenuItem.CheckedChanged += new System.EventHandler(this.SATrigger_CheckedChanged);
+      // 
+      // rightToolStripMenuItem
+      // 
+      this.rightToolStripMenuItem.CheckOnClick = true;
+      this.rightToolStripMenuItem.ForeColor = System.Drawing.SystemColors.ControlText;
+      this.rightToolStripMenuItem.Name = "rightToolStripMenuItem";
+      resources.ApplyResources(this.rightToolStripMenuItem, "rightToolStripMenuItem");
+      this.rightToolStripMenuItem.CheckedChanged += new System.EventHandler(this.SATrigger_CheckedChanged);
+      // 
+      // l3ToolStripMenuItem
+      // 
+      this.l3ToolStripMenuItem.CheckOnClick = true;
+      this.l3ToolStripMenuItem.ForeColor = System.Drawing.SystemColors.ControlText;
+      this.l3ToolStripMenuItem.Name = "l3ToolStripMenuItem";
+      resources.ApplyResources(this.l3ToolStripMenuItem, "l3ToolStripMenuItem");
+      this.l3ToolStripMenuItem.CheckedChanged += new System.EventHandler(this.SATrigger_CheckedChanged);
+      // 
+      // r3ToolStripMenuItem
+      // 
+      this.r3ToolStripMenuItem.CheckOnClick = true;
+      this.r3ToolStripMenuItem.ForeColor = System.Drawing.SystemColors.ControlText;
+      this.r3ToolStripMenuItem.Name = "r3ToolStripMenuItem";
+      resources.ApplyResources(this.r3ToolStripMenuItem, "r3ToolStripMenuItem");
+      this.r3ToolStripMenuItem.CheckedChanged += new System.EventHandler(this.SATrigger_CheckedChanged);
+      // 
+      // fingerOnTouchpadToolStripMenuItem
+      // 
+      this.fingerOnTouchpadToolStripMenuItem.CheckOnClick = true;
+      this.fingerOnTouchpadToolStripMenuItem.ForeColor = System.Drawing.SystemColors.ControlText;
+      this.fingerOnTouchpadToolStripMenuItem.Name = "fingerOnTouchpadToolStripMenuItem";
+      resources.ApplyResources(this.fingerOnTouchpadToolStripMenuItem, "fingerOnTouchpadToolStripMenuItem");
+      this.fingerOnTouchpadToolStripMenuItem.CheckedChanged += new System.EventHandler(this.SATrigger_CheckedChanged);
+      // 
+      // fingersOnTouchpadToolStripMenuItem
+      // 
+      this.fingersOnTouchpadToolStripMenuItem.CheckOnClick = true;
+      this.fingersOnTouchpadToolStripMenuItem.ForeColor = System.Drawing.SystemColors.ControlText;
+      this.fingersOnTouchpadToolStripMenuItem.Name = "fingersOnTouchpadToolStripMenuItem";
+      resources.ApplyResources(this.fingersOnTouchpadToolStripMenuItem, "fingersOnTouchpadToolStripMenuItem");
+      this.fingersOnTouchpadToolStripMenuItem.CheckedChanged += new System.EventHandler(this.SATrigger_CheckedChanged);
+      // 
+      // optionsToolStripMenuItem
+      // 
+      this.optionsToolStripMenuItem.CheckOnClick = true;
+      this.optionsToolStripMenuItem.ForeColor = System.Drawing.SystemColors.ControlText;
+      this.optionsToolStripMenuItem.Name = "optionsToolStripMenuItem";
+      resources.ApplyResources(this.optionsToolStripMenuItem, "optionsToolStripMenuItem");
+      this.optionsToolStripMenuItem.CheckedChanged += new System.EventHandler(this.SATrigger_CheckedChanged);
+      // 
+      // shareToolStripMenuItem
+      // 
+      this.shareToolStripMenuItem.CheckOnClick = true;
+      this.shareToolStripMenuItem.ForeColor = System.Drawing.SystemColors.ControlText;
+      this.shareToolStripMenuItem.Name = "shareToolStripMenuItem";
+      resources.ApplyResources(this.shareToolStripMenuItem, "shareToolStripMenuItem");
+      this.shareToolStripMenuItem.CheckedChanged += new System.EventHandler(this.SATrigger_CheckedChanged);
+      // 
+      // pSToolStripMenuItem
+      // 
+      this.pSToolStripMenuItem.CheckOnClick = true;
+      this.pSToolStripMenuItem.ForeColor = System.Drawing.SystemColors.ControlText;
+      this.pSToolStripMenuItem.Name = "pSToolStripMenuItem";
+      resources.ApplyResources(this.pSToolStripMenuItem, "pSToolStripMenuItem");
+      this.pSToolStripMenuItem.CheckedChanged += new System.EventHandler(this.SATrigger_CheckedChanged);
+      // 
+      // alwaysOnToolStripMenuItem
+      // 
+      this.alwaysOnToolStripMenuItem.CheckOnClick = true;
+      this.alwaysOnToolStripMenuItem.Name = "alwaysOnToolStripMenuItem";
+      resources.ApplyResources(this.alwaysOnToolStripMenuItem, "alwaysOnToolStripMenuItem");
+      this.alwaysOnToolStripMenuItem.CheckedChanged += new System.EventHandler(this.SATrigger_CheckedChanged);
+      // 
+      // cMTouchDisableInvert
+      // 
+      this.cMTouchDisableInvert.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.crossTouchInvStripMenuItem,
             this.circleTouchInvStripMenuItem,
             this.squareTouchInvStripMenuItem,
@@ -4140,270 +4167,272 @@
             this.optionsTouchInvStripMenuItem,
             this.shareTouchInvStripMenuItem,
             this.psTouchInvStripMenuItem});
-            this.cMTouchDisableInvert.Name = "cMTouchDisableInvert";
-            this.cMTouchDisableInvert.ShowCheckMargin = true;
-            this.cMTouchDisableInvert.ShowImageMargin = false;
-            resources.ApplyResources(this.cMTouchDisableInvert, "cMTouchDisableInvert");
-            // 
-            // crossTouchInvStripMenuItem
-            // 
-            this.crossTouchInvStripMenuItem.CheckOnClick = true;
-            this.crossTouchInvStripMenuItem.Name = "crossTouchInvStripMenuItem";
-            resources.ApplyResources(this.crossTouchInvStripMenuItem, "crossTouchInvStripMenuItem");
-            this.crossTouchInvStripMenuItem.CheckedChanged += new System.EventHandler(this.TouchDisableInvert_CheckedChanged);
-            // 
-            // circleTouchInvStripMenuItem
-            // 
-            this.circleTouchInvStripMenuItem.CheckOnClick = true;
-            this.circleTouchInvStripMenuItem.Name = "circleTouchInvStripMenuItem";
-            resources.ApplyResources(this.circleTouchInvStripMenuItem, "circleTouchInvStripMenuItem");
-            this.circleTouchInvStripMenuItem.CheckedChanged += new System.EventHandler(this.TouchDisableInvert_CheckedChanged);
-            // 
-            // squareTouchInvStripMenuItem
-            // 
-            this.squareTouchInvStripMenuItem.CheckOnClick = true;
-            this.squareTouchInvStripMenuItem.Name = "squareTouchInvStripMenuItem";
-            resources.ApplyResources(this.squareTouchInvStripMenuItem, "squareTouchInvStripMenuItem");
-            this.squareTouchInvStripMenuItem.CheckedChanged += new System.EventHandler(this.TouchDisableInvert_CheckedChanged);
-            // 
-            // triangleTouchInvStripMenuItem
-            // 
-            this.triangleTouchInvStripMenuItem.CheckOnClick = true;
-            this.triangleTouchInvStripMenuItem.Name = "triangleTouchInvStripMenuItem";
-            resources.ApplyResources(this.triangleTouchInvStripMenuItem, "triangleTouchInvStripMenuItem");
-            this.triangleTouchInvStripMenuItem.CheckedChanged += new System.EventHandler(this.TouchDisableInvert_CheckedChanged);
-            // 
-            // l1TouchInvStripMenuItem
-            // 
-            this.l1TouchInvStripMenuItem.CheckOnClick = true;
-            this.l1TouchInvStripMenuItem.Name = "l1TouchInvStripMenuItem";
-            resources.ApplyResources(this.l1TouchInvStripMenuItem, "l1TouchInvStripMenuItem");
-            this.l1TouchInvStripMenuItem.CheckedChanged += new System.EventHandler(this.TouchDisableInvert_CheckedChanged);
-            // 
-            // l2TouchInvStripMenuItem
-            // 
-            this.l2TouchInvStripMenuItem.CheckOnClick = true;
-            this.l2TouchInvStripMenuItem.Name = "l2TouchInvStripMenuItem";
-            resources.ApplyResources(this.l2TouchInvStripMenuItem, "l2TouchInvStripMenuItem");
-            this.l2TouchInvStripMenuItem.CheckedChanged += new System.EventHandler(this.TouchDisableInvert_CheckedChanged);
-            // 
-            // r1TouchInvStripMenuItem
-            // 
-            this.r1TouchInvStripMenuItem.CheckOnClick = true;
-            this.r1TouchInvStripMenuItem.Name = "r1TouchInvStripMenuItem";
-            resources.ApplyResources(this.r1TouchInvStripMenuItem, "r1TouchInvStripMenuItem");
-            this.r1TouchInvStripMenuItem.CheckedChanged += new System.EventHandler(this.TouchDisableInvert_CheckedChanged);
-            // 
-            // r2TouchInvStripMenuItem
-            // 
-            this.r2TouchInvStripMenuItem.CheckOnClick = true;
-            this.r2TouchInvStripMenuItem.Name = "r2TouchInvStripMenuItem";
-            resources.ApplyResources(this.r2TouchInvStripMenuItem, "r2TouchInvStripMenuItem");
-            this.r2TouchInvStripMenuItem.CheckedChanged += new System.EventHandler(this.TouchDisableInvert_CheckedChanged);
-            // 
-            // upTouchInvStripMenuItem
-            // 
-            this.upTouchInvStripMenuItem.CheckOnClick = true;
-            this.upTouchInvStripMenuItem.Name = "upTouchInvStripMenuItem";
-            resources.ApplyResources(this.upTouchInvStripMenuItem, "upTouchInvStripMenuItem");
-            this.upTouchInvStripMenuItem.CheckedChanged += new System.EventHandler(this.TouchDisableInvert_CheckedChanged);
-            // 
-            // downTouchInvStripMenuItem
-            // 
-            this.downTouchInvStripMenuItem.CheckOnClick = true;
-            this.downTouchInvStripMenuItem.Name = "downTouchInvStripMenuItem";
-            resources.ApplyResources(this.downTouchInvStripMenuItem, "downTouchInvStripMenuItem");
-            this.downTouchInvStripMenuItem.CheckedChanged += new System.EventHandler(this.TouchDisableInvert_CheckedChanged);
-            // 
-            // leftTouchInvStripMenuItem
-            // 
-            this.leftTouchInvStripMenuItem.CheckOnClick = true;
-            this.leftTouchInvStripMenuItem.Name = "leftTouchInvStripMenuItem";
-            resources.ApplyResources(this.leftTouchInvStripMenuItem, "leftTouchInvStripMenuItem");
-            this.leftTouchInvStripMenuItem.CheckedChanged += new System.EventHandler(this.TouchDisableInvert_CheckedChanged);
-            // 
-            // rightTouchInvStripMenuItem
-            // 
-            this.rightTouchInvStripMenuItem.CheckOnClick = true;
-            this.rightTouchInvStripMenuItem.Name = "rightTouchInvStripMenuItem";
-            resources.ApplyResources(this.rightTouchInvStripMenuItem, "rightTouchInvStripMenuItem");
-            this.rightTouchInvStripMenuItem.CheckedChanged += new System.EventHandler(this.TouchDisableInvert_CheckedChanged);
-            // 
-            // l3TouchInvStripMenuItem
-            // 
-            this.l3TouchInvStripMenuItem.CheckOnClick = true;
-            this.l3TouchInvStripMenuItem.Name = "l3TouchInvStripMenuItem";
-            resources.ApplyResources(this.l3TouchInvStripMenuItem, "l3TouchInvStripMenuItem");
-            this.l3TouchInvStripMenuItem.CheckedChanged += new System.EventHandler(this.TouchDisableInvert_CheckedChanged);
-            // 
-            // r3TouchInvStripMenuItem
-            // 
-            this.r3TouchInvStripMenuItem.CheckOnClick = true;
-            this.r3TouchInvStripMenuItem.Name = "r3TouchInvStripMenuItem";
-            resources.ApplyResources(this.r3TouchInvStripMenuItem, "r3TouchInvStripMenuItem");
-            this.r3TouchInvStripMenuItem.CheckedChanged += new System.EventHandler(this.TouchDisableInvert_CheckedChanged);
-            // 
-            // oneFingerTouchInvStripMenuItem
-            // 
-            this.oneFingerTouchInvStripMenuItem.CheckOnClick = true;
-            this.oneFingerTouchInvStripMenuItem.Name = "oneFingerTouchInvStripMenuItem";
-            resources.ApplyResources(this.oneFingerTouchInvStripMenuItem, "oneFingerTouchInvStripMenuItem");
-            this.oneFingerTouchInvStripMenuItem.CheckedChanged += new System.EventHandler(this.TouchDisableInvert_CheckedChanged);
-            // 
-            // twoFingerTouchInvStripMenuItem
-            // 
-            this.twoFingerTouchInvStripMenuItem.CheckOnClick = true;
-            this.twoFingerTouchInvStripMenuItem.Name = "twoFingerTouchInvStripMenuItem";
-            resources.ApplyResources(this.twoFingerTouchInvStripMenuItem, "twoFingerTouchInvStripMenuItem");
-            this.twoFingerTouchInvStripMenuItem.CheckedChanged += new System.EventHandler(this.TouchDisableInvert_CheckedChanged);
-            // 
-            // optionsTouchInvStripMenuItem
-            // 
-            this.optionsTouchInvStripMenuItem.CheckOnClick = true;
-            this.optionsTouchInvStripMenuItem.Name = "optionsTouchInvStripMenuItem";
-            resources.ApplyResources(this.optionsTouchInvStripMenuItem, "optionsTouchInvStripMenuItem");
-            this.optionsTouchInvStripMenuItem.CheckedChanged += new System.EventHandler(this.TouchDisableInvert_CheckedChanged);
-            // 
-            // shareTouchInvStripMenuItem
-            // 
-            this.shareTouchInvStripMenuItem.CheckOnClick = true;
-            this.shareTouchInvStripMenuItem.Name = "shareTouchInvStripMenuItem";
-            resources.ApplyResources(this.shareTouchInvStripMenuItem, "shareTouchInvStripMenuItem");
-            this.shareTouchInvStripMenuItem.CheckedChanged += new System.EventHandler(this.TouchDisableInvert_CheckedChanged);
-            // 
-            // psTouchInvStripMenuItem
-            // 
-            this.psTouchInvStripMenuItem.CheckOnClick = true;
-            this.psTouchInvStripMenuItem.Name = "psTouchInvStripMenuItem";
-            resources.ApplyResources(this.psTouchInvStripMenuItem, "psTouchInvStripMenuItem");
-            this.psTouchInvStripMenuItem.CheckedChanged += new System.EventHandler(this.TouchDisableInvert_CheckedChanged);
-            // 
-            // Options
-            // 
-            resources.ApplyResources(this, "$this");
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
-            this.BackColor = System.Drawing.SystemColors.Window;
-            this.Controls.Add(this.fLPSettings);
-            this.Controls.Add(this.tCControls);
-            this.MaximizeBox = false;
-            this.MinimizeBox = false;
-            this.Name = "Options";
-            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.Options_FormClosing);
-            ((System.ComponentModel.ISupportInitialize)(this.nUDRainbow)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.tBBlueBar)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.tBGreenBar)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.tBRedBar)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDTap)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDScroll)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDTouch)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDIdleDisconnect)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDR2)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDRumbleBoost)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.tBLowRedBar)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.tBLowGreenBar)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.tBLowBlueBar)).EndInit();
-            this.pnlFull.ResumeLayout(false);
-            this.pnlFull.PerformLayout();
-            this.pnlLowBattery.ResumeLayout(false);
-            this.pnlLowBattery.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDRS)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.numUDMouseSens)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDLS)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDL2)).EndInit();
-            this.gBTouchpad.ResumeLayout(false);
-            this.gBTouchpad.PerformLayout();
-            this.pnlTPMouse.ResumeLayout(false);
-            this.pnlTPMouse.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.trackFrictionNUD)).EndInit();
-            this.fLPTouchSwipe.ResumeLayout(false);
-            this.cMSPresets.ResumeLayout(false);
-            this.gBOther.ResumeLayout(false);
-            this.gBOther.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.pBProgram)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDSixaxis)).EndInit();
-            this.gBLightbar.ResumeLayout(false);
-            this.gBLightbar.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDRainbowB)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDflashLED)).EndInit();
-            this.gBRumble.ResumeLayout(false);
-            this.gBRumble.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDSZ)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDSX)).EndInit();
-            this.lbL2TrackS.ResumeLayout(false);
-            this.lbL2TrackS.PerformLayout();
-            this.pnlSATrack.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.tBR2)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.tBL2)).EndInit();
-            this.pnlSixaxis.ResumeLayout(false);
-            this.pnlSixaxis.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.tBsixaxisAccelX)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.tBsixaxisGyroX)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.tBsixaxisGyroY)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.tBsixaxisGyroZ)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.tBsixaxisAccelY)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.tBsixaxisAccelZ)).EndInit();
-            this.pnlLSTrack.ResumeLayout(false);
-            this.pnlRSTrack.ResumeLayout(false);
-            this.fLPTiltControls.ResumeLayout(false);
-            this.fLPTiltControls.PerformLayout();
-            this.tCControls.ResumeLayout(false);
-            this.tPControls.ResumeLayout(false);
-            this.pnlController.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.pBHoveredButton)).EndInit();
-            this.tPSpecial.ResumeLayout(false);
-            this.pnlActions.ResumeLayout(false);
-            this.panel2.ResumeLayout(false);
-            this.fLPActionButtons.ResumeLayout(false);
-            this.tCSens.ResumeLayout(false);
-            this.tPDeadzone.ResumeLayout(false);
-            this.tPDeadzone.PerformLayout();
-            this.antiDeadzoneTabPage.ResumeLayout(false);
-            this.antiDeadzoneTabPage.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDSixaxisZAntiDead)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDSixaxisXAntiDead)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDR2AntiDead)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDL2AntiDead)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDRSAntiDead)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDLSAntiDead)).EndInit();
-            this.maxZoneTabPage.ResumeLayout(false);
-            this.maxZoneTabPage.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDSixAxisZMaxZone)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDSixAxisXMaxZone)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDR2Maxzone)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDL2Maxzone)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDRSMaxZone)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDLSMaxZone)).EndInit();
-            this.squStickTabPage.ResumeLayout(false);
-            this.tPOutCurve.ResumeLayout(false);
-            this.tPOutCurve.PerformLayout();
-            this.tPCurve.ResumeLayout(false);
-            this.tPCurve.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDLSCurve)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDRSCurve)).EndInit();
-            this.tpRotation.ResumeLayout(false);
-            this.tpRotation.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDRSRotation)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDLSRotation)).EndInit();
-            this.fLPSettings.ResumeLayout(false);
-            this.gBGyro.ResumeLayout(false);
-            this.gBGyro.PerformLayout();
-            this.pnlSAMouse.ResumeLayout(false);
-            this.pnlSAMouse.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.gyroMouseDzNUD)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDGyroSmoothWeight)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDGyroMouseVertScale)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDGyroSensitivity)).EndInit();
-            this.gBSensitivity.ResumeLayout(false);
-            this.gBSensitivity.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDL2S)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDLSS)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDR2S)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDRSS)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDSXS)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDSZS)).EndInit();
-            this.cMGyroTriggers.ResumeLayout(false);
-            this.cMTouchDisableInvert.ResumeLayout(false);
-            this.ResumeLayout(false);
+      this.cMTouchDisableInvert.Name = "cMTouchDisableInvert";
+      this.cMTouchDisableInvert.ShowCheckMargin = true;
+      this.cMTouchDisableInvert.ShowImageMargin = false;
+      resources.ApplyResources(this.cMTouchDisableInvert, "cMTouchDisableInvert");
+      // 
+      // crossTouchInvStripMenuItem
+      // 
+      this.crossTouchInvStripMenuItem.CheckOnClick = true;
+      this.crossTouchInvStripMenuItem.Name = "crossTouchInvStripMenuItem";
+      resources.ApplyResources(this.crossTouchInvStripMenuItem, "crossTouchInvStripMenuItem");
+      this.crossTouchInvStripMenuItem.CheckedChanged += new System.EventHandler(this.TouchDisableInvert_CheckedChanged);
+      // 
+      // circleTouchInvStripMenuItem
+      // 
+      this.circleTouchInvStripMenuItem.CheckOnClick = true;
+      this.circleTouchInvStripMenuItem.Name = "circleTouchInvStripMenuItem";
+      resources.ApplyResources(this.circleTouchInvStripMenuItem, "circleTouchInvStripMenuItem");
+      this.circleTouchInvStripMenuItem.CheckedChanged += new System.EventHandler(this.TouchDisableInvert_CheckedChanged);
+      // 
+      // squareTouchInvStripMenuItem
+      // 
+      this.squareTouchInvStripMenuItem.CheckOnClick = true;
+      this.squareTouchInvStripMenuItem.Name = "squareTouchInvStripMenuItem";
+      resources.ApplyResources(this.squareTouchInvStripMenuItem, "squareTouchInvStripMenuItem");
+      this.squareTouchInvStripMenuItem.CheckedChanged += new System.EventHandler(this.TouchDisableInvert_CheckedChanged);
+      // 
+      // triangleTouchInvStripMenuItem
+      // 
+      this.triangleTouchInvStripMenuItem.CheckOnClick = true;
+      this.triangleTouchInvStripMenuItem.Name = "triangleTouchInvStripMenuItem";
+      resources.ApplyResources(this.triangleTouchInvStripMenuItem, "triangleTouchInvStripMenuItem");
+      this.triangleTouchInvStripMenuItem.CheckedChanged += new System.EventHandler(this.TouchDisableInvert_CheckedChanged);
+      // 
+      // l1TouchInvStripMenuItem
+      // 
+      this.l1TouchInvStripMenuItem.CheckOnClick = true;
+      this.l1TouchInvStripMenuItem.Name = "l1TouchInvStripMenuItem";
+      resources.ApplyResources(this.l1TouchInvStripMenuItem, "l1TouchInvStripMenuItem");
+      this.l1TouchInvStripMenuItem.CheckedChanged += new System.EventHandler(this.TouchDisableInvert_CheckedChanged);
+      // 
+      // l2TouchInvStripMenuItem
+      // 
+      this.l2TouchInvStripMenuItem.CheckOnClick = true;
+      this.l2TouchInvStripMenuItem.Name = "l2TouchInvStripMenuItem";
+      resources.ApplyResources(this.l2TouchInvStripMenuItem, "l2TouchInvStripMenuItem");
+      this.l2TouchInvStripMenuItem.CheckedChanged += new System.EventHandler(this.TouchDisableInvert_CheckedChanged);
+      // 
+      // r1TouchInvStripMenuItem
+      // 
+      this.r1TouchInvStripMenuItem.CheckOnClick = true;
+      this.r1TouchInvStripMenuItem.Name = "r1TouchInvStripMenuItem";
+      resources.ApplyResources(this.r1TouchInvStripMenuItem, "r1TouchInvStripMenuItem");
+      this.r1TouchInvStripMenuItem.CheckedChanged += new System.EventHandler(this.TouchDisableInvert_CheckedChanged);
+      // 
+      // r2TouchInvStripMenuItem
+      // 
+      this.r2TouchInvStripMenuItem.CheckOnClick = true;
+      this.r2TouchInvStripMenuItem.Name = "r2TouchInvStripMenuItem";
+      resources.ApplyResources(this.r2TouchInvStripMenuItem, "r2TouchInvStripMenuItem");
+      this.r2TouchInvStripMenuItem.CheckedChanged += new System.EventHandler(this.TouchDisableInvert_CheckedChanged);
+      // 
+      // upTouchInvStripMenuItem
+      // 
+      this.upTouchInvStripMenuItem.CheckOnClick = true;
+      this.upTouchInvStripMenuItem.Name = "upTouchInvStripMenuItem";
+      resources.ApplyResources(this.upTouchInvStripMenuItem, "upTouchInvStripMenuItem");
+      this.upTouchInvStripMenuItem.CheckedChanged += new System.EventHandler(this.TouchDisableInvert_CheckedChanged);
+      // 
+      // downTouchInvStripMenuItem
+      // 
+      this.downTouchInvStripMenuItem.CheckOnClick = true;
+      this.downTouchInvStripMenuItem.Name = "downTouchInvStripMenuItem";
+      resources.ApplyResources(this.downTouchInvStripMenuItem, "downTouchInvStripMenuItem");
+      this.downTouchInvStripMenuItem.CheckedChanged += new System.EventHandler(this.TouchDisableInvert_CheckedChanged);
+      // 
+      // leftTouchInvStripMenuItem
+      // 
+      this.leftTouchInvStripMenuItem.CheckOnClick = true;
+      this.leftTouchInvStripMenuItem.Name = "leftTouchInvStripMenuItem";
+      resources.ApplyResources(this.leftTouchInvStripMenuItem, "leftTouchInvStripMenuItem");
+      this.leftTouchInvStripMenuItem.CheckedChanged += new System.EventHandler(this.TouchDisableInvert_CheckedChanged);
+      // 
+      // rightTouchInvStripMenuItem
+      // 
+      this.rightTouchInvStripMenuItem.CheckOnClick = true;
+      this.rightTouchInvStripMenuItem.Name = "rightTouchInvStripMenuItem";
+      resources.ApplyResources(this.rightTouchInvStripMenuItem, "rightTouchInvStripMenuItem");
+      this.rightTouchInvStripMenuItem.CheckedChanged += new System.EventHandler(this.TouchDisableInvert_CheckedChanged);
+      // 
+      // l3TouchInvStripMenuItem
+      // 
+      this.l3TouchInvStripMenuItem.CheckOnClick = true;
+      this.l3TouchInvStripMenuItem.Name = "l3TouchInvStripMenuItem";
+      resources.ApplyResources(this.l3TouchInvStripMenuItem, "l3TouchInvStripMenuItem");
+      this.l3TouchInvStripMenuItem.CheckedChanged += new System.EventHandler(this.TouchDisableInvert_CheckedChanged);
+      // 
+      // r3TouchInvStripMenuItem
+      // 
+      this.r3TouchInvStripMenuItem.CheckOnClick = true;
+      this.r3TouchInvStripMenuItem.Name = "r3TouchInvStripMenuItem";
+      resources.ApplyResources(this.r3TouchInvStripMenuItem, "r3TouchInvStripMenuItem");
+      this.r3TouchInvStripMenuItem.CheckedChanged += new System.EventHandler(this.TouchDisableInvert_CheckedChanged);
+      // 
+      // oneFingerTouchInvStripMenuItem
+      // 
+      this.oneFingerTouchInvStripMenuItem.CheckOnClick = true;
+      this.oneFingerTouchInvStripMenuItem.Name = "oneFingerTouchInvStripMenuItem";
+      resources.ApplyResources(this.oneFingerTouchInvStripMenuItem, "oneFingerTouchInvStripMenuItem");
+      this.oneFingerTouchInvStripMenuItem.CheckedChanged += new System.EventHandler(this.TouchDisableInvert_CheckedChanged);
+      // 
+      // twoFingerTouchInvStripMenuItem
+      // 
+      this.twoFingerTouchInvStripMenuItem.CheckOnClick = true;
+      this.twoFingerTouchInvStripMenuItem.Name = "twoFingerTouchInvStripMenuItem";
+      resources.ApplyResources(this.twoFingerTouchInvStripMenuItem, "twoFingerTouchInvStripMenuItem");
+      this.twoFingerTouchInvStripMenuItem.CheckedChanged += new System.EventHandler(this.TouchDisableInvert_CheckedChanged);
+      // 
+      // optionsTouchInvStripMenuItem
+      // 
+      this.optionsTouchInvStripMenuItem.CheckOnClick = true;
+      this.optionsTouchInvStripMenuItem.Name = "optionsTouchInvStripMenuItem";
+      resources.ApplyResources(this.optionsTouchInvStripMenuItem, "optionsTouchInvStripMenuItem");
+      this.optionsTouchInvStripMenuItem.CheckedChanged += new System.EventHandler(this.TouchDisableInvert_CheckedChanged);
+      // 
+      // shareTouchInvStripMenuItem
+      // 
+      this.shareTouchInvStripMenuItem.CheckOnClick = true;
+      this.shareTouchInvStripMenuItem.Name = "shareTouchInvStripMenuItem";
+      resources.ApplyResources(this.shareTouchInvStripMenuItem, "shareTouchInvStripMenuItem");
+      this.shareTouchInvStripMenuItem.CheckedChanged += new System.EventHandler(this.TouchDisableInvert_CheckedChanged);
+      // 
+      // psTouchInvStripMenuItem
+      // 
+      this.psTouchInvStripMenuItem.CheckOnClick = true;
+      this.psTouchInvStripMenuItem.Name = "psTouchInvStripMenuItem";
+      resources.ApplyResources(this.psTouchInvStripMenuItem, "psTouchInvStripMenuItem");
+      this.psTouchInvStripMenuItem.CheckedChanged += new System.EventHandler(this.TouchDisableInvert_CheckedChanged);
+      // 
+      // Options
+      // 
+      resources.ApplyResources(this, "$this");
+      this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
+      this.BackColor = System.Drawing.SystemColors.Window;
+      this.Controls.Add(this.fLPSettings);
+      this.Controls.Add(this.tCControls);
+      this.MaximizeBox = false;
+      this.MinimizeBox = false;
+      this.Name = "Options";
+      this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.Options_FormClosing);
+      ((System.ComponentModel.ISupportInitialize)(this.nUDRainbow)).EndInit();
+      ((System.ComponentModel.ISupportInitialize)(this.tBBlueBar)).EndInit();
+      ((System.ComponentModel.ISupportInitialize)(this.tBGreenBar)).EndInit();
+      ((System.ComponentModel.ISupportInitialize)(this.tBRedBar)).EndInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDTap)).EndInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDScroll)).EndInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDTouch)).EndInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDIdleDisconnect)).EndInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDR2)).EndInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDRumbleBoost)).EndInit();
+      ((System.ComponentModel.ISupportInitialize)(this.tBLowRedBar)).EndInit();
+      ((System.ComponentModel.ISupportInitialize)(this.tBLowGreenBar)).EndInit();
+      ((System.ComponentModel.ISupportInitialize)(this.tBLowBlueBar)).EndInit();
+      this.pnlFull.ResumeLayout(false);
+      this.pnlFull.PerformLayout();
+      this.pnlLowBattery.ResumeLayout(false);
+      this.pnlLowBattery.PerformLayout();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDRS)).EndInit();
+      ((System.ComponentModel.ISupportInitialize)(this.numUDMouseSens)).EndInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDLS)).EndInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDL2)).EndInit();
+      this.gBTouchpad.ResumeLayout(false);
+      this.gBTouchpad.PerformLayout();
+      this.pnlTPMouse.ResumeLayout(false);
+      this.pnlTPMouse.PerformLayout();
+      ((System.ComponentModel.ISupportInitialize)(this.trackFrictionNUD)).EndInit();
+      this.fLPTouchSwipe.ResumeLayout(false);
+      this.cMSPresets.ResumeLayout(false);
+      this.gBOther.ResumeLayout(false);
+      this.gBOther.PerformLayout();
+      ((System.ComponentModel.ISupportInitialize)(this.pBProgram)).EndInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDSixaxis)).EndInit();
+      this.gBLightbar.ResumeLayout(false);
+      this.gBLightbar.PerformLayout();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDRainbowB)).EndInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDflashLED)).EndInit();
+      this.gBRumble.ResumeLayout(false);
+      this.gBRumble.PerformLayout();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDSZ)).EndInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDSX)).EndInit();
+      this.lbL2TrackS.ResumeLayout(false);
+      this.lbL2TrackS.PerformLayout();
+      this.pnlSATrack.ResumeLayout(false);
+      ((System.ComponentModel.ISupportInitialize)(this.tBR2)).EndInit();
+      ((System.ComponentModel.ISupportInitialize)(this.tBL2)).EndInit();
+      this.pnlSixaxis.ResumeLayout(false);
+      this.pnlSixaxis.PerformLayout();
+      ((System.ComponentModel.ISupportInitialize)(this.tBsixaxisAccelX)).EndInit();
+      ((System.ComponentModel.ISupportInitialize)(this.tBsixaxisGyroX)).EndInit();
+      ((System.ComponentModel.ISupportInitialize)(this.tBsixaxisGyroY)).EndInit();
+      ((System.ComponentModel.ISupportInitialize)(this.tBsixaxisGyroZ)).EndInit();
+      ((System.ComponentModel.ISupportInitialize)(this.tBsixaxisAccelY)).EndInit();
+      ((System.ComponentModel.ISupportInitialize)(this.tBsixaxisAccelZ)).EndInit();
+      this.pnlLSTrack.ResumeLayout(false);
+      this.pnlRSTrack.ResumeLayout(false);
+      this.fLPTiltControls.ResumeLayout(false);
+      this.fLPTiltControls.PerformLayout();
+      this.tCControls.ResumeLayout(false);
+      this.tPControls.ResumeLayout(false);
+      this.pnlController.ResumeLayout(false);
+      ((System.ComponentModel.ISupportInitialize)(this.pBHoveredButton)).EndInit();
+      this.tPSpecial.ResumeLayout(false);
+      this.pnlActions.ResumeLayout(false);
+      this.panel2.ResumeLayout(false);
+      this.fLPActionButtons.ResumeLayout(false);
+      this.tCSens.ResumeLayout(false);
+      this.tPDeadzone.ResumeLayout(false);
+      this.tPDeadzone.PerformLayout();
+      this.antiDeadzoneTabPage.ResumeLayout(false);
+      this.antiDeadzoneTabPage.PerformLayout();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDSixaxisZAntiDead)).EndInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDSixaxisXAntiDead)).EndInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDR2AntiDead)).EndInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDL2AntiDead)).EndInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDRSAntiDead)).EndInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDLSAntiDead)).EndInit();
+      this.maxZoneTabPage.ResumeLayout(false);
+      this.maxZoneTabPage.PerformLayout();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDSixAxisZMaxZone)).EndInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDSixAxisXMaxZone)).EndInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDR2Maxzone)).EndInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDL2Maxzone)).EndInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDRSMaxZone)).EndInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDLSMaxZone)).EndInit();
+      this.squStickTabPage.ResumeLayout(false);
+      this.squStickTabPage.PerformLayout();
+      ((System.ComponentModel.ISupportInitialize)(this.RoundnessNUpDown)).EndInit();
+      this.tPOutCurve.ResumeLayout(false);
+      this.tPOutCurve.PerformLayout();
+      this.tPCurve.ResumeLayout(false);
+      this.tPCurve.PerformLayout();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDLSCurve)).EndInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDRSCurve)).EndInit();
+      this.tpRotation.ResumeLayout(false);
+      this.tpRotation.PerformLayout();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDRSRotation)).EndInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDLSRotation)).EndInit();
+      this.fLPSettings.ResumeLayout(false);
+      this.gBGyro.ResumeLayout(false);
+      this.gBGyro.PerformLayout();
+      this.pnlSAMouse.ResumeLayout(false);
+      this.pnlSAMouse.PerformLayout();
+      ((System.ComponentModel.ISupportInitialize)(this.gyroMouseDzNUD)).EndInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDGyroSmoothWeight)).EndInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDGyroMouseVertScale)).EndInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDGyroSensitivity)).EndInit();
+      this.gBSensitivity.ResumeLayout(false);
+      this.gBSensitivity.PerformLayout();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDL2S)).EndInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDLSS)).EndInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDR2S)).EndInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDRSS)).EndInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDSXS)).EndInit();
+      ((System.ComponentModel.ISupportInitialize)(this.nUDSZS)).EndInit();
+      this.cMGyroTriggers.ResumeLayout(false);
+      this.cMTouchDisableInvert.ResumeLayout(false);
+      this.ResumeLayout(false);
 
         }
 
@@ -4782,5 +4811,7 @@
         private System.Windows.Forms.CheckBox lsSquStickCk;
         private System.Windows.Forms.ComboBox OutContTypeCb;
         private System.Windows.Forms.Label outcontLb;
-    }
+    private System.Windows.Forms.Label label28;
+    private System.Windows.Forms.NumericUpDown RoundnessNUpDown;
+  }
 }

--- a/DS4Windows/DS4Forms/Options.cs
+++ b/DS4Windows/DS4Forms/Options.cs
@@ -688,6 +688,7 @@ namespace DS4Windows.Forms
 
                 lsSquStickCk.Checked = squareStickLS[device];
                 rsSquStickCk.Checked = squareStickRS[device];
+                RoundnessNUpDown.Value = (decimal)squareStickRoundness[device];        
 
                 cBDinput.Checked = DinputOnly[device];
                 olddinputcheck = cBDinput.Checked;
@@ -1330,6 +1331,7 @@ namespace DS4Windows.Forms
             SZAntiDeadzone[device] = (double)nUDSixaxisZAntiDead.Value;
             squareStickLS[device] = lsSquStickCk.Checked;
             squareStickRS[device] = rsSquStickCk.Checked;
+            squareStickRoundness[device] = (double)RoundnessNUpDown.Value;
             MouseAccel[device] = cBMouseAccel.Checked;
             DinputOnly[device] = cBDinput.Checked;
             StartTouchpadOff[device] = cbStartTouchpadOff.Checked;
@@ -3154,7 +3156,14 @@ namespace DS4Windows.Forms
             }
         }
 
-        private void OutContTypeCb_SelectedIndexChanged(object sender, EventArgs e)
+        private void RoundnessNUpDown_ValueChanged(object sender, EventArgs e) 
+        {
+            if (loading == false) {
+                squareStickRoundness[device] = (int)RoundnessNUpDown.Value;
+            }
+        }
+
+    private void OutContTypeCb_SelectedIndexChanged(object sender, EventArgs e)
         {
             if (loading == false)
             {
@@ -3178,7 +3187,7 @@ namespace DS4Windows.Forms
             }
         }
 
-        private void trackFrictionNUD_ValueChanged(object sender, EventArgs e)
+    private void trackFrictionNUD_ValueChanged(object sender, EventArgs e)
         {
             if (loading == false)
             {

--- a/DS4Windows/DS4Forms/Options.resx
+++ b/DS4Windows/DS4Forms/Options.resx
@@ -7165,14 +7165,62 @@ with profile</value>
   <data name="&gt;&gt;maxZoneTabPage.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
+  <data name="RoundnessNUpDown.Location" type="System.Drawing.Point, System.Drawing">
+    <value>216, 17</value>
+  </data>
+  <data name="RoundnessNUpDown.Size" type="System.Drawing.Size, System.Drawing">
+    <value>36, 20</value>
+  </data>
+  <data name="RoundnessNUpDown.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;RoundnessNUpDown.Name" xml:space="preserve">
+    <value>RoundnessNUpDown</value>
+  </data>
+  <data name="&gt;&gt;RoundnessNUpDown.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;RoundnessNUpDown.Parent" xml:space="preserve">
+    <value>squStickTabPage</value>
+  </data>
+  <data name="&gt;&gt;RoundnessNUpDown.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="label28.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label28.Location" type="System.Drawing.Point, System.Drawing">
+    <value>141, 19</value>
+  </data>
+  <data name="label28.Size" type="System.Drawing.Size, System.Drawing">
+    <value>61, 13</value>
+  </data>
+  <data name="label28.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="label28.Text" xml:space="preserve">
+    <value>Roundness</value>
+  </data>
+  <data name="&gt;&gt;label28.Name" xml:space="preserve">
+    <value>label28</value>
+  </data>
+  <data name="&gt;&gt;label28.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label28.Parent" xml:space="preserve">
+    <value>squStickTabPage</value>
+  </data>
+  <data name="&gt;&gt;label28.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
   <data name="rsSquStickCk.Location" type="System.Drawing.Point, System.Drawing">
-    <value>130, 13</value>
+    <value>70, 14</value>
   </data>
   <data name="rsSquStickCk.RightToLeft" type="System.Windows.Forms.RightToLeft, System.Windows.Forms">
     <value>No</value>
   </data>
   <data name="rsSquStickCk.Size" type="System.Drawing.Size, System.Drawing">
-    <value>104, 24</value>
+    <value>43, 24</value>
   </data>
   <data name="rsSquStickCk.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -7190,16 +7238,16 @@ with profile</value>
     <value>squStickTabPage</value>
   </data>
   <data name="&gt;&gt;rsSquStickCk.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>2</value>
   </data>
   <data name="lsSquStickCk.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 13</value>
+    <value>10, 14</value>
   </data>
   <data name="lsSquStickCk.RightToLeft" type="System.Windows.Forms.RightToLeft, System.Windows.Forms">
     <value>No</value>
   </data>
   <data name="lsSquStickCk.Size" type="System.Drawing.Size, System.Drawing">
-    <value>91, 24</value>
+    <value>48, 24</value>
   </data>
   <data name="lsSquStickCk.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -7217,7 +7265,7 @@ with profile</value>
     <value>squStickTabPage</value>
   </data>
   <data name="&gt;&gt;lsSquStickCk.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>3</value>
   </data>
   <data name="squStickTabPage.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>

--- a/DS4Windows/DS4Windows.csproj
+++ b/DS4Windows/DS4Windows.csproj
@@ -28,6 +28,8 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>


### PR DESCRIPTION
This PR implements a selectable field for the value of roundness with the stick squaring algorithm.

The reason for implementing this feature is to add more control over the squaring algorithm, where users can themselves decide what kind of square they would like to go for, instead of being locked to a roundness value of 5.
The default is set to 5.0, to not introduce discrepancies for past users of the squaring feature.

A new field has been added under the  "Square Stick" tab, which represents the roundness.
It accepts values between 0.0 and 5.0 inclusive.

Checkboxes for the stick square have been moved to the left, to accomodate more place for the new roundness control.

This is a solution to issue #738