### PR TITLE
Improvement 1: Pre-defined output curves using a pre-fixed calculation logic. Now only Custom curve uses bezier logic.  Improvent 2: Steering wheel emul mode using vjoy output axis support in UseDInputOnly mode.

### DIFF
--- a/DS4Windows/DS4Control/Mapping.cs
+++ b/DS4Windows/DS4Control/Mapping.cs
@@ -911,89 +911,10 @@ namespace DS4Windows
                 dState.LY = (byte)(tempY * capY + 128.0);
             }
 
-            int lsOutCurveMode = getLsOutCurveMode(device);
-            if (lsOutCurveMode > 0 && (dState.LX != 128 || dState.LY != 128))
+            if (getLsOutCurveMode(device) > 0)
             {
-                double capX = dState.LX >= 128 ? 127.0 : 128.0;
-                double capY = dState.LY >= 128 ? 127.0 : 128.0;
-                double tempX = (dState.LX - 128.0) / capX;
-                double tempY = (dState.LY - 128.0) / capY;
-                double signX = tempX >= 0.0 ? 1.0 : -1.0;
-                double signY = tempY >= 0.0 ? 1.0 : -1.0;
-
-                if (lsOutCurveMode == 1)
-                {
-                    double absX = Math.Abs(tempX);
-                    double absY = Math.Abs(tempY);
-                    double outputX = 0.0;
-                    double outputY = 0.0;
-
-                    if (absX <= 0.4)
-                    {
-                        outputX = 0.55 * absX;
-                    }
-                    else if (absX <= 0.75)
-                    {
-                        outputX = absX - 0.18;
-                    }
-                    else if (absX > 0.75)
-                    {
-                        outputX = (absX * 1.72) - 0.72;
-                    }
-
-                    if (absY <= 0.4)
-                    {
-                        outputY = 0.55 * absY;
-                    }
-                    else if (absY <= 0.75)
-                    {
-                        outputY = absY - 0.18;
-                    }
-                    else if (absY > 0.75)
-                    {
-                        outputY = (absY * 1.72) - 0.72;
-                    }
-
-                    dState.LX = (byte)(outputX * signX * capX + 128.0);
-                    dState.LY = (byte)(outputY * signY * capY + 128.0);
-                }
-                else if (lsOutCurveMode == 2)
-                {
-                    double outputX = tempX * tempX;
-                    double outputY = tempY * tempY;
-                    dState.LX = (byte)(outputX * signX * capX + 128.0);
-                    dState.LY = (byte)(outputY * signY * capY + 128.0);
-                }
-                else if (lsOutCurveMode == 3)
-                {
-                    double outputX = tempX * tempX * tempX;
-                    double outputY = tempY * tempY * tempY;
-                    dState.LX = (byte)(outputX * capX + 128.0);
-                    dState.LY = (byte)(outputY * capY + 128.0);
-                }
-                else if (lsOutCurveMode == 4)
-                {
-                    double absX = Math.Abs(tempX);
-                    double absY = Math.Abs(tempY);
-                    double outputX = absX * (absX - 2.0);
-                    double outputY = absY * (absY - 2.0);
-                    dState.LX = (byte)(-1.0 * outputX * signX * capX + 128.0);
-                    dState.LY = (byte)(-1.0 * outputY * signY * capY + 128.0);
-                }
-                else if (lsOutCurveMode == 5)
-                {
-                    double innerX = Math.Abs(tempX) - 1.0;
-                    double innerY = Math.Abs(tempY) - 1.0;
-                    double outputX = innerX * innerX * innerX + 1.0;
-                    double outputY = innerY * innerY * innerY + 1.0;
-                    dState.LX = (byte)(1.0 * outputX * signX * capX + 128.0);
-                    dState.LY = (byte)(1.0 * outputY * signY * capY + 128.0);
-                }
-                else if (lsOutCurveMode == 6)
-                {
-                    dState.LX = lsOutBezierCurveObj[device].arrayBezierLUT[dState.LX];
-                    dState.LY = lsOutBezierCurveObj[device].arrayBezierLUT[dState.LY];
-                }
+                dState.LX = lsOutBezierCurveObj[device].arrayBezierLUT[dState.LX];
+                dState.LY = lsOutBezierCurveObj[device].arrayBezierLUT[dState.LY];
             }
             
             if (squStk.rsMode && (dState.RX != 128 || dState.RY != 128))
@@ -1014,151 +935,20 @@ namespace DS4Windows
                 dState.RY = (byte)(tempY * capY + 128.0);
             }
 
-            int rsOutCurveMode = getRsOutCurveMode(device);
-            if (rsOutCurveMode > 0 && (dState.RX != 128 || dState.RY != 128))
+            if (getRsOutCurveMode(device) > 0)
             {
-                double capX = dState.RX >= 128 ? 127.0 : 128.0;
-                double capY = dState.RY >= 128 ? 127.0 : 128.0;
-                double tempX = (dState.RX - 128.0) / capX;
-                double tempY = (dState.RY - 128.0) / capY;
-                double signX = tempX >= 0.0 ? 1.0 : -1.0;
-                double signY = tempY >= 0.0 ? 1.0 : -1.0;
-
-                if (rsOutCurveMode == 1)
-                {
-                    double absX = Math.Abs(tempX);
-                    double absY = Math.Abs(tempY);
-                    double outputX = 0.0;
-                    double outputY = 0.0;
-
-                    if (absX <= 0.4)
-                    {
-                        outputX = 0.55 * absX;
-                    }
-                    else if (absX <= 0.75)
-                    {
-                        outputX = absX - 0.18;
-                    }
-                    else if (absX > 0.75)
-                    {
-                        outputX = (absX * 1.72) - 0.72;
-                    }
-
-                    if (absY <= 0.4)
-                    {
-                        outputY = 0.55 * absY;
-                    }
-                    else if (absY <= 0.75)
-                    {
-                        outputY = absY - 0.18;
-                    }
-                    else if (absY > 0.75)
-                    {
-                        outputY = (absY * 1.72) - 0.72;
-                    }
-
-                    dState.RX = (byte)(outputX * signX * capX + 128.0);
-                    dState.RY = (byte)(outputY * signY * capY + 128.0);
-                }
-                else if (rsOutCurveMode == 2)
-                {
-                    double outputX = tempX * tempX;
-                    double outputY = tempY * tempY;
-                    dState.RX = (byte)(outputX * signX * capX + 128.0);
-                    dState.RY = (byte)(outputY * signY * capY + 128.0);
-                }
-                else if (rsOutCurveMode == 3)
-                {
-                    double outputX = tempX * tempX * tempX;
-                    double outputY = tempY * tempY * tempY;
-                    dState.RX = (byte)(outputX * capX + 128.0);
-                    dState.RY = (byte)(outputY * capY + 128.0);
-                }
-                else if (rsOutCurveMode == 4)
-                {
-                    double absX = Math.Abs(tempX);
-                    double absY = Math.Abs(tempY);
-                    double outputX = absX * (absX - 2.0);
-                    double outputY = absY * (absY - 2.0);
-                    dState.RX = (byte)(-1.0 * outputX * signX * capX + 128.0);
-                    dState.RY = (byte)(-1.0 * outputY * signY * capY + 128.0);
-                }
-                else if (rsOutCurveMode == 5)
-                {
-                    double innerX = Math.Abs(tempX) - 1.0;
-                    double innerY = Math.Abs(tempY) - 1.0;
-                    double outputX = innerX * innerX * innerX + 1.0;
-                    double outputY = innerY * innerY * innerY + 1.0;
-                    dState.RX = (byte)(1.0 * outputX * signX * capX + 128.0);
-                    dState.RY = (byte)(1.0 * outputY * signY * capY + 128.0);
-                }
-                else if (rsOutCurveMode == 6)
-                {
-                    dState.RX = rsOutBezierCurveObj[device].arrayBezierLUT[dState.RX];
-                    dState.RY = rsOutBezierCurveObj[device].arrayBezierLUT[dState.RY];
-                }
+                dState.RX = rsOutBezierCurveObj[device].arrayBezierLUT[dState.RX];
+                dState.RY = rsOutBezierCurveObj[device].arrayBezierLUT[dState.RY];
             }
 
-            int l2OutCurveMode = getL2OutCurveMode(device);
-            if (l2OutCurveMode > 0 && dState.L2 != 0)
+            if (getL2OutCurveMode(device) > 0)
             {
-                double temp = dState.L2 / 255.0;
-                if (l2OutCurveMode == 1)
-                {
-                    double output = temp * temp;
-                    dState.L2 = (byte)(output * 255.0);
-                }
-                else if (l2OutCurveMode == 2)
-                {
-                    double output = temp * temp * temp;
-                    dState.L2 = (byte)(output * 255.0);
-                }
-                else if (l2OutCurveMode == 3)
-                {
-                    double output = temp * (temp - 2.0);
-                    dState.L2 = (byte)(-1.0 * output * 255.0);
-                }
-                else if (l2OutCurveMode == 4)
-                {
-                    double inner = Math.Abs(temp) - 1.0;
-                    double output = inner * inner * inner + 1.0;
-                    dState.L2 = (byte)(-1.0 * output * 255.0);
-                }
-                else if (l2OutCurveMode == 5)
-                {
-                    dState.L2 = l2OutBezierCurveObj[device].arrayBezierLUT[dState.L2];
-                }
+                dState.L2 = l2OutBezierCurveObj[device].arrayBezierLUT[dState.L2];
             }
 
-            int r2OutCurveMode = getR2OutCurveMode(device);
-            if (r2OutCurveMode > 0 && dState.R2 != 0)
+            if (getR2OutCurveMode(device) > 0)
             {
-                double temp = dState.R2 / 255.0;
-                if (r2OutCurveMode == 1)
-                {
-                    double output = temp * temp;
-                    dState.R2 = (byte)(output * 255.0);
-                }
-                else if (r2OutCurveMode == 2)
-                {
-                    double output = temp * temp * temp;
-                    dState.R2 = (byte)(output * 255.0);
-                }
-                else if (r2OutCurveMode == 3)
-                {
-                    double output = temp * (temp - 2.0);
-                    dState.R2 = (byte)(-1.0 * output * 255.0);
-                }
-                else if (r2OutCurveMode == 4)
-                {
-                    double inner = Math.Abs(temp) - 1.0;
-                    double output = inner * inner * inner + 1.0;
-                    dState.R2 = (byte)(-1.0 * output * 255.0);
-                }
-                else if (r2OutCurveMode == 5)
-                {
-                    dState.R2 = r2OutBezierCurveObj[device].arrayBezierLUT[dState.R2];
-                }
+                dState.R2 = r2OutBezierCurveObj[device].arrayBezierLUT[dState.R2];
             }
                 
 
@@ -1218,78 +1008,16 @@ namespace DS4Windows
                         (int)Math.Min(128d, szsens * 128d * (absz / 128d));
                 }
 
-                int sxOutCurveMode = getSXOutCurveMode(device);
-                if (sxOutCurveMode > 0)
+                if (getSXOutCurveMode(device) > 0)
                 {
-                    double temp = dState.Motion.outputAccelX / 128.0;
-                    double sign = Math.Sign(temp);
-                    if (sxOutCurveMode == 1)
-                    {
-                        double output = temp * temp;
-                        result = (int)(output * sign * 128.0);
-                        dState.Motion.outputAccelX = result;
-                    }
-                    else if (sxOutCurveMode == 2)
-                    {
-                        double output = temp * temp * temp;
-                        result = (int)(output * 128.0);
-                        dState.Motion.outputAccelX = result;
-                    }
-                    else if (sxOutCurveMode == 3)
-                    {
-                        double abs = Math.Abs(temp);
-                        double output = abs * (abs - 2.0);
-                        dState.Motion.outputAccelX = (byte)(-1.0 * output *
-                            sign * 128.0);
-                    }
-                    else if (sxOutCurveMode == 4)
-                    {
-                        double inner = Math.Abs(temp) - 1.0;
-                        double output = inner * inner * inner + 1.0;
-                        dState.Motion.outputAccelX = (byte)(-1.0 * output * 255.0);
-                    }
-                    else if (sxOutCurveMode == 5)
-                    {
-                        int signSA = Math.Sign(dState.Motion.outputAccelX);
-                        dState.Motion.outputAccelX = sxOutBezierCurveObj[device].arrayBezierLUT[Math.Min(Math.Abs(dState.Motion.outputAccelX), 128)] * signSA;
-                    }
+                    int signSA = Math.Sign(dState.Motion.outputAccelX);
+                    dState.Motion.outputAccelX = sxOutBezierCurveObj[device].arrayBezierLUT[Math.Min(Math.Abs(dState.Motion.outputAccelX), 128)] * signSA;
                 }
 
-                int szOutCurveMode = getSZOutCurveMode(device);
-                if (szOutCurveMode > 0 && dState.Motion.outputAccelZ != 0)
+                if (getSZOutCurveMode(device) > 0)
                 {
-                    double temp = dState.Motion.outputAccelZ / 128.0;
-                    double sign = Math.Sign(temp);
-                    if (szOutCurveMode == 1)
-                    {
-                        double output = temp * temp;
-                        result = (int)(output * sign * 128.0);
-                        dState.Motion.outputAccelZ = result;
-                    }
-                    else if (szOutCurveMode == 2)
-                    {
-                        double output = temp * temp * temp;
-                        result = (int)(output * 128.0);
-                        dState.Motion.outputAccelZ = result;
-                    }
-                    else if (szOutCurveMode == 3)
-                    {
-                        double abs = Math.Abs(temp);
-                        double output = abs * (abs - 2.0);
-                        dState.Motion.outputAccelZ = (byte)(-1.0 * output *
-                            sign * 128.0);
-                    }
-                    else if (szOutCurveMode == 4)
-                    {
-                        double inner = Math.Abs(temp) - 1.0;
-                        double output = inner * inner * inner + 1.0;
-                        dState.Motion.outputAccelZ = (byte)(-1.0 * output * 255.0);
-                    }
-                    else if (szOutCurveMode == 5)
-                    {
-                        int signSA = Math.Sign(dState.Motion.outputAccelZ);
-                        dState.Motion.outputAccelZ = szOutBezierCurveObj[device].arrayBezierLUT[Math.Min(Math.Abs(dState.Motion.outputAccelZ), 128)] * signSA;
-                    }
+                    int signSA = Math.Sign(dState.Motion.outputAccelZ);
+                    dState.Motion.outputAccelZ = szOutBezierCurveObj[device].arrayBezierLUT[Math.Min(Math.Abs(dState.Motion.outputAccelZ), 128)] * signSA;
                 }
             }
 

--- a/DS4Windows/DS4Control/ScpUtil.cs
+++ b/DS4Windows/DS4Control/ScpUtil.cs
@@ -1717,11 +1717,11 @@ namespace DS4Windows
             // Set bezier curve obj of axis. 0=Linear (no curve mapping), 1-5=Pre-defined curves, 6=User supplied custom curve string value of a profile (comma separated list of 4 decimal numbers)
             switch (curveOptionValue)
             {
-                case 1: bezierCurveArray[device].InitBezierCurve(99.0, 99.0, 0.00, 0.00, axisType); break;  // Enhanced Precision (hard-coded curve) (The same curve as bezier 0.70, 0.28, 1.00, 1.00)
-                case 2: bezierCurveArray[device].InitBezierCurve(0.55, 0.09, 0.68, 0.53, axisType); break;  // Quadric
-                case 3: bezierCurveArray[device].InitBezierCurve(0.74, 0.12, 0.64, 0.29, axisType); break;  // Cubic
-                case 4: bezierCurveArray[device].InitBezierCurve(0.00, 0.00, 0.41, 0.96, axisType); break;  // Easeout Quad
-                case 5: bezierCurveArray[device].InitBezierCurve(0.08, 0.22, 0.22, 0.91, axisType); break;  // Easeout Cubic
+                case 1: bezierCurveArray[device].InitBezierCurve(99.0, 91.0, 0.00, 0.00, axisType); break;  // Enhanced Precision (hard-coded curve) (almost the same curve as bezier 0.70, 0.28, 1.00, 1.00)
+                case 2: bezierCurveArray[device].InitBezierCurve(99.0, 92.0, 0.00, 0.00, axisType); break;  // Quadric
+                case 3: bezierCurveArray[device].InitBezierCurve(99.0, 93.0, 0.00, 0.00, axisType); break;  // Cubic
+                case 4: bezierCurveArray[device].InitBezierCurve(99.0, 94.0, 0.00, 0.00, axisType); break;  // Easeout Quad
+                case 5: bezierCurveArray[device].InitBezierCurve(99.0, 95.0, 0.00, 0.00, axisType); break;  // Easeout Cubic
                 case 6: bezierCurveArray[device].InitBezierCurve(bezierCurveArray[device].CustomDefinition, axisType); break;  // Custom output curve
             }
         }


### PR DESCRIPTION
Pre-defined output curves initialized using a pre-fixed formula. Now only the "Custom" output curve goes through bezier curve logic, but at runtime all output curve options are mapped using a lookup table (better performance and easier code maintenance).