### PR TITLE
Fixed the output curve handling for L2/R2/SX/SZ axies in the original IF-THEN-ELSE logic. All axies have nowadays EnchPrecision option in GUI dropdown listbox, so outputCurve=1 is now EnchPrecision curve in all axies and 6 is custom.

### DIFF
--- a/DS4Windows/DS4Control/Mapping.cs
+++ b/DS4Windows/DS4Control/Mapping.cs
@@ -1105,26 +1105,38 @@ namespace DS4Windows
                 double temp = dState.L2 / 255.0;
                 if (l2OutCurveMode == 1)
                 {
-                    double output = temp * temp;
+                    double output;
+
+                    if (temp <= 0.4)
+                        output = 0.55 * temp;
+                    else if (temp <= 0.75)
+                        output = temp - 0.18;
+                    else // if (temp > 0.75)
+                        output = (temp * 1.72) - 0.72;
                     dState.L2 = (byte)(output * 255.0);
                 }
                 else if (l2OutCurveMode == 2)
                 {
-                    double output = temp * temp * temp;
+                    double output = temp * temp;
                     dState.L2 = (byte)(output * 255.0);
                 }
                 else if (l2OutCurveMode == 3)
                 {
+                    double output = temp * temp * temp;
+                    dState.L2 = (byte)(output * 255.0);
+                }
+                else if (l2OutCurveMode == 4)
+                {
                     double output = temp * (temp - 2.0);
                     dState.L2 = (byte)(-1.0 * output * 255.0);
                 }
-                else if (l2OutCurveMode == 4)
+                else if (l2OutCurveMode == 5)
                 {
                     double inner = Math.Abs(temp) - 1.0;
                     double output = inner * inner * inner + 1.0;
                     dState.L2 = (byte)(-1.0 * output * 255.0);
                 }
-                else if (l2OutCurveMode == 5)
+                else if (l2OutCurveMode == 6)
                 {
                     dState.L2 = l2OutBezierCurveObj[device].arrayBezierLUT[dState.L2];
                 }
@@ -1136,26 +1148,38 @@ namespace DS4Windows
                 double temp = dState.R2 / 255.0;
                 if (r2OutCurveMode == 1)
                 {
-                    double output = temp * temp;
+                    double output;
+
+                    if (temp <= 0.4)
+                        output = 0.55 * temp;
+                    else if (temp <= 0.75)
+                        output = temp - 0.18;
+                    else // if (temp > 0.75)
+                        output = (temp * 1.72) - 0.72;
                     dState.R2 = (byte)(output * 255.0);
                 }
                 else if (r2OutCurveMode == 2)
                 {
-                    double output = temp * temp * temp;
+                    double output = temp * temp;
                     dState.R2 = (byte)(output * 255.0);
                 }
                 else if (r2OutCurveMode == 3)
                 {
+                    double output = temp * temp * temp;
+                    dState.R2 = (byte)(output * 255.0);
+                }
+                else if (r2OutCurveMode == 4)
+                {
                     double output = temp * (temp - 2.0);
                     dState.R2 = (byte)(-1.0 * output * 255.0);
                 }
-                else if (r2OutCurveMode == 4)
+                else if (r2OutCurveMode == 5)
                 {
                     double inner = Math.Abs(temp) - 1.0;
                     double output = inner * inner * inner + 1.0;
                     dState.R2 = (byte)(-1.0 * output * 255.0);
                 }
-                else if (r2OutCurveMode == 5)
+                else if (r2OutCurveMode == 6)
                 {
                     dState.R2 = r2OutBezierCurveObj[device].arrayBezierLUT[dState.R2];
                 }
@@ -1225,30 +1249,43 @@ namespace DS4Windows
                     double sign = Math.Sign(temp);
                     if (sxOutCurveMode == 1)
                     {
+                        double output;
+                        double abs = Math.Abs(temp);
+
+                        if (abs <= 0.4)
+                            output = 0.55 * abs;
+                        else if (abs <= 0.75)
+                            output = abs - 0.18;
+                        else // if (abs > 0.75)
+                            output = (abs * 1.72) - 0.72;
+                        dState.Motion.outputAccelX = (byte)(output * sign * 128.0);
+                    }
+                    else if (sxOutCurveMode == 2)
+                    {
                         double output = temp * temp;
                         result = (int)(output * sign * 128.0);
                         dState.Motion.outputAccelX = result;
                     }
-                    else if (sxOutCurveMode == 2)
+                    else if (sxOutCurveMode == 3)
                     {
                         double output = temp * temp * temp;
                         result = (int)(output * 128.0);
                         dState.Motion.outputAccelX = result;
                     }
-                    else if (sxOutCurveMode == 3)
+                    else if (sxOutCurveMode == 4)
                     {
                         double abs = Math.Abs(temp);
                         double output = abs * (abs - 2.0);
                         dState.Motion.outputAccelX = (byte)(-1.0 * output *
                             sign * 128.0);
                     }
-                    else if (sxOutCurveMode == 4)
+                    else if (sxOutCurveMode == 5)
                     {
                         double inner = Math.Abs(temp) - 1.0;
                         double output = inner * inner * inner + 1.0;
                         dState.Motion.outputAccelX = (byte)(-1.0 * output * 255.0);
                     }
-                    else if (sxOutCurveMode == 5)
+                    else if (sxOutCurveMode == 6)
                     {
                         int signSA = Math.Sign(dState.Motion.outputAccelX);
                         dState.Motion.outputAccelX = sxOutBezierCurveObj[device].arrayBezierLUT[Math.Min(Math.Abs(dState.Motion.outputAccelX), 128)] * signSA;
@@ -1262,30 +1299,43 @@ namespace DS4Windows
                     double sign = Math.Sign(temp);
                     if (szOutCurveMode == 1)
                     {
+                        double output;
+                        double abs = Math.Abs(temp);
+
+                        if (abs <= 0.4)
+                            output = 0.55 * abs;
+                        else if (abs <= 0.75)
+                            output = abs - 0.18;
+                        else // if (abs > 0.75)
+                            output = (abs * 1.72) - 0.72;
+                        dState.Motion.outputAccelZ = (byte)(output * sign * 128.0);
+                    }
+                    else if (szOutCurveMode == 2)
+                    {
                         double output = temp * temp;
                         result = (int)(output * sign * 128.0);
                         dState.Motion.outputAccelZ = result;
                     }
-                    else if (szOutCurveMode == 2)
+                    else if (szOutCurveMode == 3)
                     {
                         double output = temp * temp * temp;
                         result = (int)(output * 128.0);
                         dState.Motion.outputAccelZ = result;
                     }
-                    else if (szOutCurveMode == 3)
+                    else if (szOutCurveMode == 4)
                     {
                         double abs = Math.Abs(temp);
                         double output = abs * (abs - 2.0);
                         dState.Motion.outputAccelZ = (byte)(-1.0 * output *
                             sign * 128.0);
                     }
-                    else if (szOutCurveMode == 4)
+                    else if (szOutCurveMode == 5)
                     {
                         double inner = Math.Abs(temp) - 1.0;
                         double output = inner * inner * inner + 1.0;
                         dState.Motion.outputAccelZ = (byte)(-1.0 * output * 255.0);
                     }
-                    else if (szOutCurveMode == 5)
+                    else if (szOutCurveMode == 6)
                     {
                         int signSA = Math.Sign(dState.Motion.outputAccelZ);
                         dState.Motion.outputAccelZ = szOutBezierCurveObj[device].arrayBezierLUT[Math.Min(Math.Abs(dState.Motion.outputAccelZ), 128)] * signSA;

--- a/DS4Windows/DS4Control/ScpUtil.cs
+++ b/DS4Windows/DS4Control/ScpUtil.cs
@@ -1717,11 +1717,13 @@ namespace DS4Windows
             // Set bezier curve obj of axis. 0=Linear (no curve mapping), 1-5=Pre-defined curves, 6=User supplied custom curve string value of a profile (comma separated list of 4 decimal numbers)
             switch (curveOptionValue)
             {
-                case 1: bezierCurveArray[device].InitBezierCurve(99.0, 91.0, 0.00, 0.00, axisType); break;  // Enhanced Precision (hard-coded curve) (almost the same curve as bezier 0.70, 0.28, 1.00, 1.00)
-                case 2: bezierCurveArray[device].InitBezierCurve(99.0, 92.0, 0.00, 0.00, axisType); break;  // Quadric
-                case 3: bezierCurveArray[device].InitBezierCurve(99.0, 93.0, 0.00, 0.00, axisType); break;  // Cubic
-                case 4: bezierCurveArray[device].InitBezierCurve(99.0, 94.0, 0.00, 0.00, axisType); break;  // Easeout Quad
-                case 5: bezierCurveArray[device].InitBezierCurve(99.0, 95.0, 0.00, 0.00, axisType); break;  // Easeout Cubic
+                // Commented out case 1..5 because Mapping.cs:SetCurveAndDeadzone function has the original IF-THEN-ELSE code logic for those original 1..5 output curve mappings (ie. no need to initialize the lookup result table).
+                // Only the new bezier custom curve option 6 uses the lookup result table (initialized in BezierCurve class based on an input curve definition).
+                //case 1: bezierCurveArray[device].InitBezierCurve(99.0, 91.0, 0.00, 0.00, axisType); break;  // Enhanced Precision (hard-coded curve) (almost the same curve as bezier 0.70, 0.28, 1.00, 1.00)
+                //case 2: bezierCurveArray[device].InitBezierCurve(99.0, 92.0, 0.00, 0.00, axisType); break;  // Quadric
+                //case 3: bezierCurveArray[device].InitBezierCurve(99.0, 93.0, 0.00, 0.00, axisType); break;  // Cubic
+                //case 4: bezierCurveArray[device].InitBezierCurve(99.0, 94.0, 0.00, 0.00, axisType); break;  // Easeout Quad
+                //case 5: bezierCurveArray[device].InitBezierCurve(99.0, 95.0, 0.00, 0.00, axisType); break;  // Easeout Cubic
                 case 6: bezierCurveArray[device].InitBezierCurve(bezierCurveArray[device].CustomDefinition, axisType); break;  // Custom output curve
             }
         }


### PR DESCRIPTION
Nowadays all output axies have "Enhanced Precision" output curve option in GUI dropdown list. Added EnchPrecision curveOutput==1 IF-THEN-ELSE block to l2/r2/sx/sz curve output code logic and curveOutput=6 is the new custom option in all axies.

When the bezier output curve logic was merged into the master branch, but then the original IF-THEN-ELSE output curve was restored, the code was no longer in sync with Options GUI screen. All axies have nowadays EnchancedPrecision output curve in GUI dropdown list (originally only RS/LS axies had it). The original if-then-else code didn't handle this properly because the original if-then-else logic calculated EnchPrecision only for LS/RS axies.

This pull request fixes that issue and adds EnchPrecision to L2/R2/SZ/SX axies also.
