### PR TITLE
Modified the layout of axis configuration Options tab page

### DIFF
--- a/DS4Windows/DS4Forms/Options.Designer.cs
+++ b/DS4Windows/DS4Forms/Options.Designer.cs
@@ -255,17 +255,30 @@
             this.btnChargingColor = new System.Windows.Forms.Button();
             this.lbWhileCharging = new System.Windows.Forms.Label();
             this.panel5 = new System.Windows.Forms.Panel();
+            this.label1 = new System.Windows.Forms.Label();
+            this.maxRainSatTB = new System.Windows.Forms.TrackBar();
             this.btnRainbow = new System.Windows.Forms.Button();
             this.nUDRainbow = new System.Windows.Forms.NumericUpDown();
             this.lbspc = new System.Windows.Forms.Label();
             this.tabAxis = new System.Windows.Forms.TabPage();
             this.flowLayoutPanel3 = new System.Windows.Forms.FlowLayoutPanel();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
-            this.tBCustomOutputCurve = new System.Windows.Forms.TextBox();
-            this.lbCurveEditorURL = new System.Windows.Forms.LinkLabel();
+            this.label4 = new System.Windows.Forms.Label();
+            this.nUDRSRotation = new System.Windows.Forms.NumericUpDown();
+            this.btnRSCurveEditor = new System.Windows.Forms.Button();
+            this.lbRSCurvePercent = new System.Windows.Forms.Label();
+            this.tBRSCustomOutputCurve = new System.Windows.Forms.TextBox();
+            this.nUDRSCurve = new System.Windows.Forms.NumericUpDown();
+            this.BtnLSCurveEditor = new System.Windows.Forms.Button();
+            this.label3 = new System.Windows.Forms.Label();
+            this.rsSquStickCk = new System.Windows.Forms.CheckBox();
+            this.numericUpDown1 = new System.Windows.Forms.NumericUpDown();
+            this.label2 = new System.Windows.Forms.Label();
+            this.tBLSCustomOutputCurve = new System.Windows.Forms.TextBox();
+            this.rsOutCurveComboBox = new System.Windows.Forms.ComboBox();
+            this.nUDRSS = new System.Windows.Forms.NumericUpDown();
             this.nUDLSS = new System.Windows.Forms.NumericUpDown();
             this.label69 = new System.Windows.Forms.Label();
-            this.label46 = new System.Windows.Forms.Label();
             this.RoundnessNUpDown = new System.Windows.Forms.NumericUpDown();
             this.lsSquStickCk = new System.Windows.Forms.CheckBox();
             this.nUDLSRotation = new System.Windows.Forms.NumericUpDown();
@@ -275,39 +288,30 @@
             this.label44 = new System.Windows.Forms.Label();
             this.lsOutCurveComboBox = new System.Windows.Forms.ComboBox();
             this.label43 = new System.Windows.Forms.Label();
+            this.nUDRSAntiDead = new System.Windows.Forms.NumericUpDown();
             this.nUDLSAntiDead = new System.Windows.Forms.NumericUpDown();
             this.label42 = new System.Windows.Forms.Label();
+            this.nUDRSMaxZone = new System.Windows.Forms.NumericUpDown();
             this.nUDLSMaxZone = new System.Windows.Forms.NumericUpDown();
             this.label41 = new System.Windows.Forms.Label();
+            this.nUDRS = new System.Windows.Forms.NumericUpDown();
             this.nUDLS = new System.Windows.Forms.NumericUpDown();
             this.label40 = new System.Windows.Forms.Label();
-            this.groupBox2 = new System.Windows.Forms.GroupBox();
-            this.tBRSCustomOutputCurve = new System.Windows.Forms.TextBox();
-            this.lbRSCurveEditorURL = new System.Windows.Forms.LinkLabel();
-            this.nUDRSS = new System.Windows.Forms.NumericUpDown();
-            this.label70 = new System.Windows.Forms.Label();
-            this.rsOutCurveComboBox = new System.Windows.Forms.ComboBox();
-            this.nUDRSRotation = new System.Windows.Forms.NumericUpDown();
-            this.label52 = new System.Windows.Forms.Label();
-            this.lbRSCurvePercent = new System.Windows.Forms.Label();
-            this.nUDRSCurve = new System.Windows.Forms.NumericUpDown();
-            this.label51 = new System.Windows.Forms.Label();
-            this.rsSquStickCk = new System.Windows.Forms.CheckBox();
-            this.numericUpDown1 = new System.Windows.Forms.NumericUpDown();
-            this.label28 = new System.Windows.Forms.Label();
-            this.label50 = new System.Windows.Forms.Label();
-            this.nUDRSAntiDead = new System.Windows.Forms.NumericUpDown();
-            this.label49 = new System.Windows.Forms.Label();
-            this.nUDRSMaxZone = new System.Windows.Forms.NumericUpDown();
-            this.label48 = new System.Windows.Forms.Label();
-            this.nUDRS = new System.Windows.Forms.NumericUpDown();
-            this.label47 = new System.Windows.Forms.Label();
             this.groupBox3 = new System.Windows.Forms.GroupBox();
+            this.btnR2CurveEditor = new System.Windows.Forms.Button();
+            this.btnL2CurveEditor = new System.Windows.Forms.Button();
+            this.tBR2CustomOutputCurve = new System.Windows.Forms.TextBox();
+            this.label6 = new System.Windows.Forms.Label();
+            this.label5 = new System.Windows.Forms.Label();
+            this.nUDR2S = new System.Windows.Forms.NumericUpDown();
             this.tBL2CustomOutputCurve = new System.Windows.Forms.TextBox();
-            this.lbL2CurveEditorURL = new System.Windows.Forms.LinkLabel();
+            this.cBR2OutputCurve = new System.Windows.Forms.ComboBox();
             this.nUDL2S = new System.Windows.Forms.NumericUpDown();
+            this.nUDR2AntiDead = new System.Windows.Forms.NumericUpDown();
             this.label71 = new System.Windows.Forms.Label();
+            this.nUDR2Maxzone = new System.Windows.Forms.NumericUpDown();
             this.cBL2OutputCurve = new System.Windows.Forms.ComboBox();
+            this.nUDR2 = new System.Windows.Forms.NumericUpDown();
             this.nUDL2AntiDead = new System.Windows.Forms.NumericUpDown();
             this.nUDL2Maxzone = new System.Windows.Forms.NumericUpDown();
             this.nUDL2 = new System.Windows.Forms.NumericUpDown();
@@ -315,42 +319,26 @@
             this.label55 = new System.Windows.Forms.Label();
             this.label56 = new System.Windows.Forms.Label();
             this.label57 = new System.Windows.Forms.Label();
-            this.groupBox4 = new System.Windows.Forms.GroupBox();
-            this.tBR2CustomOutputCurve = new System.Windows.Forms.TextBox();
-            this.lbR2CurveEditorURL = new System.Windows.Forms.LinkLabel();
-            this.nUDR2S = new System.Windows.Forms.NumericUpDown();
-            this.label72 = new System.Windows.Forms.Label();
-            this.cBR2OutputCurve = new System.Windows.Forms.ComboBox();
-            this.nUDR2AntiDead = new System.Windows.Forms.NumericUpDown();
-            this.nUDR2Maxzone = new System.Windows.Forms.NumericUpDown();
-            this.nUDR2 = new System.Windows.Forms.NumericUpDown();
-            this.label53 = new System.Windows.Forms.Label();
-            this.label58 = new System.Windows.Forms.Label();
-            this.label59 = new System.Windows.Forms.Label();
-            this.label60 = new System.Windows.Forms.Label();
             this.groupBox5 = new System.Windows.Forms.GroupBox();
+            this.btnSixZCurveEditor = new System.Windows.Forms.Button();
+            this.btnSixXCurveEditor = new System.Windows.Forms.Button();
+            this.label8 = new System.Windows.Forms.Label();
+            this.label7 = new System.Windows.Forms.Label();
             this.tBSixZCustomOutputCurve = new System.Windows.Forms.TextBox();
-            this.lbSixZCurveEditorURL = new System.Windows.Forms.LinkLabel();
             this.tBSixXCustomOutputCurve = new System.Windows.Forms.TextBox();
-            this.lbSixXCurveEditorURL = new System.Windows.Forms.LinkLabel();
             this.nUDSZS = new System.Windows.Forms.NumericUpDown();
             this.nUDSXS = new System.Windows.Forms.NumericUpDown();
-            this.label74 = new System.Windows.Forms.Label();
             this.label73 = new System.Windows.Forms.Label();
             this.cBSixaxisZOutputCurve = new System.Windows.Forms.ComboBox();
-            this.label68 = new System.Windows.Forms.Label();
             this.cBSixaxisXOutputCurve = new System.Windows.Forms.ComboBox();
             this.label67 = new System.Windows.Forms.Label();
             this.nUDSixaxisZAntiDead = new System.Windows.Forms.NumericUpDown();
-            this.label66 = new System.Windows.Forms.Label();
             this.nUDSixaxisXAntiDead = new System.Windows.Forms.NumericUpDown();
             this.label65 = new System.Windows.Forms.Label();
             this.nUDSixAxisZMaxZone = new System.Windows.Forms.NumericUpDown();
-            this.label64 = new System.Windows.Forms.Label();
             this.nUDSixAxisXMaxZone = new System.Windows.Forms.NumericUpDown();
             this.label63 = new System.Windows.Forms.Label();
             this.nUDSZ = new System.Windows.Forms.NumericUpDown();
-            this.label62 = new System.Windows.Forms.Label();
             this.nUDSX = new System.Windows.Forms.NumericUpDown();
             this.label61 = new System.Windows.Forms.Label();
             this.tabGyro = new System.Windows.Forms.TabPage();
@@ -452,8 +440,6 @@
             this.panel12 = new System.Windows.Forms.Panel();
             this.OutContTypeCb = new System.Windows.Forms.ComboBox();
             this.outcontLb = new System.Windows.Forms.Label();
-            this.maxRainSatTB = new System.Windows.Forms.TrackBar();
-            this.label1 = new System.Windows.Forms.Label();
             ((System.ComponentModel.ISupportInitialize)(this.nUDTap)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nUDScroll)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nUDTouch)).BeginInit();
@@ -501,35 +487,34 @@
             ((System.ComponentModel.ISupportInitialize)(this.nUDflashLED)).BeginInit();
             this.panel4.SuspendLayout();
             this.panel5.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.maxRainSatTB)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nUDRainbow)).BeginInit();
             this.tabAxis.SuspendLayout();
             this.flowLayoutPanel3.SuspendLayout();
             this.groupBox1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.nUDRSRotation)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nUDRSCurve)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown1)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nUDRSS)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nUDLSS)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.RoundnessNUpDown)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nUDLSRotation)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nUDLSCurve)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDLSAntiDead)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDLSMaxZone)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDLS)).BeginInit();
-            this.groupBox2.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDRSS)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDRSRotation)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDRSCurve)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown1)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nUDRSAntiDead)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nUDLSAntiDead)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nUDRSMaxZone)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nUDLSMaxZone)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nUDRS)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nUDLS)).BeginInit();
             this.groupBox3.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDL2S)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDL2AntiDead)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDL2Maxzone)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDL2)).BeginInit();
-            this.groupBox4.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.nUDR2S)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nUDL2S)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nUDR2AntiDead)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nUDR2Maxzone)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nUDR2)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nUDL2AntiDead)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nUDL2Maxzone)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nUDL2)).BeginInit();
             this.groupBox5.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.nUDSZS)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nUDSXS)).BeginInit();
@@ -569,7 +554,6 @@
             ((System.ComponentModel.ISupportInitialize)(this.nUDIdleDisconnect)).BeginInit();
             this.panel11.SuspendLayout();
             this.panel12.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.maxRainSatTB)).BeginInit();
             this.SuspendLayout();
             // 
             // cBLightbyBattery
@@ -2720,6 +2704,19 @@
             resources.ApplyResources(this.panel5, "panel5");
             this.panel5.Name = "panel5";
             // 
+            // label1
+            // 
+            resources.ApplyResources(this.label1, "label1");
+            this.label1.Name = "label1";
+            // 
+            // maxRainSatTB
+            // 
+            resources.ApplyResources(this.maxRainSatTB, "maxRainSatTB");
+            this.maxRainSatTB.Maximum = 100;
+            this.maxRainSatTB.Name = "maxRainSatTB";
+            this.maxRainSatTB.TickStyle = System.Windows.Forms.TickStyle.None;
+            this.maxRainSatTB.Value = 100;
+            // 
             // btnRainbow
             // 
             this.btnRainbow.Image = global::DS4Windows.Properties.Resources.rainbow;
@@ -2753,19 +2750,28 @@
             // 
             resources.ApplyResources(this.flowLayoutPanel3, "flowLayoutPanel3");
             this.flowLayoutPanel3.Controls.Add(this.groupBox1);
-            this.flowLayoutPanel3.Controls.Add(this.groupBox2);
             this.flowLayoutPanel3.Controls.Add(this.groupBox3);
-            this.flowLayoutPanel3.Controls.Add(this.groupBox4);
             this.flowLayoutPanel3.Controls.Add(this.groupBox5);
             this.flowLayoutPanel3.Name = "flowLayoutPanel3";
             // 
             // groupBox1
             // 
-            this.groupBox1.Controls.Add(this.tBCustomOutputCurve);
-            this.groupBox1.Controls.Add(this.lbCurveEditorURL);
+            this.groupBox1.Controls.Add(this.label4);
+            this.groupBox1.Controls.Add(this.nUDRSRotation);
+            this.groupBox1.Controls.Add(this.btnRSCurveEditor);
+            this.groupBox1.Controls.Add(this.lbRSCurvePercent);
+            this.groupBox1.Controls.Add(this.tBRSCustomOutputCurve);
+            this.groupBox1.Controls.Add(this.nUDRSCurve);
+            this.groupBox1.Controls.Add(this.BtnLSCurveEditor);
+            this.groupBox1.Controls.Add(this.label3);
+            this.groupBox1.Controls.Add(this.rsSquStickCk);
+            this.groupBox1.Controls.Add(this.numericUpDown1);
+            this.groupBox1.Controls.Add(this.label2);
+            this.groupBox1.Controls.Add(this.tBLSCustomOutputCurve);
+            this.groupBox1.Controls.Add(this.rsOutCurveComboBox);
+            this.groupBox1.Controls.Add(this.nUDRSS);
             this.groupBox1.Controls.Add(this.nUDLSS);
             this.groupBox1.Controls.Add(this.label69);
-            this.groupBox1.Controls.Add(this.label46);
             this.groupBox1.Controls.Add(this.RoundnessNUpDown);
             this.groupBox1.Controls.Add(this.lsSquStickCk);
             this.groupBox1.Controls.Add(this.nUDLSRotation);
@@ -2775,26 +2781,156 @@
             this.groupBox1.Controls.Add(this.label44);
             this.groupBox1.Controls.Add(this.lsOutCurveComboBox);
             this.groupBox1.Controls.Add(this.label43);
+            this.groupBox1.Controls.Add(this.nUDRSAntiDead);
             this.groupBox1.Controls.Add(this.nUDLSAntiDead);
             this.groupBox1.Controls.Add(this.label42);
+            this.groupBox1.Controls.Add(this.nUDRSMaxZone);
             this.groupBox1.Controls.Add(this.nUDLSMaxZone);
             this.groupBox1.Controls.Add(this.label41);
+            this.groupBox1.Controls.Add(this.nUDRS);
             this.groupBox1.Controls.Add(this.nUDLS);
             this.groupBox1.Controls.Add(this.label40);
             resources.ApplyResources(this.groupBox1, "groupBox1");
             this.groupBox1.Name = "groupBox1";
             this.groupBox1.TabStop = false;
             // 
-            // tBCustomOutputCurve
+            // label4
             // 
-            resources.ApplyResources(this.tBCustomOutputCurve, "tBCustomOutputCurve");
-            this.tBCustomOutputCurve.Name = "tBCustomOutputCurve";
+            resources.ApplyResources(this.label4, "label4");
+            this.label4.Name = "label4";
             // 
-            // lbCurveEditorURL
+            // nUDRSRotation
             // 
-            resources.ApplyResources(this.lbCurveEditorURL, "lbCurveEditorURL");
-            this.lbCurveEditorURL.Name = "lbCurveEditorURL";
-            this.lbCurveEditorURL.TabStop = true;
+            resources.ApplyResources(this.nUDRSRotation, "nUDRSRotation");
+            this.nUDRSRotation.Maximum = new decimal(new int[] {
+            180,
+            0,
+            0,
+            0});
+            this.nUDRSRotation.Minimum = new decimal(new int[] {
+            180,
+            0,
+            0,
+            -2147483648});
+            this.nUDRSRotation.Name = "nUDRSRotation";
+            // 
+            // btnRSCurveEditor
+            // 
+            resources.ApplyResources(this.btnRSCurveEditor, "btnRSCurveEditor");
+            this.btnRSCurveEditor.Name = "btnRSCurveEditor";
+            this.btnRSCurveEditor.UseVisualStyleBackColor = true;
+            this.btnRSCurveEditor.Click += new System.EventHandler(this.BtnCurveEditor_Click);
+            // 
+            // lbRSCurvePercent
+            // 
+            resources.ApplyResources(this.lbRSCurvePercent, "lbRSCurvePercent");
+            this.lbRSCurvePercent.Name = "lbRSCurvePercent";
+            // 
+            // tBRSCustomOutputCurve
+            // 
+            resources.ApplyResources(this.tBRSCustomOutputCurve, "tBRSCustomOutputCurve");
+            this.tBRSCustomOutputCurve.Name = "tBRSCustomOutputCurve";
+            // 
+            // nUDRSCurve
+            // 
+            this.nUDRSCurve.Increment = new decimal(new int[] {
+            10,
+            0,
+            0,
+            0});
+            resources.ApplyResources(this.nUDRSCurve, "nUDRSCurve");
+            this.nUDRSCurve.Name = "nUDRSCurve";
+            // 
+            // BtnLSCurveEditor
+            // 
+            resources.ApplyResources(this.BtnLSCurveEditor, "BtnLSCurveEditor");
+            this.BtnLSCurveEditor.Name = "BtnLSCurveEditor";
+            this.BtnLSCurveEditor.UseVisualStyleBackColor = true;
+            this.BtnLSCurveEditor.Click += new System.EventHandler(this.BtnCurveEditor_Click);
+            // 
+            // label3
+            // 
+            resources.ApplyResources(this.label3, "label3");
+            this.label3.Name = "label3";
+            // 
+            // rsSquStickCk
+            // 
+            resources.ApplyResources(this.rsSquStickCk, "rsSquStickCk");
+            this.rsSquStickCk.Name = "rsSquStickCk";
+            this.rsSquStickCk.UseVisualStyleBackColor = true;
+            // 
+            // numericUpDown1
+            // 
+            this.numericUpDown1.DecimalPlaces = 1;
+            this.numericUpDown1.Increment = new decimal(new int[] {
+            1,
+            0,
+            0,
+            65536});
+            resources.ApplyResources(this.numericUpDown1, "numericUpDown1");
+            this.numericUpDown1.Maximum = new decimal(new int[] {
+            5,
+            0,
+            0,
+            0});
+            this.numericUpDown1.Name = "numericUpDown1";
+            this.numericUpDown1.Value = new decimal(new int[] {
+            50,
+            0,
+            0,
+            65536});
+            // 
+            // label2
+            // 
+            resources.ApplyResources(this.label2, "label2");
+            this.label2.Name = "label2";
+            // 
+            // tBLSCustomOutputCurve
+            // 
+            resources.ApplyResources(this.tBLSCustomOutputCurve, "tBLSCustomOutputCurve");
+            this.tBLSCustomOutputCurve.Name = "tBLSCustomOutputCurve";
+            // 
+            // rsOutCurveComboBox
+            // 
+            this.rsOutCurveComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.rsOutCurveComboBox.DropDownWidth = 120;
+            this.rsOutCurveComboBox.FormattingEnabled = true;
+            this.rsOutCurveComboBox.Items.AddRange(new object[] {
+            resources.GetString("rsOutCurveComboBox.Items"),
+            resources.GetString("rsOutCurveComboBox.Items1"),
+            resources.GetString("rsOutCurveComboBox.Items2"),
+            resources.GetString("rsOutCurveComboBox.Items3"),
+            resources.GetString("rsOutCurveComboBox.Items4"),
+            resources.GetString("rsOutCurveComboBox.Items5"),
+            resources.GetString("rsOutCurveComboBox.Items6")});
+            resources.ApplyResources(this.rsOutCurveComboBox, "rsOutCurveComboBox");
+            this.rsOutCurveComboBox.Name = "rsOutCurveComboBox";
+            // 
+            // nUDRSS
+            // 
+            this.nUDRSS.DecimalPlaces = 2;
+            this.nUDRSS.Increment = new decimal(new int[] {
+            1,
+            0,
+            0,
+            65536});
+            resources.ApplyResources(this.nUDRSS, "nUDRSS");
+            this.nUDRSS.Maximum = new decimal(new int[] {
+            5,
+            0,
+            0,
+            0});
+            this.nUDRSS.Minimum = new decimal(new int[] {
+            5,
+            0,
+            0,
+            65536});
+            this.nUDRSS.Name = "nUDRSS";
+            this.nUDRSS.Value = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
             // 
             // nUDLSS
             // 
@@ -2826,11 +2962,6 @@
             // 
             resources.ApplyResources(this.label69, "label69");
             this.label69.Name = "label69";
-            // 
-            // label46
-            // 
-            resources.ApplyResources(this.label46, "label46");
-            this.label46.Name = "label46";
             // 
             // RoundnessNUpDown
             // 
@@ -2920,6 +3051,27 @@
             resources.ApplyResources(this.label43, "label43");
             this.label43.Name = "label43";
             // 
+            // nUDRSAntiDead
+            // 
+            this.nUDRSAntiDead.DecimalPlaces = 2;
+            this.nUDRSAntiDead.Increment = new decimal(new int[] {
+            1,
+            0,
+            0,
+            65536});
+            resources.ApplyResources(this.nUDRSAntiDead, "nUDRSAntiDead");
+            this.nUDRSAntiDead.Maximum = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
+            this.nUDRSAntiDead.Name = "nUDRSAntiDead";
+            this.nUDRSAntiDead.Value = new decimal(new int[] {
+            20,
+            0,
+            0,
+            131072});
+            // 
             // nUDLSAntiDead
             // 
             this.nUDLSAntiDead.DecimalPlaces = 2;
@@ -2945,6 +3097,27 @@
             // 
             resources.ApplyResources(this.label42, "label42");
             this.label42.Name = "label42";
+            // 
+            // nUDRSMaxZone
+            // 
+            this.nUDRSMaxZone.DecimalPlaces = 2;
+            this.nUDRSMaxZone.Increment = new decimal(new int[] {
+            1,
+            0,
+            0,
+            65536});
+            resources.ApplyResources(this.nUDRSMaxZone, "nUDRSMaxZone");
+            this.nUDRSMaxZone.Maximum = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
+            this.nUDRSMaxZone.Name = "nUDRSMaxZone";
+            this.nUDRSMaxZone.Value = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
             // 
             // nUDLSMaxZone
             // 
@@ -2972,6 +3145,27 @@
             resources.ApplyResources(this.label41, "label41");
             this.label41.Name = "label41";
             // 
+            // nUDRS
+            // 
+            this.nUDRS.DecimalPlaces = 2;
+            this.nUDRS.Increment = new decimal(new int[] {
+            1,
+            0,
+            0,
+            65536});
+            resources.ApplyResources(this.nUDRS, "nUDRS");
+            this.nUDRS.Maximum = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
+            this.nUDRS.Name = "nUDRS";
+            this.nUDRS.Value = new decimal(new int[] {
+            8,
+            0,
+            0,
+            131072});
+            // 
             // nUDLS
             // 
             this.nUDLS.DecimalPlaces = 2;
@@ -2998,252 +3192,22 @@
             resources.ApplyResources(this.label40, "label40");
             this.label40.Name = "label40";
             // 
-            // groupBox2
-            // 
-            this.groupBox2.Controls.Add(this.tBRSCustomOutputCurve);
-            this.groupBox2.Controls.Add(this.lbRSCurveEditorURL);
-            this.groupBox2.Controls.Add(this.nUDRSS);
-            this.groupBox2.Controls.Add(this.label70);
-            this.groupBox2.Controls.Add(this.rsOutCurveComboBox);
-            this.groupBox2.Controls.Add(this.nUDRSRotation);
-            this.groupBox2.Controls.Add(this.label52);
-            this.groupBox2.Controls.Add(this.lbRSCurvePercent);
-            this.groupBox2.Controls.Add(this.nUDRSCurve);
-            this.groupBox2.Controls.Add(this.label51);
-            this.groupBox2.Controls.Add(this.rsSquStickCk);
-            this.groupBox2.Controls.Add(this.numericUpDown1);
-            this.groupBox2.Controls.Add(this.label28);
-            this.groupBox2.Controls.Add(this.label50);
-            this.groupBox2.Controls.Add(this.nUDRSAntiDead);
-            this.groupBox2.Controls.Add(this.label49);
-            this.groupBox2.Controls.Add(this.nUDRSMaxZone);
-            this.groupBox2.Controls.Add(this.label48);
-            this.groupBox2.Controls.Add(this.nUDRS);
-            this.groupBox2.Controls.Add(this.label47);
-            resources.ApplyResources(this.groupBox2, "groupBox2");
-            this.groupBox2.Name = "groupBox2";
-            this.groupBox2.TabStop = false;
-            // 
-            // tBRSCustomOutputCurve
-            // 
-            resources.ApplyResources(this.tBRSCustomOutputCurve, "tBRSCustomOutputCurve");
-            this.tBRSCustomOutputCurve.Name = "tBRSCustomOutputCurve";
-            // 
-            // lbRSCurveEditorURL
-            // 
-            resources.ApplyResources(this.lbRSCurveEditorURL, "lbRSCurveEditorURL");
-            this.lbRSCurveEditorURL.Name = "lbRSCurveEditorURL";
-            this.lbRSCurveEditorURL.TabStop = true;
-            // 
-            // nUDRSS
-            // 
-            this.nUDRSS.DecimalPlaces = 2;
-            this.nUDRSS.Increment = new decimal(new int[] {
-            1,
-            0,
-            0,
-            65536});
-            resources.ApplyResources(this.nUDRSS, "nUDRSS");
-            this.nUDRSS.Maximum = new decimal(new int[] {
-            5,
-            0,
-            0,
-            0});
-            this.nUDRSS.Minimum = new decimal(new int[] {
-            5,
-            0,
-            0,
-            65536});
-            this.nUDRSS.Name = "nUDRSS";
-            this.nUDRSS.Value = new decimal(new int[] {
-            1,
-            0,
-            0,
-            0});
-            // 
-            // label70
-            // 
-            resources.ApplyResources(this.label70, "label70");
-            this.label70.Name = "label70";
-            // 
-            // rsOutCurveComboBox
-            // 
-            this.rsOutCurveComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.rsOutCurveComboBox.DropDownWidth = 120;
-            this.rsOutCurveComboBox.FormattingEnabled = true;
-            this.rsOutCurveComboBox.Items.AddRange(new object[] {
-            resources.GetString("rsOutCurveComboBox.Items"),
-            resources.GetString("rsOutCurveComboBox.Items1"),
-            resources.GetString("rsOutCurveComboBox.Items2"),
-            resources.GetString("rsOutCurveComboBox.Items3"),
-            resources.GetString("rsOutCurveComboBox.Items4"),
-            resources.GetString("rsOutCurveComboBox.Items5"),
-            resources.GetString("rsOutCurveComboBox.Items6")});
-            resources.ApplyResources(this.rsOutCurveComboBox, "rsOutCurveComboBox");
-            this.rsOutCurveComboBox.Name = "rsOutCurveComboBox";
-            // 
-            // nUDRSRotation
-            // 
-            resources.ApplyResources(this.nUDRSRotation, "nUDRSRotation");
-            this.nUDRSRotation.Maximum = new decimal(new int[] {
-            180,
-            0,
-            0,
-            0});
-            this.nUDRSRotation.Minimum = new decimal(new int[] {
-            180,
-            0,
-            0,
-            -2147483648});
-            this.nUDRSRotation.Name = "nUDRSRotation";
-            // 
-            // label52
-            // 
-            resources.ApplyResources(this.label52, "label52");
-            this.label52.Name = "label52";
-            // 
-            // lbRSCurvePercent
-            // 
-            resources.ApplyResources(this.lbRSCurvePercent, "lbRSCurvePercent");
-            this.lbRSCurvePercent.Name = "lbRSCurvePercent";
-            // 
-            // nUDRSCurve
-            // 
-            this.nUDRSCurve.Increment = new decimal(new int[] {
-            10,
-            0,
-            0,
-            0});
-            resources.ApplyResources(this.nUDRSCurve, "nUDRSCurve");
-            this.nUDRSCurve.Name = "nUDRSCurve";
-            // 
-            // label51
-            // 
-            resources.ApplyResources(this.label51, "label51");
-            this.label51.Name = "label51";
-            // 
-            // rsSquStickCk
-            // 
-            resources.ApplyResources(this.rsSquStickCk, "rsSquStickCk");
-            this.rsSquStickCk.Name = "rsSquStickCk";
-            this.rsSquStickCk.UseVisualStyleBackColor = true;
-            // 
-            // numericUpDown1
-            // 
-            this.numericUpDown1.DecimalPlaces = 1;
-            this.numericUpDown1.Increment = new decimal(new int[] {
-            1,
-            0,
-            0,
-            65536});
-            resources.ApplyResources(this.numericUpDown1, "numericUpDown1");
-            this.numericUpDown1.Maximum = new decimal(new int[] {
-            5,
-            0,
-            0,
-            0});
-            this.numericUpDown1.Name = "numericUpDown1";
-            this.numericUpDown1.Value = new decimal(new int[] {
-            50,
-            0,
-            0,
-            65536});
-            // 
-            // label28
-            // 
-            resources.ApplyResources(this.label28, "label28");
-            this.label28.Name = "label28";
-            // 
-            // label50
-            // 
-            resources.ApplyResources(this.label50, "label50");
-            this.label50.Name = "label50";
-            // 
-            // nUDRSAntiDead
-            // 
-            this.nUDRSAntiDead.DecimalPlaces = 2;
-            this.nUDRSAntiDead.Increment = new decimal(new int[] {
-            1,
-            0,
-            0,
-            65536});
-            resources.ApplyResources(this.nUDRSAntiDead, "nUDRSAntiDead");
-            this.nUDRSAntiDead.Maximum = new decimal(new int[] {
-            1,
-            0,
-            0,
-            0});
-            this.nUDRSAntiDead.Name = "nUDRSAntiDead";
-            this.nUDRSAntiDead.Value = new decimal(new int[] {
-            20,
-            0,
-            0,
-            131072});
-            // 
-            // label49
-            // 
-            resources.ApplyResources(this.label49, "label49");
-            this.label49.Name = "label49";
-            // 
-            // nUDRSMaxZone
-            // 
-            this.nUDRSMaxZone.DecimalPlaces = 2;
-            this.nUDRSMaxZone.Increment = new decimal(new int[] {
-            1,
-            0,
-            0,
-            65536});
-            resources.ApplyResources(this.nUDRSMaxZone, "nUDRSMaxZone");
-            this.nUDRSMaxZone.Maximum = new decimal(new int[] {
-            1,
-            0,
-            0,
-            0});
-            this.nUDRSMaxZone.Name = "nUDRSMaxZone";
-            this.nUDRSMaxZone.Value = new decimal(new int[] {
-            1,
-            0,
-            0,
-            0});
-            // 
-            // label48
-            // 
-            resources.ApplyResources(this.label48, "label48");
-            this.label48.Name = "label48";
-            // 
-            // nUDRS
-            // 
-            this.nUDRS.DecimalPlaces = 2;
-            this.nUDRS.Increment = new decimal(new int[] {
-            1,
-            0,
-            0,
-            65536});
-            resources.ApplyResources(this.nUDRS, "nUDRS");
-            this.nUDRS.Maximum = new decimal(new int[] {
-            1,
-            0,
-            0,
-            0});
-            this.nUDRS.Name = "nUDRS";
-            this.nUDRS.Value = new decimal(new int[] {
-            8,
-            0,
-            0,
-            131072});
-            // 
-            // label47
-            // 
-            resources.ApplyResources(this.label47, "label47");
-            this.label47.Name = "label47";
-            // 
             // groupBox3
             // 
+            this.groupBox3.Controls.Add(this.btnR2CurveEditor);
+            this.groupBox3.Controls.Add(this.btnL2CurveEditor);
+            this.groupBox3.Controls.Add(this.tBR2CustomOutputCurve);
+            this.groupBox3.Controls.Add(this.label6);
+            this.groupBox3.Controls.Add(this.label5);
+            this.groupBox3.Controls.Add(this.nUDR2S);
             this.groupBox3.Controls.Add(this.tBL2CustomOutputCurve);
-            this.groupBox3.Controls.Add(this.lbL2CurveEditorURL);
+            this.groupBox3.Controls.Add(this.cBR2OutputCurve);
             this.groupBox3.Controls.Add(this.nUDL2S);
+            this.groupBox3.Controls.Add(this.nUDR2AntiDead);
             this.groupBox3.Controls.Add(this.label71);
+            this.groupBox3.Controls.Add(this.nUDR2Maxzone);
             this.groupBox3.Controls.Add(this.cBL2OutputCurve);
+            this.groupBox3.Controls.Add(this.nUDR2);
             this.groupBox3.Controls.Add(this.nUDL2AntiDead);
             this.groupBox3.Controls.Add(this.nUDL2Maxzone);
             this.groupBox3.Controls.Add(this.nUDL2);
@@ -3255,16 +3219,81 @@
             this.groupBox3.Name = "groupBox3";
             this.groupBox3.TabStop = false;
             // 
+            // btnR2CurveEditor
+            // 
+            resources.ApplyResources(this.btnR2CurveEditor, "btnR2CurveEditor");
+            this.btnR2CurveEditor.Name = "btnR2CurveEditor";
+            this.btnR2CurveEditor.UseVisualStyleBackColor = true;
+            this.btnR2CurveEditor.Click += new System.EventHandler(this.BtnCurveEditor_Click);
+            // 
+            // btnL2CurveEditor
+            // 
+            resources.ApplyResources(this.btnL2CurveEditor, "btnL2CurveEditor");
+            this.btnL2CurveEditor.Name = "btnL2CurveEditor";
+            this.btnL2CurveEditor.UseVisualStyleBackColor = true;
+            this.btnL2CurveEditor.Click += new System.EventHandler(this.BtnCurveEditor_Click);
+            // 
+            // tBR2CustomOutputCurve
+            // 
+            resources.ApplyResources(this.tBR2CustomOutputCurve, "tBR2CustomOutputCurve");
+            this.tBR2CustomOutputCurve.Name = "tBR2CustomOutputCurve";
+            // 
+            // label6
+            // 
+            resources.ApplyResources(this.label6, "label6");
+            this.label6.Name = "label6";
+            // 
+            // label5
+            // 
+            resources.ApplyResources(this.label5, "label5");
+            this.label5.Name = "label5";
+            // 
+            // nUDR2S
+            // 
+            this.nUDR2S.DecimalPlaces = 2;
+            this.nUDR2S.Increment = new decimal(new int[] {
+            1,
+            0,
+            0,
+            65536});
+            resources.ApplyResources(this.nUDR2S, "nUDR2S");
+            this.nUDR2S.Maximum = new decimal(new int[] {
+            10,
+            0,
+            0,
+            0});
+            this.nUDR2S.Minimum = new decimal(new int[] {
+            1,
+            0,
+            0,
+            65536});
+            this.nUDR2S.Name = "nUDR2S";
+            this.nUDR2S.Value = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
+            // 
             // tBL2CustomOutputCurve
             // 
             resources.ApplyResources(this.tBL2CustomOutputCurve, "tBL2CustomOutputCurve");
             this.tBL2CustomOutputCurve.Name = "tBL2CustomOutputCurve";
             // 
-            // lbL2CurveEditorURL
+            // cBR2OutputCurve
             // 
-            resources.ApplyResources(this.lbL2CurveEditorURL, "lbL2CurveEditorURL");
-            this.lbL2CurveEditorURL.Name = "lbL2CurveEditorURL";
-            this.lbL2CurveEditorURL.TabStop = true;
+            this.cBR2OutputCurve.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cBR2OutputCurve.DropDownWidth = 70;
+            this.cBR2OutputCurve.FormattingEnabled = true;
+            this.cBR2OutputCurve.Items.AddRange(new object[] {
+            resources.GetString("cBR2OutputCurve.Items"),
+            resources.GetString("cBR2OutputCurve.Items1"),
+            resources.GetString("cBR2OutputCurve.Items2"),
+            resources.GetString("cBR2OutputCurve.Items3"),
+            resources.GetString("cBR2OutputCurve.Items4"),
+            resources.GetString("cBR2OutputCurve.Items5"),
+            resources.GetString("cBR2OutputCurve.Items6")});
+            resources.ApplyResources(this.cBR2OutputCurve, "cBR2OutputCurve");
+            this.cBR2OutputCurve.Name = "cBR2OutputCurve";
             // 
             // nUDL2S
             // 
@@ -3292,10 +3321,47 @@
             0,
             0});
             // 
+            // nUDR2AntiDead
+            // 
+            this.nUDR2AntiDead.DecimalPlaces = 2;
+            this.nUDR2AntiDead.Increment = new decimal(new int[] {
+            1,
+            0,
+            0,
+            65536});
+            resources.ApplyResources(this.nUDR2AntiDead, "nUDR2AntiDead");
+            this.nUDR2AntiDead.Maximum = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
+            this.nUDR2AntiDead.Name = "nUDR2AntiDead";
+            // 
             // label71
             // 
             resources.ApplyResources(this.label71, "label71");
             this.label71.Name = "label71";
+            // 
+            // nUDR2Maxzone
+            // 
+            this.nUDR2Maxzone.DecimalPlaces = 2;
+            this.nUDR2Maxzone.Increment = new decimal(new int[] {
+            1,
+            0,
+            0,
+            65536});
+            resources.ApplyResources(this.nUDR2Maxzone, "nUDR2Maxzone");
+            this.nUDR2Maxzone.Maximum = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
+            this.nUDR2Maxzone.Name = "nUDR2Maxzone";
+            this.nUDR2Maxzone.Value = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
             // 
             // cBL2OutputCurve
             // 
@@ -3312,6 +3378,22 @@
             resources.GetString("cBL2OutputCurve.Items6")});
             resources.ApplyResources(this.cBL2OutputCurve, "cBL2OutputCurve");
             this.cBL2OutputCurve.Name = "cBL2OutputCurve";
+            // 
+            // nUDR2
+            // 
+            this.nUDR2.DecimalPlaces = 2;
+            this.nUDR2.Increment = new decimal(new int[] {
+            1,
+            0,
+            0,
+            65536});
+            resources.ApplyResources(this.nUDR2, "nUDR2");
+            this.nUDR2.Maximum = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
+            this.nUDR2.Name = "nUDR2";
             // 
             // nUDL2AntiDead
             // 
@@ -3386,206 +3468,66 @@
             resources.ApplyResources(this.label57, "label57");
             this.label57.Name = "label57";
             // 
-            // groupBox4
-            // 
-            this.groupBox4.Controls.Add(this.tBR2CustomOutputCurve);
-            this.groupBox4.Controls.Add(this.lbR2CurveEditorURL);
-            this.groupBox4.Controls.Add(this.nUDR2S);
-            this.groupBox4.Controls.Add(this.label72);
-            this.groupBox4.Controls.Add(this.cBR2OutputCurve);
-            this.groupBox4.Controls.Add(this.nUDR2AntiDead);
-            this.groupBox4.Controls.Add(this.nUDR2Maxzone);
-            this.groupBox4.Controls.Add(this.nUDR2);
-            this.groupBox4.Controls.Add(this.label53);
-            this.groupBox4.Controls.Add(this.label58);
-            this.groupBox4.Controls.Add(this.label59);
-            this.groupBox4.Controls.Add(this.label60);
-            resources.ApplyResources(this.groupBox4, "groupBox4");
-            this.groupBox4.Name = "groupBox4";
-            this.groupBox4.TabStop = false;
-            // 
-            // tBR2CustomOutputCurve
-            // 
-            resources.ApplyResources(this.tBR2CustomOutputCurve, "tBR2CustomOutputCurve");
-            this.tBR2CustomOutputCurve.Name = "tBR2CustomOutputCurve";
-            // 
-            // lbR2CurveEditorURL
-            // 
-            resources.ApplyResources(this.lbR2CurveEditorURL, "lbR2CurveEditorURL");
-            this.lbR2CurveEditorURL.Name = "lbR2CurveEditorURL";
-            this.lbR2CurveEditorURL.TabStop = true;
-            // 
-            // nUDR2S
-            // 
-            this.nUDR2S.DecimalPlaces = 2;
-            this.nUDR2S.Increment = new decimal(new int[] {
-            1,
-            0,
-            0,
-            65536});
-            resources.ApplyResources(this.nUDR2S, "nUDR2S");
-            this.nUDR2S.Maximum = new decimal(new int[] {
-            10,
-            0,
-            0,
-            0});
-            this.nUDR2S.Minimum = new decimal(new int[] {
-            1,
-            0,
-            0,
-            65536});
-            this.nUDR2S.Name = "nUDR2S";
-            this.nUDR2S.Value = new decimal(new int[] {
-            1,
-            0,
-            0,
-            0});
-            // 
-            // label72
-            // 
-            resources.ApplyResources(this.label72, "label72");
-            this.label72.Name = "label72";
-            // 
-            // cBR2OutputCurve
-            // 
-            this.cBR2OutputCurve.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cBR2OutputCurve.DropDownWidth = 70;
-            this.cBR2OutputCurve.FormattingEnabled = true;
-            this.cBR2OutputCurve.Items.AddRange(new object[] {
-            resources.GetString("cBR2OutputCurve.Items"),
-            resources.GetString("cBR2OutputCurve.Items1"),
-            resources.GetString("cBR2OutputCurve.Items2"),
-            resources.GetString("cBR2OutputCurve.Items3"),
-            resources.GetString("cBR2OutputCurve.Items4"),
-            resources.GetString("cBR2OutputCurve.Items5"),
-            resources.GetString("cBR2OutputCurve.Items6")});
-            resources.ApplyResources(this.cBR2OutputCurve, "cBR2OutputCurve");
-            this.cBR2OutputCurve.Name = "cBR2OutputCurve";
-            // 
-            // nUDR2AntiDead
-            // 
-            this.nUDR2AntiDead.DecimalPlaces = 2;
-            this.nUDR2AntiDead.Increment = new decimal(new int[] {
-            1,
-            0,
-            0,
-            65536});
-            resources.ApplyResources(this.nUDR2AntiDead, "nUDR2AntiDead");
-            this.nUDR2AntiDead.Maximum = new decimal(new int[] {
-            1,
-            0,
-            0,
-            0});
-            this.nUDR2AntiDead.Name = "nUDR2AntiDead";
-            // 
-            // nUDR2Maxzone
-            // 
-            this.nUDR2Maxzone.DecimalPlaces = 2;
-            this.nUDR2Maxzone.Increment = new decimal(new int[] {
-            1,
-            0,
-            0,
-            65536});
-            resources.ApplyResources(this.nUDR2Maxzone, "nUDR2Maxzone");
-            this.nUDR2Maxzone.Maximum = new decimal(new int[] {
-            1,
-            0,
-            0,
-            0});
-            this.nUDR2Maxzone.Name = "nUDR2Maxzone";
-            this.nUDR2Maxzone.Value = new decimal(new int[] {
-            1,
-            0,
-            0,
-            0});
-            // 
-            // nUDR2
-            // 
-            this.nUDR2.DecimalPlaces = 2;
-            this.nUDR2.Increment = new decimal(new int[] {
-            1,
-            0,
-            0,
-            65536});
-            resources.ApplyResources(this.nUDR2, "nUDR2");
-            this.nUDR2.Maximum = new decimal(new int[] {
-            1,
-            0,
-            0,
-            0});
-            this.nUDR2.Name = "nUDR2";
-            // 
-            // label53
-            // 
-            resources.ApplyResources(this.label53, "label53");
-            this.label53.Name = "label53";
-            // 
-            // label58
-            // 
-            resources.ApplyResources(this.label58, "label58");
-            this.label58.Name = "label58";
-            // 
-            // label59
-            // 
-            resources.ApplyResources(this.label59, "label59");
-            this.label59.Name = "label59";
-            // 
-            // label60
-            // 
-            resources.ApplyResources(this.label60, "label60");
-            this.label60.Name = "label60";
-            // 
             // groupBox5
             // 
+            this.groupBox5.Controls.Add(this.btnSixZCurveEditor);
+            this.groupBox5.Controls.Add(this.btnSixXCurveEditor);
+            this.groupBox5.Controls.Add(this.label8);
+            this.groupBox5.Controls.Add(this.label7);
             this.groupBox5.Controls.Add(this.tBSixZCustomOutputCurve);
-            this.groupBox5.Controls.Add(this.lbSixZCurveEditorURL);
             this.groupBox5.Controls.Add(this.tBSixXCustomOutputCurve);
-            this.groupBox5.Controls.Add(this.lbSixXCurveEditorURL);
             this.groupBox5.Controls.Add(this.nUDSZS);
             this.groupBox5.Controls.Add(this.nUDSXS);
-            this.groupBox5.Controls.Add(this.label74);
             this.groupBox5.Controls.Add(this.label73);
             this.groupBox5.Controls.Add(this.cBSixaxisZOutputCurve);
-            this.groupBox5.Controls.Add(this.label68);
             this.groupBox5.Controls.Add(this.cBSixaxisXOutputCurve);
             this.groupBox5.Controls.Add(this.label67);
             this.groupBox5.Controls.Add(this.nUDSixaxisZAntiDead);
-            this.groupBox5.Controls.Add(this.label66);
             this.groupBox5.Controls.Add(this.nUDSixaxisXAntiDead);
             this.groupBox5.Controls.Add(this.label65);
             this.groupBox5.Controls.Add(this.nUDSixAxisZMaxZone);
-            this.groupBox5.Controls.Add(this.label64);
             this.groupBox5.Controls.Add(this.nUDSixAxisXMaxZone);
             this.groupBox5.Controls.Add(this.label63);
             this.groupBox5.Controls.Add(this.nUDSZ);
-            this.groupBox5.Controls.Add(this.label62);
             this.groupBox5.Controls.Add(this.nUDSX);
             this.groupBox5.Controls.Add(this.label61);
             resources.ApplyResources(this.groupBox5, "groupBox5");
             this.groupBox5.Name = "groupBox5";
             this.groupBox5.TabStop = false;
             // 
+            // btnSixZCurveEditor
+            // 
+            resources.ApplyResources(this.btnSixZCurveEditor, "btnSixZCurveEditor");
+            this.btnSixZCurveEditor.Name = "btnSixZCurveEditor";
+            this.btnSixZCurveEditor.UseVisualStyleBackColor = true;
+            this.btnSixZCurveEditor.Click += new System.EventHandler(this.BtnCurveEditor_Click);
+            // 
+            // btnSixXCurveEditor
+            // 
+            resources.ApplyResources(this.btnSixXCurveEditor, "btnSixXCurveEditor");
+            this.btnSixXCurveEditor.Name = "btnSixXCurveEditor";
+            this.btnSixXCurveEditor.UseVisualStyleBackColor = true;
+            this.btnSixXCurveEditor.Click += new System.EventHandler(this.BtnCurveEditor_Click);
+            // 
+            // label8
+            // 
+            resources.ApplyResources(this.label8, "label8");
+            this.label8.Name = "label8";
+            // 
+            // label7
+            // 
+            resources.ApplyResources(this.label7, "label7");
+            this.label7.Name = "label7";
+            // 
             // tBSixZCustomOutputCurve
             // 
             resources.ApplyResources(this.tBSixZCustomOutputCurve, "tBSixZCustomOutputCurve");
             this.tBSixZCustomOutputCurve.Name = "tBSixZCustomOutputCurve";
             // 
-            // lbSixZCurveEditorURL
-            // 
-            resources.ApplyResources(this.lbSixZCurveEditorURL, "lbSixZCurveEditorURL");
-            this.lbSixZCurveEditorURL.Name = "lbSixZCurveEditorURL";
-            this.lbSixZCurveEditorURL.TabStop = true;
-            // 
             // tBSixXCustomOutputCurve
             // 
             resources.ApplyResources(this.tBSixXCustomOutputCurve, "tBSixXCustomOutputCurve");
             this.tBSixXCustomOutputCurve.Name = "tBSixXCustomOutputCurve";
-            // 
-            // lbSixXCurveEditorURL
-            // 
-            resources.ApplyResources(this.lbSixXCurveEditorURL, "lbSixXCurveEditorURL");
-            this.lbSixXCurveEditorURL.Name = "lbSixXCurveEditorURL";
-            this.lbSixXCurveEditorURL.TabStop = true;
             // 
             // nUDSZS
             // 
@@ -3639,11 +3581,6 @@
             0,
             0});
             // 
-            // label74
-            // 
-            resources.ApplyResources(this.label74, "label74");
-            this.label74.Name = "label74";
-            // 
             // label73
             // 
             resources.ApplyResources(this.label73, "label73");
@@ -3664,11 +3601,6 @@
             resources.GetString("cBSixaxisZOutputCurve.Items6")});
             resources.ApplyResources(this.cBSixaxisZOutputCurve, "cBSixaxisZOutputCurve");
             this.cBSixaxisZOutputCurve.Name = "cBSixaxisZOutputCurve";
-            // 
-            // label68
-            // 
-            resources.ApplyResources(this.label68, "label68");
-            this.label68.Name = "label68";
             // 
             // cBSixaxisXOutputCurve
             // 
@@ -3706,11 +3638,6 @@
             0,
             0});
             this.nUDSixaxisZAntiDead.Name = "nUDSixaxisZAntiDead";
-            // 
-            // label66
-            // 
-            resources.ApplyResources(this.label66, "label66");
-            this.label66.Name = "label66";
             // 
             // nUDSixaxisXAntiDead
             // 
@@ -3753,11 +3680,6 @@
             0,
             0,
             0});
-            // 
-            // label64
-            // 
-            resources.ApplyResources(this.label64, "label64");
-            this.label64.Name = "label64";
             // 
             // nUDSixAxisXMaxZone
             // 
@@ -3805,11 +3727,6 @@
             0,
             0,
             131072});
-            // 
-            // label62
-            // 
-            resources.ApplyResources(this.label62, "label62");
-            this.label62.Name = "label62";
             // 
             // nUDSX
             // 
@@ -4697,19 +4614,6 @@
             resources.ApplyResources(this.outcontLb, "outcontLb");
             this.outcontLb.Name = "outcontLb";
             // 
-            // maxRainSatTB
-            // 
-            resources.ApplyResources(this.maxRainSatTB, "maxRainSatTB");
-            this.maxRainSatTB.Maximum = 100;
-            this.maxRainSatTB.Name = "maxRainSatTB";
-            this.maxRainSatTB.TickStyle = System.Windows.Forms.TickStyle.None;
-            this.maxRainSatTB.Value = 100;
-            // 
-            // label1
-            // 
-            resources.ApplyResources(this.label1, "label1");
-            this.label1.Name = "label1";
-            // 
             // Options
             // 
             resources.ApplyResources(this, "$this");
@@ -4778,39 +4682,36 @@
             this.panel4.PerformLayout();
             this.panel5.ResumeLayout(false);
             this.panel5.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.maxRainSatTB)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.nUDRainbow)).EndInit();
             this.tabAxis.ResumeLayout(false);
             this.flowLayoutPanel3.ResumeLayout(false);
             this.groupBox1.ResumeLayout(false);
             this.groupBox1.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.nUDRSRotation)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nUDRSCurve)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown1)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nUDRSS)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.nUDLSS)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.RoundnessNUpDown)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.nUDLSRotation)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.nUDLSCurve)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDLSAntiDead)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDLSMaxZone)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDLS)).EndInit();
-            this.groupBox2.ResumeLayout(false);
-            this.groupBox2.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDRSS)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDRSRotation)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDRSCurve)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown1)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.nUDRSAntiDead)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nUDLSAntiDead)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.nUDRSMaxZone)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nUDLSMaxZone)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.nUDRS)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nUDLS)).EndInit();
             this.groupBox3.ResumeLayout(false);
             this.groupBox3.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDL2S)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDL2AntiDead)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDL2Maxzone)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nUDL2)).EndInit();
-            this.groupBox4.ResumeLayout(false);
-            this.groupBox4.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.nUDR2S)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nUDL2S)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.nUDR2AntiDead)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.nUDR2Maxzone)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.nUDR2)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nUDL2AntiDead)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nUDL2Maxzone)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nUDL2)).EndInit();
             this.groupBox5.ResumeLayout(false);
             this.groupBox5.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.nUDSZS)).EndInit();
@@ -4863,7 +4764,6 @@
             this.panel11.PerformLayout();
             this.panel12.ResumeLayout(false);
             this.panel12.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.maxRainSatTB)).EndInit();
             this.ResumeLayout(false);
 
         }
@@ -5167,7 +5067,6 @@
         private System.Windows.Forms.TabPage tabAxis;
         private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel3;
         private System.Windows.Forms.GroupBox groupBox1;
-        private System.Windows.Forms.Label label46;
         private System.Windows.Forms.NumericUpDown RoundnessNUpDown;
         private System.Windows.Forms.CheckBox lsSquStickCk;
         private System.Windows.Forms.NumericUpDown nUDLSRotation;
@@ -5183,23 +5082,15 @@
         private System.Windows.Forms.Label label41;
         private System.Windows.Forms.NumericUpDown nUDLS;
         private System.Windows.Forms.Label label40;
-        private System.Windows.Forms.GroupBox groupBox2;
         private System.Windows.Forms.ComboBox rsOutCurveComboBox;
         private System.Windows.Forms.NumericUpDown nUDRSRotation;
-        private System.Windows.Forms.Label label52;
         private System.Windows.Forms.Label lbRSCurvePercent;
         private System.Windows.Forms.NumericUpDown nUDRSCurve;
-        private System.Windows.Forms.Label label51;
         private System.Windows.Forms.CheckBox rsSquStickCk;
         private System.Windows.Forms.NumericUpDown numericUpDown1;
-        private System.Windows.Forms.Label label28;
-        private System.Windows.Forms.Label label50;
         private System.Windows.Forms.NumericUpDown nUDRSAntiDead;
-        private System.Windows.Forms.Label label49;
         private System.Windows.Forms.NumericUpDown nUDRSMaxZone;
-        private System.Windows.Forms.Label label48;
         private System.Windows.Forms.NumericUpDown nUDRS;
-        private System.Windows.Forms.Label label47;
         private System.Windows.Forms.GroupBox groupBox3;
         private System.Windows.Forms.ComboBox cBL2OutputCurve;
         private System.Windows.Forms.NumericUpDown nUDL2AntiDead;
@@ -5209,44 +5100,31 @@
         private System.Windows.Forms.Label label55;
         private System.Windows.Forms.Label label56;
         private System.Windows.Forms.Label label57;
-        private System.Windows.Forms.GroupBox groupBox4;
-        private System.Windows.Forms.TextBox tBCustomOutputCurve;
-        private System.Windows.Forms.LinkLabel lbCurveEditorURL;
+        private System.Windows.Forms.TextBox tBLSCustomOutputCurve;
         private System.Windows.Forms.NumericUpDown nUDLSS;
         private System.Windows.Forms.Label label69;
         private System.Windows.Forms.NumericUpDown nUDRSS;
-        private System.Windows.Forms.Label label70;
         private System.Windows.Forms.NumericUpDown nUDL2S;
         private System.Windows.Forms.Label label71;
         private System.Windows.Forms.NumericUpDown nUDR2S;
-        private System.Windows.Forms.Label label72;
         private System.Windows.Forms.ComboBox cBR2OutputCurve;
         private System.Windows.Forms.NumericUpDown nUDR2AntiDead;
         private System.Windows.Forms.NumericUpDown nUDR2Maxzone;
         private System.Windows.Forms.NumericUpDown nUDR2;
-        private System.Windows.Forms.Label label53;
-        private System.Windows.Forms.Label label58;
-        private System.Windows.Forms.Label label59;
-        private System.Windows.Forms.Label label60;
         private System.Windows.Forms.GroupBox groupBox5;
         private System.Windows.Forms.NumericUpDown nUDSZS;
         private System.Windows.Forms.NumericUpDown nUDSXS;
-        private System.Windows.Forms.Label label74;
         private System.Windows.Forms.Label label73;
         private System.Windows.Forms.ComboBox cBSixaxisZOutputCurve;
-        private System.Windows.Forms.Label label68;
         private System.Windows.Forms.ComboBox cBSixaxisXOutputCurve;
         private System.Windows.Forms.Label label67;
         private System.Windows.Forms.NumericUpDown nUDSixaxisZAntiDead;
-        private System.Windows.Forms.Label label66;
         private System.Windows.Forms.NumericUpDown nUDSixaxisXAntiDead;
         private System.Windows.Forms.Label label65;
         private System.Windows.Forms.NumericUpDown nUDSixAxisZMaxZone;
-        private System.Windows.Forms.Label label64;
         private System.Windows.Forms.NumericUpDown nUDSixAxisXMaxZone;
         private System.Windows.Forms.Label label63;
         private System.Windows.Forms.NumericUpDown nUDSZ;
-        private System.Windows.Forms.Label label62;
         private System.Windows.Forms.NumericUpDown nUDSX;
         private System.Windows.Forms.Label label61;
         private System.Windows.Forms.TabPage tabOther;
@@ -5282,16 +5160,24 @@
         private System.Windows.Forms.ComboBox OutContTypeCb;
         private System.Windows.Forms.Label outcontLb;
         private System.Windows.Forms.TextBox tBRSCustomOutputCurve;
-        private System.Windows.Forms.LinkLabel lbRSCurveEditorURL;
         private System.Windows.Forms.TextBox tBL2CustomOutputCurve;
-        private System.Windows.Forms.LinkLabel lbL2CurveEditorURL;
         private System.Windows.Forms.TextBox tBR2CustomOutputCurve;
-        private System.Windows.Forms.LinkLabel lbR2CurveEditorURL;
         private System.Windows.Forms.TextBox tBSixZCustomOutputCurve;
-        private System.Windows.Forms.LinkLabel lbSixZCurveEditorURL;
         private System.Windows.Forms.TextBox tBSixXCustomOutputCurve;
-        private System.Windows.Forms.LinkLabel lbSixXCurveEditorURL;
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.TrackBar maxRainSatTB;
+        private System.Windows.Forms.Label label4;
+        private System.Windows.Forms.Button btnRSCurveEditor;
+        private System.Windows.Forms.Button BtnLSCurveEditor;
+        private System.Windows.Forms.Label label3;
+        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.Button btnR2CurveEditor;
+        private System.Windows.Forms.Button btnL2CurveEditor;
+        private System.Windows.Forms.Label label6;
+        private System.Windows.Forms.Label label5;
+        private System.Windows.Forms.Button btnSixZCurveEditor;
+        private System.Windows.Forms.Button btnSixXCurveEditor;
+        private System.Windows.Forms.Label label8;
+        private System.Windows.Forms.Label label7;
     }
 }

--- a/DS4Windows/DS4Forms/Options.cs
+++ b/DS4Windows/DS4Forms/Options.cs
@@ -152,21 +152,19 @@ namespace DS4Windows.Forms
             populateHoverImageDict();
             populateHoverLabelDict();
 
-            tBCustomOutputCurve.Text = String.Empty;
-            //lbCurveEditorURL.Text = $"   - {lbCurveEditorURL.Text}";
-            tBCustomOutputCurve.Enabled = lbCurveEditorURL.Enabled = false;
+            tBLSCustomOutputCurve.Text = String.Empty;
             tBRSCustomOutputCurve.Text = String.Empty;
-            tBRSCustomOutputCurve.Enabled = lbRSCurveEditorURL.Enabled = false;
             tBL2CustomOutputCurve.Text = String.Empty;
-            tBL2CustomOutputCurve.Enabled = lbL2CurveEditorURL.Enabled = false;
             tBR2CustomOutputCurve.Text = String.Empty;
-            tBR2CustomOutputCurve.Enabled = lbR2CurveEditorURL.Enabled = false;
             tBSixXCustomOutputCurve.Text = String.Empty;
-            tBSixXCustomOutputCurve.Enabled = lbSixXCurveEditorURL.Enabled = false;
             tBSixZCustomOutputCurve.Text = String.Empty;
-            tBSixZCustomOutputCurve.Enabled = lbSixZCurveEditorURL.Enabled = false;
+
+            CustomCurveChecker();
 
             SetupEvents();
+
+            tp.SetToolTip(RoundnessNUpDown, Properties.Resources.SquareStickRoundness);
+            tp.SetToolTip(numericUpDown1, Properties.Resources.SquareStickRoundness);
         }
 
         private void TriggerCondAndCombo_SelectedIndexChanged(object sender, EventArgs e)
@@ -342,15 +340,13 @@ namespace DS4Windows.Forms
             RoundnessNUpDown.ValueChanged += RoundnessNUpDown_ValueChanged;
             nUDLSCurve.ValueChanged += nUDLSCurve_ValueChanged;
             nUDLSRotation.ValueChanged += nUDLSRotation_ValueChanged;
-            tBCustomOutputCurve.Leave += tBCustomOutputCurve_Leave;
-            lbCurveEditorURL.LinkClicked += lbCurveEditorURL_LinkClicked;
+            tBLSCustomOutputCurve.Leave += tBCustomOutputCurve_Leave;
             nUDRS.ValueChanged += numUDRS_ValueChanged;
             nUDRSMaxZone.ValueChanged += nUDRSMaxZone_ValueChanged;
             nUDRSAntiDead.ValueChanged += nUDRSAntiDead_ValueChanged;
             nUDRSS.ValueChanged += nUDRSSens_ValueChanged;
             rsOutCurveComboBox.SelectedIndexChanged += rsOutCurveComboBox_SelectedIndexChanged;
             tBRSCustomOutputCurve.Leave += TBRSCustomOutputCurve_Leave;
-            lbRSCurveEditorURL.Click += LbRSCurveEditorURL_Click;
             rsSquStickCk.Click += rsSquStickCk_Click;
             nUDRSCurve.ValueChanged += nUDRSCurve_ValueChanged;
             nUDRSRotation.ValueChanged += nUDRSRotation_ValueChanged;
@@ -360,14 +356,12 @@ namespace DS4Windows.Forms
             nUDL2S.ValueChanged += nUDL2Sens_ValueChanged;
             cBL2OutputCurve.SelectedIndexChanged += cBL2OutputCurve_SelectedIndexChanged;
             tBL2CustomOutputCurve.Leave += TBL2CustomOutputCurve_Leave;
-            lbL2CurveEditorURL.Click += LbL2CurveEditorURL_Click;
             nUDR2.ValueChanged += numUDR2_ValueChanged;
             nUDR2Maxzone.ValueChanged += nUDR2Maxzone_ValueChanged;
             nUDR2AntiDead.ValueChanged += nUDR2AntiDead_ValueChanged;
             nUDR2S.ValueChanged += nUDR2Sens_ValueChanged;
             cBR2OutputCurve.SelectedIndexChanged += cBR2OutputCurve_SelectedIndexChanged;
             tBR2CustomOutputCurve.Leave += TBR2CustomOutputCurve_Leave;
-            lbR2CurveEditorURL.Click += LbR2CurveEditorURL_Click;
             nUDSX.ValueChanged += nUDSX_ValueChanged;
             nUDSZ.ValueChanged += nUDSZ_ValueChanged;
             nUDSixAxisXMaxZone.ValueChanged += nUDSixAxisXMaxZone_ValueChanged;
@@ -378,10 +372,8 @@ namespace DS4Windows.Forms
             nUDSZS.ValueChanged += nUDSZSens_ValueChanged;
             cBSixaxisXOutputCurve.SelectedIndexChanged += cBSixaxisXOutputCurve_SelectedIndexChanged;
             tBSixXCustomOutputCurve.Leave += TBSixXCustomOutputCurve_Leave;
-            lbSixXCurveEditorURL.Click += LbSixXCurveEditorURL_Click;
             cBSixaxisZOutputCurve.SelectedIndexChanged += cBSixaxisZOutputCurve_SelectedIndexChanged;
             tBSixZCustomOutputCurve.Leave += TBSixZCustomOutputCurve_Leave;
-            lbSixZCurveEditorURL.Click += LbSixZCurveEditorURL_Click;
 
             // Gyro events
             gyroOutputMode.SelectedIndexChanged += GyroOutputMode_SelectedIndexChanged;
@@ -466,34 +458,14 @@ namespace DS4Windows.Forms
             }
         }
 
-        private void LbSixZCurveEditorURL_Click(object sender, EventArgs e)
+        private void BtnCurveEditor_Click(object sender, EventArgs e)
         {
-            string customDefinition = szOutBezierCurveObj[device].ToString();
-            LaunchCurveEditor(customDefinition);
-        }
-
-        private void LbSixXCurveEditorURL_Click(object sender, EventArgs e)
-        {
-            string customDefinition = sxOutBezierCurveObj[device].ToString();
-            LaunchCurveEditor(customDefinition);
-        }
-
-        private void LbR2CurveEditorURL_Click(object sender, EventArgs e)
-        {
-            string customDefinition = r2OutBezierCurveObj[device].ToString();
-            LaunchCurveEditor(customDefinition);
-        }
-
-        private void LbRSCurveEditorURL_Click(object sender, EventArgs e)
-        {
-            string customDefinition = rsOutBezierCurveObj[device].ToString();
-            LaunchCurveEditor(customDefinition);
-        }
-
-        private void LbL2CurveEditorURL_Click(object sender, EventArgs e)
-        {
-            string customDefinition = l2OutBezierCurveObj[device].ToString();
-            LaunchCurveEditor(customDefinition);
+            if(sender == BtnLSCurveEditor) LaunchCurveEditor(lsOutBezierCurveObj[device].ToString());
+            else if (sender == btnRSCurveEditor) LaunchCurveEditor(rsOutBezierCurveObj[device].ToString());
+            else if (sender == btnL2CurveEditor) LaunchCurveEditor(l2OutBezierCurveObj[device].ToString());
+            else if (sender == btnR2CurveEditor) LaunchCurveEditor(r2OutBezierCurveObj[device].ToString());
+            else if (sender == btnSixXCurveEditor) LaunchCurveEditor(sxOutBezierCurveObj[device].ToString());
+            else if (sender == btnSixZCurveEditor) LaunchCurveEditor(szOutBezierCurveObj[device].ToString());
         }
 
         private void TBSixZCustomOutputCurve_Leave(object sender, EventArgs e)
@@ -501,7 +473,7 @@ namespace DS4Windows.Forms
             if (loading == false)
             {
                 if (cBSixaxisZOutputCurve.SelectedIndex == cBSixaxisZOutputCurve.Items.Count - 1)
-                    szOutBezierCurveObj[device].InitBezierCurve(tBCustomOutputCurve.Text, BezierCurve.AxisType.SA, true);
+                    szOutBezierCurveObj[device].InitBezierCurve(tBSixZCustomOutputCurve.Text, BezierCurve.AxisType.SA, true);
             }
         }
 
@@ -510,7 +482,7 @@ namespace DS4Windows.Forms
             if (loading == false)
             {
                 if (cBSixaxisXOutputCurve.SelectedIndex == cBSixaxisXOutputCurve.Items.Count - 1)
-                    sxOutBezierCurveObj[device].InitBezierCurve(tBCustomOutputCurve.Text, BezierCurve.AxisType.SA, true);
+                    sxOutBezierCurveObj[device].InitBezierCurve(tBSixXCustomOutputCurve.Text, BezierCurve.AxisType.SA, true);
             }
         }
 
@@ -519,7 +491,7 @@ namespace DS4Windows.Forms
             if (loading == false)
             {
                 if (cBR2OutputCurve.SelectedIndex == cBR2OutputCurve.Items.Count - 1)
-                    r2OutBezierCurveObj[device].InitBezierCurve(tBCustomOutputCurve.Text, BezierCurve.AxisType.L2R2, true);
+                    r2OutBezierCurveObj[device].InitBezierCurve(tBR2CustomOutputCurve.Text, BezierCurve.AxisType.L2R2, true);
             }
         }
 
@@ -528,7 +500,17 @@ namespace DS4Windows.Forms
             if (loading == false)
             {
                 if (cBL2OutputCurve.SelectedIndex == cBL2OutputCurve.Items.Count - 1)
-                    l2OutBezierCurveObj[device].InitBezierCurve(tBCustomOutputCurve.Text, BezierCurve.AxisType.L2R2, true);
+                    l2OutBezierCurveObj[device].InitBezierCurve(tBL2CustomOutputCurve.Text, BezierCurve.AxisType.L2R2, true);
+            }
+        }
+
+        private void tBCustomOutputCurve_Leave(object sender, EventArgs e)
+        {
+            if (loading == false)
+            {
+                // Focus leaves the custom output curve editbox. Store the new custom curve value into LS/RS/L2/R2/SX/SZ bezierCurve object
+                if (lsOutCurveComboBox.SelectedIndex == lsOutCurveComboBox.Items.Count - 1)
+                    lsOutBezierCurveObj[device].InitBezierCurve(tBLSCustomOutputCurve.Text, BezierCurve.AxisType.LSRS, true);
             }
         }
 
@@ -537,7 +519,7 @@ namespace DS4Windows.Forms
             if (loading == false)
             {
                 if (rsOutCurveComboBox.SelectedIndex == rsOutCurveComboBox.Items.Count - 1)
-                    rsOutBezierCurveObj[device].InitBezierCurve(tBCustomOutputCurve.Text, BezierCurve.AxisType.LSRS, true);
+                    rsOutBezierCurveObj[device].InitBezierCurve(tBRSCustomOutputCurve.Text, BezierCurve.AxisType.LSRS, true);
             }
         }
 
@@ -1048,19 +1030,14 @@ namespace DS4Windows.Forms
                 cBSixaxisXOutputCurve.SelectedIndex = 0;
                 cBSixaxisZOutputCurve.SelectedIndex = 0;
 
-                tBCustomOutputCurve.Text = String.Empty;
-                //lbCurveEditorURL.Text = $"   - {lbCurveEditorURL.Text}";
-                tBCustomOutputCurve.Enabled = lbCurveEditorURL.Enabled = false;
+                tBLSCustomOutputCurve.Text = String.Empty;
                 tBRSCustomOutputCurve.Text = String.Empty;
-                tBRSCustomOutputCurve.Enabled = lbRSCurveEditorURL.Enabled = false;
                 tBL2CustomOutputCurve.Text = String.Empty;
-                tBL2CustomOutputCurve.Enabled = lbL2CurveEditorURL.Enabled = false;
                 tBR2CustomOutputCurve.Text = String.Empty;
-                tBR2CustomOutputCurve.Enabled = lbR2CurveEditorURL.Enabled = false;
                 tBSixXCustomOutputCurve.Text = String.Empty;
-                tBSixXCustomOutputCurve.Enabled = lbSixXCurveEditorURL.Enabled = false;
                 tBSixZCustomOutputCurve.Text = String.Empty;
-                tBSixZCustomOutputCurve.Enabled = lbSixZCurveEditorURL.Enabled = false;
+
+                CustomCurveChecker();
 
                 rBTPMouse.Checked = true;
                 //rBSAControls.Checked = true;
@@ -3257,13 +3234,11 @@ namespace DS4Windows.Forms
             if (!loading)
             {
                 bool customIdx = lsOutCurveComboBox.SelectedIndex == lsOutCurveComboBox.Items.Count - 1;
-                // This same handler is called when combobox label object is clicked. Update curve mode only when sender is ComboxBox with a new selection index
-                if (sender is ComboBox && customIdx)
+                if (customIdx)
                     setLsOutCurveMode(device, lsOutCurveComboBox.SelectedIndex);
 
-                tBCustomOutputCurve.Enabled = lbCurveEditorURL.Enabled = customIdx;
-                tBCustomOutputCurve.Text = (customIdx ? lsOutBezierCurveObj[device].ToString() : "");
-                //lbCurveEditorURL.Text = $"LS - {lbCurveEditorURL.Text.Substring(5)}";
+                tBLSCustomOutputCurve.Enabled = BtnLSCurveEditor.Enabled = customIdx;
+                tBLSCustomOutputCurve.Text = (customIdx ? lsOutBezierCurveObj[device].ToString() : "");
             }
         }
 
@@ -3272,73 +3247,91 @@ namespace DS4Windows.Forms
             if (!loading)
             {
                 bool customIdx = rsOutCurveComboBox.SelectedIndex == rsOutCurveComboBox.Items.Count - 1;
-                if (sender is ComboBox && customIdx)
+                if (customIdx)
                     setRsOutCurveMode(device, rsOutCurveComboBox.SelectedIndex);
 
-                tBRSCustomOutputCurve.Enabled = lbRSCurveEditorURL.Enabled = customIdx;
+                tBRSCustomOutputCurve.Enabled = btnRSCurveEditor.Enabled = customIdx;
                 tBRSCustomOutputCurve.Text = (customIdx ? rsOutBezierCurveObj[device].ToString() : "");
-                //lbCurveEditorURL.Text = $"RS - {lbCurveEditorURL.Text.Substring(5)}";
+            }
+        }
+
+        private void cBL2OutputCurve_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            if (loading == false)
+            {
+                bool customIdx = cBL2OutputCurve.SelectedIndex == cBL2OutputCurve.Items.Count - 1;
+                if (customIdx)
+                    setL2OutCurveMode(device, cBL2OutputCurve.SelectedIndex);
+
+                tBL2CustomOutputCurve.Enabled = btnL2CurveEditor.Enabled = customIdx;
+                tBL2CustomOutputCurve.Text = (tBL2CustomOutputCurve.Enabled ? l2OutBezierCurveObj[device].ToString() : "");
+            }
+        }
+
+        private void cBR2OutputCurve_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            if (loading == false)
+            {
+                bool customIdx = cBR2OutputCurve.SelectedIndex == cBR2OutputCurve.Items.Count - 1;
+                if (customIdx)
+                    setR2OutCurveMode(device, cBR2OutputCurve.SelectedIndex);
+
+                tBR2CustomOutputCurve.Enabled = btnR2CurveEditor.Enabled = customIdx;
+                tBR2CustomOutputCurve.Text = (tBR2CustomOutputCurve.Enabled ? r2OutBezierCurveObj[device].ToString() : "");
+            }
+        }
+
+        private void cBSixaxisXOutputCurve_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            if (loading == false)
+            {
+                bool customIdx = cBSixaxisXOutputCurve.SelectedIndex == cBSixaxisXOutputCurve.Items.Count - 1;
+                if (customIdx)
+                    setSXOutCurveMode(device, cBSixaxisXOutputCurve.SelectedIndex);
+
+                tBSixXCustomOutputCurve.Enabled = btnSixXCurveEditor.Enabled = customIdx;
+                tBSixXCustomOutputCurve.Text = (tBSixXCustomOutputCurve.Enabled ? sxOutBezierCurveObj[device].ToString() : "");
+            }
+        }
+
+        private void cBSixaxisZOutputCurve_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            if (loading == false)
+            {
+                bool customIdx = cBSixaxisZOutputCurve.SelectedIndex == cBSixaxisZOutputCurve.Items.Count - 1;
+                if (customIdx)
+                    setSZOutCurveMode(device, cBSixaxisZOutputCurve.SelectedIndex);
+
+                tBSixZCustomOutputCurve.Enabled = btnSixZCurveEditor.Enabled = customIdx;
+                tBSixZCustomOutputCurve.Text = (tBSixZCustomOutputCurve.Enabled ? szOutBezierCurveObj[device].ToString() : "");
             }
         }
 
         private void CustomCurveChecker()
         {
             bool customIdx = lsOutCurveComboBox.SelectedIndex == lsOutCurveComboBox.Items.Count - 1;
-            if (customIdx)
-            {
-                tBCustomOutputCurve.Enabled = lbCurveEditorURL.Enabled = customIdx;
-                tBCustomOutputCurve.Text = (customIdx ? lsOutBezierCurveObj[device].ToString() : "");
-                //lbCurveEditorURL.Text = $"LS - {lbCurveEditorURL.Text.Substring(5)}";
-                goto end;
-            }
+            tBLSCustomOutputCurve.Enabled = BtnLSCurveEditor.Enabled = customIdx;
+            tBLSCustomOutputCurve.Text = (customIdx ? lsOutBezierCurveObj[device].ToString() : "");
 
             customIdx = rsOutCurveComboBox.SelectedIndex == rsOutCurveComboBox.Items.Count - 1;
-            if (customIdx)
-            {
-                tBRSCustomOutputCurve.Enabled = lbRSCurveEditorURL.Enabled = customIdx;
-                tBRSCustomOutputCurve.Text = (customIdx ? rsOutBezierCurveObj[device].ToString() : "");
-                //lbCurveEditorURL.Text = $"RS - {lbCurveEditorURL.Text.Substring(5)}";
-                goto end;
-            }
+            tBRSCustomOutputCurve.Enabled = btnRSCurveEditor.Enabled = customIdx;
+            tBRSCustomOutputCurve.Text = (customIdx ? rsOutBezierCurveObj[device].ToString() : "");
 
             customIdx = cBL2OutputCurve.SelectedIndex == cBL2OutputCurve.Items.Count - 1;
-            if (customIdx)
-            {
-                tBL2CustomOutputCurve.Enabled = lbL2CurveEditorURL.Enabled = customIdx;
-                tBL2CustomOutputCurve.Text = (tBL2CustomOutputCurve.Enabled ? l2OutBezierCurveObj[device].ToString() : "");
-                //lbCurveEditorURL.Text = $"L2 - {lbCurveEditorURL.Text.Substring(5)}";
-                goto end;
-            }
+            tBL2CustomOutputCurve.Enabled = btnL2CurveEditor.Enabled = customIdx;
+            tBL2CustomOutputCurve.Text = (customIdx ? l2OutBezierCurveObj[device].ToString() : "");
 
             customIdx = cBR2OutputCurve.SelectedIndex == cBR2OutputCurve.Items.Count - 1;
-            if (customIdx)
-            {
-                tBR2CustomOutputCurve.Enabled = lbR2CurveEditorURL.Enabled = customIdx;
-                tBR2CustomOutputCurve.Text = (tBR2CustomOutputCurve.Enabled ? r2OutBezierCurveObj[device].ToString() : "");
-                //lbCurveEditorURL.Text = $"R2 - {lbCurveEditorURL.Text.Substring(5)}";
-                goto end;
-            }
+            tBR2CustomOutputCurve.Enabled = btnR2CurveEditor.Enabled = customIdx;
+            tBR2CustomOutputCurve.Text = (customIdx ? r2OutBezierCurveObj[device].ToString() : "");
 
             customIdx = cBSixaxisXOutputCurve.SelectedIndex == cBSixaxisXOutputCurve.Items.Count - 1;
-            if (customIdx)
-            {
-                tBSixXCustomOutputCurve.Enabled = lbSixXCurveEditorURL.Enabled = customIdx;
-                tBSixXCustomOutputCurve.Text = (tBSixXCustomOutputCurve.Enabled ? sxOutBezierCurveObj[device].ToString() : "");
-                //lbCurveEditorURL.Text = $"SX - {lbCurveEditorURL.Text.Substring(5)}";
-                goto end;
-            }
+            tBSixXCustomOutputCurve.Enabled = btnSixXCurveEditor.Enabled = customIdx;
+            tBSixXCustomOutputCurve.Text = (customIdx ? sxOutBezierCurveObj[device].ToString() : "");
 
             customIdx = cBSixaxisZOutputCurve.SelectedIndex == cBSixaxisZOutputCurve.Items.Count - 1;
-            if (customIdx)
-            {
-                tBSixZCustomOutputCurve.Enabled = lbCurveEditorURL.Enabled = customIdx;
-                tBSixZCustomOutputCurve.Text = (tBSixZCustomOutputCurve.Enabled ? szOutBezierCurveObj[device].ToString() : "");
-                //lbCurveEditorURL.Text = $"SZ - {lbCurveEditorURL.Text.Substring(5)}";
-                goto end;
-            }
-
-            end:
-                return;
+            tBSixZCustomOutputCurve.Enabled = btnSixZCurveEditor.Enabled = customIdx;
+            tBSixZCustomOutputCurve.Text = (customIdx ? szOutBezierCurveObj[device].ToString() : "");
         }
 
         private void gyroTriggerBehavior_CheckedChanged(object sender, EventArgs e)
@@ -3439,62 +3432,6 @@ namespace DS4Windows.Forms
             if (loading == false)
             {
                 SZAntiDeadzone[device] = (double)nUDSixaxisZAntiDead.Value;
-            }
-        }
-
-        private void cBL2OutputCurve_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            if (loading == false)
-            {
-                bool customIdx = cBL2OutputCurve.SelectedIndex == cBL2OutputCurve.Items.Count - 1;
-                if (sender is ComboBox && customIdx)
-                    setL2OutCurveMode(device, cBL2OutputCurve.SelectedIndex);
-
-                tBL2CustomOutputCurve.Enabled = lbL2CurveEditorURL.Enabled = customIdx;
-                tBL2CustomOutputCurve.Text = (tBL2CustomOutputCurve.Enabled ? l2OutBezierCurveObj[device].ToString() : "");
-                //lbCurveEditorURL.Text = $"L2 - {lbCurveEditorURL.Text.Substring(5)}";
-            }
-        }
-
-        private void cBR2OutputCurve_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            if (loading == false)
-            {
-                bool customIdx = cBR2OutputCurve.SelectedIndex == cBR2OutputCurve.Items.Count - 1;
-                if (sender is ComboBox && customIdx)
-                    setR2OutCurveMode(device, cBR2OutputCurve.SelectedIndex);
-
-                tBR2CustomOutputCurve.Enabled = lbR2CurveEditorURL.Enabled = customIdx;
-                tBR2CustomOutputCurve.Text = (tBR2CustomOutputCurve.Enabled ? r2OutBezierCurveObj[device].ToString() : "");
-                //lbCurveEditorURL.Text = $"R2 - {lbCurveEditorURL.Text.Substring(5)}";
-            }
-        }
-
-        private void cBSixaxisXOutputCurve_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            if (loading == false)
-            {
-                bool customIdx = cBSixaxisXOutputCurve.SelectedIndex == cBSixaxisXOutputCurve.Items.Count - 1;
-                if (sender is ComboBox && customIdx)
-                    setSXOutCurveMode(device, cBSixaxisXOutputCurve.SelectedIndex);
-
-                tBSixXCustomOutputCurve.Enabled = lbSixXCurveEditorURL.Enabled = customIdx;
-                tBSixXCustomOutputCurve.Text = (tBSixXCustomOutputCurve.Enabled ? sxOutBezierCurveObj[device].ToString() : "");
-                //lbCurveEditorURL.Text = $"SX - {lbCurveEditorURL.Text.Substring(5)}";
-            }
-        }
-
-        private void cBSixaxisZOutputCurve_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            if (loading == false)
-            {
-                bool customIdx = cBSixaxisZOutputCurve.SelectedIndex == cBSixaxisZOutputCurve.Items.Count - 1;
-                if (sender is ComboBox && customIdx)
-                    setSZOutCurveMode(device, cBSixaxisZOutputCurve.SelectedIndex);
-
-                tBSixZCustomOutputCurve.Enabled = lbSixZCurveEditorURL.Enabled = customIdx;
-                tBSixZCustomOutputCurve.Text = (tBSixZCustomOutputCurve.Enabled ? szOutBezierCurveObj[device].ToString() : "");
-                //lbCurveEditorURL.Text = $"SZ - {lbCurveEditorURL.Text.Substring(5)}";
             }
         }
 
@@ -3735,22 +3672,6 @@ namespace DS4Windows.Forms
             catch (Exception ex)
             {
                 AppLogger.LogToGui($"ERROR. Failed to open {Global.exepath}\\BezierCurveEditor\\index.html web app. Check that the web file exits or launch it outside of DS4Windows application. {ex.Message}", true);
-            }
-        }
-
-        private void lbCurveEditorURL_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
-        {            
-            string customDefinition = lsOutBezierCurveObj[device].ToString();
-            LaunchCurveEditor(customDefinition);
-        }
-
-        private void tBCustomOutputCurve_Leave(object sender, EventArgs e)
-        {
-            if (loading == false)
-            {
-                // Focus leaves the custom output curve editbox. Store the new custom curve value into LS/RS/L2/R2/SX/SZ bezierCurve object
-                if (lsOutCurveComboBox.SelectedIndex == lsOutCurveComboBox.Items.Count - 1)
-                    lsOutBezierCurveObj[device].InitBezierCurve(tBCustomOutputCurve.Text, BezierCurve.AxisType.LSRS, true);
             }
         }
 

--- a/DS4Windows/DS4Forms/Options.fi.resx
+++ b/DS4Windows/DS4Forms/Options.fi.resx
@@ -742,4 +742,46 @@
   <data name="twoFingerTouchInvStripMenuItem.Text" xml:space="preserve">
     <value>2 sormea kosketuslevyllä</value>
   </data>
+  <data name="btnSATrack.Text" xml:space="preserve">
+    <value>nappi1</value>
+  </data>
+  <data name="circleTouchInvStripMenuItem.Text" xml:space="preserve">
+    <value>Ympyrä</value>
+  </data>
+  <data name="circleToolStripMenuItem.Text" xml:space="preserve">
+    <value>Ympyrä</value>
+  </data>
+  <data name="lBControls.Items1" xml:space="preserve">
+    <value>Ympyrä:</value>
+  </data>
+  <data name="gyroOutputMode.Items" xml:space="preserve">
+    <value>Kontrollit</value>
+  </data>
+  <data name="downTouchInvStripMenuItem.Text" xml:space="preserve">
+    <value>Alas</value>
+  </data>
+  <data name="downToolStripMenuItem.Text" xml:space="preserve">
+    <value>Alas</value>
+  </data>
+  <data name="lBControls.Items7" xml:space="preserve">
+    <value>Alas:</value>
+  </data>
+  <data name="gyroMStickUseSmoothCk.Text" xml:space="preserve">
+    <value>Tasaaminen</value>
+  </data>
+  <data name="gyroMStickToggleCk.Text" xml:space="preserve">
+    <value>Kytke</value>
+  </data>
+  <data name="squareTouchInvStripMenuItem.Text" xml:space="preserve">
+    <value>Neliö</value>
+  </data>
+  <data name="squareToolStripMenuItem.Text" xml:space="preserve">
+    <value>Neliö</value>
+  </data>
+  <data name="lBControls.Items2" xml:space="preserve">
+    <value>Neliö :</value>
+  </data>
+  <data name="label4.Text" xml:space="preserve">
+    <value>Neliötikku</value>
+  </data>
 </root>

--- a/DS4Windows/DS4Forms/Options.resx
+++ b/DS4Windows/DS4Forms/Options.resx
@@ -411,198 +411,6 @@
   <data name="&gt;&gt;cBTouchpadJitterCompensation.ZOrder" xml:space="preserve">
     <value>10</value>
   </data>
-  <data name="&gt;&gt;pnlTPMouse.Name" xml:space="preserve">
-    <value>pnlTPMouse</value>
-  </data>
-  <data name="&gt;&gt;pnlTPMouse.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;pnlTPMouse.Parent" xml:space="preserve">
-    <value>gBTouchpad</value>
-  </data>
-  <data name="&gt;&gt;pnlTPMouse.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;rBTPControls.Name" xml:space="preserve">
-    <value>rBTPControls</value>
-  </data>
-  <data name="&gt;&gt;rBTPControls.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;rBTPControls.Parent" xml:space="preserve">
-    <value>gBTouchpad</value>
-  </data>
-  <data name="&gt;&gt;rBTPControls.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;rBTPMouse.Name" xml:space="preserve">
-    <value>rBTPMouse</value>
-  </data>
-  <data name="&gt;&gt;rBTPMouse.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;rBTPMouse.Parent" xml:space="preserve">
-    <value>gBTouchpad</value>
-  </data>
-  <data name="&gt;&gt;rBTPMouse.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;fLPTouchSwipe.Name" xml:space="preserve">
-    <value>fLPTouchSwipe</value>
-  </data>
-  <data name="&gt;&gt;fLPTouchSwipe.Type" xml:space="preserve">
-    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;fLPTouchSwipe.Parent" xml:space="preserve">
-    <value>gBTouchpad</value>
-  </data>
-  <data name="&gt;&gt;fLPTouchSwipe.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="gBTouchpad.Location" type="System.Drawing.Point, System.Drawing">
-    <value>2, 259</value>
-  </data>
-  <data name="gBTouchpad.Size" type="System.Drawing.Size, System.Drawing">
-    <value>270, 190</value>
-  </data>
-  <data name="gBTouchpad.TabIndex" type="System.Int32, mscorlib">
-    <value>246</value>
-  </data>
-  <data name="gBTouchpad.Text" xml:space="preserve">
-    <value>Touchpad</value>
-  </data>
-  <data name="&gt;&gt;gBTouchpad.Name" xml:space="preserve">
-    <value>gBTouchpad</value>
-  </data>
-  <data name="&gt;&gt;gBTouchpad.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;gBTouchpad.Parent" xml:space="preserve">
-    <value>tPControls</value>
-  </data>
-  <data name="&gt;&gt;gBTouchpad.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;trackFrictionLb.Name" xml:space="preserve">
-    <value>trackFrictionLb</value>
-  </data>
-  <data name="&gt;&gt;trackFrictionLb.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;trackFrictionLb.Parent" xml:space="preserve">
-    <value>pnlTPMouse</value>
-  </data>
-  <data name="&gt;&gt;trackFrictionLb.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;trackFrictionNUD.Name" xml:space="preserve">
-    <value>trackFrictionNUD</value>
-  </data>
-  <data name="&gt;&gt;trackFrictionNUD.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;trackFrictionNUD.Parent" xml:space="preserve">
-    <value>pnlTPMouse</value>
-  </data>
-  <data name="&gt;&gt;trackFrictionNUD.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;trackballCk.Name" xml:space="preserve">
-    <value>trackballCk</value>
-  </data>
-  <data name="&gt;&gt;trackballCk.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;trackballCk.Parent" xml:space="preserve">
-    <value>pnlTPMouse</value>
-  </data>
-  <data name="&gt;&gt;trackballCk.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;touchpadDisInvertButton.Name" xml:space="preserve">
-    <value>touchpadDisInvertButton</value>
-  </data>
-  <data name="&gt;&gt;touchpadDisInvertButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;touchpadDisInvertButton.Parent" xml:space="preserve">
-    <value>pnlTPMouse</value>
-  </data>
-  <data name="&gt;&gt;touchpadDisInvertButton.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;label25.Name" xml:space="preserve">
-    <value>label25</value>
-  </data>
-  <data name="&gt;&gt;label25.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label25.Parent" xml:space="preserve">
-    <value>pnlTPMouse</value>
-  </data>
-  <data name="&gt;&gt;label25.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;label15.Name" xml:space="preserve">
-    <value>label15</value>
-  </data>
-  <data name="&gt;&gt;label15.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label15.Parent" xml:space="preserve">
-    <value>pnlTPMouse</value>
-  </data>
-  <data name="&gt;&gt;label15.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;touchpadInvertComboBox.Name" xml:space="preserve">
-    <value>touchpadInvertComboBox</value>
-  </data>
-  <data name="&gt;&gt;touchpadInvertComboBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;touchpadInvertComboBox.Parent" xml:space="preserve">
-    <value>pnlTPMouse</value>
-  </data>
-  <data name="&gt;&gt;touchpadInvertComboBox.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;cbStartTouchpadOff.Name" xml:space="preserve">
-    <value>cbStartTouchpadOff</value>
-  </data>
-  <data name="&gt;&gt;cbStartTouchpadOff.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbStartTouchpadOff.Parent" xml:space="preserve">
-    <value>pnlTPMouse</value>
-  </data>
-  <data name="&gt;&gt;cbStartTouchpadOff.ZOrder" xml:space="preserve">
-    <value>16</value>
-  </data>
-  <data name="pnlTPMouse.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 36</value>
-  </data>
-  <data name="pnlTPMouse.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>2, 2, 2, 2</value>
-  </data>
-  <data name="pnlTPMouse.Size" type="System.Drawing.Size, System.Drawing">
-    <value>266, 149</value>
-  </data>
-  <data name="pnlTPMouse.TabIndex" type="System.Int32, mscorlib">
-    <value>257</value>
-  </data>
-  <data name="&gt;&gt;pnlTPMouse.Name" xml:space="preserve">
-    <value>pnlTPMouse</value>
-  </data>
-  <data name="&gt;&gt;pnlTPMouse.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;pnlTPMouse.Parent" xml:space="preserve">
-    <value>gBTouchpad</value>
-  </data>
-  <data name="&gt;&gt;pnlTPMouse.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="trackFrictionLb.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -834,6 +642,30 @@
   <data name="&gt;&gt;cbStartTouchpadOff.ZOrder" xml:space="preserve">
     <value>16</value>
   </data>
+  <data name="pnlTPMouse.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 36</value>
+  </data>
+  <data name="pnlTPMouse.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 2, 2, 2</value>
+  </data>
+  <data name="pnlTPMouse.Size" type="System.Drawing.Size, System.Drawing">
+    <value>266, 149</value>
+  </data>
+  <data name="pnlTPMouse.TabIndex" type="System.Int32, mscorlib">
+    <value>257</value>
+  </data>
+  <data name="&gt;&gt;pnlTPMouse.Name" xml:space="preserve">
+    <value>pnlTPMouse</value>
+  </data>
+  <data name="&gt;&gt;pnlTPMouse.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pnlTPMouse.Parent" xml:space="preserve">
+    <value>gBTouchpad</value>
+  </data>
+  <data name="&gt;&gt;pnlTPMouse.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <data name="rBTPControls.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -900,126 +732,156 @@
   <data name="&gt;&gt;rBTPMouse.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
-  <data name="&gt;&gt;bnSwipeUp.Name" xml:space="preserve">
-    <value>bnSwipeUp</value>
-  </data>
-  <data name="&gt;&gt;bnSwipeUp.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;bnSwipeUp.Parent" xml:space="preserve">
-    <value>fLPTouchSwipe</value>
-  </data>
-  <data name="&gt;&gt;bnSwipeUp.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;lbSwipeUp.Name" xml:space="preserve">
-    <value>lbSwipeUp</value>
-  </data>
-  <data name="&gt;&gt;lbSwipeUp.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbSwipeUp.Parent" xml:space="preserve">
-    <value>fLPTouchSwipe</value>
-  </data>
-  <data name="&gt;&gt;lbSwipeUp.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;bnSwipeDown.Name" xml:space="preserve">
-    <value>bnSwipeDown</value>
-  </data>
-  <data name="&gt;&gt;bnSwipeDown.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;bnSwipeDown.Parent" xml:space="preserve">
-    <value>fLPTouchSwipe</value>
-  </data>
-  <data name="&gt;&gt;bnSwipeDown.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;lbSwipeDown.Name" xml:space="preserve">
-    <value>lbSwipeDown</value>
-  </data>
-  <data name="&gt;&gt;lbSwipeDown.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbSwipeDown.Parent" xml:space="preserve">
-    <value>fLPTouchSwipe</value>
-  </data>
-  <data name="&gt;&gt;lbSwipeDown.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;bnSwipeLeft.Name" xml:space="preserve">
-    <value>bnSwipeLeft</value>
-  </data>
-  <data name="&gt;&gt;bnSwipeLeft.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;bnSwipeLeft.Parent" xml:space="preserve">
-    <value>fLPTouchSwipe</value>
-  </data>
-  <data name="&gt;&gt;bnSwipeLeft.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;lbSwipeLeft.Name" xml:space="preserve">
-    <value>lbSwipeLeft</value>
-  </data>
-  <data name="&gt;&gt;lbSwipeLeft.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbSwipeLeft.Parent" xml:space="preserve">
-    <value>fLPTouchSwipe</value>
-  </data>
-  <data name="&gt;&gt;lbSwipeLeft.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;bnSwipeRight.Name" xml:space="preserve">
-    <value>bnSwipeRight</value>
-  </data>
-  <data name="&gt;&gt;bnSwipeRight.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;bnSwipeRight.Parent" xml:space="preserve">
-    <value>fLPTouchSwipe</value>
-  </data>
-  <data name="&gt;&gt;bnSwipeRight.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;lbSwipeRight.Name" xml:space="preserve">
-    <value>lbSwipeRight</value>
-  </data>
-  <data name="&gt;&gt;lbSwipeRight.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbSwipeRight.Parent" xml:space="preserve">
-    <value>fLPTouchSwipe</value>
-  </data>
-  <data name="&gt;&gt;lbSwipeRight.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="fLPTouchSwipe.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 40</value>
-  </data>
-  <data name="fLPTouchSwipe.Size" type="System.Drawing.Size, System.Drawing">
-    <value>260, 148</value>
-  </data>
-  <data name="fLPTouchSwipe.TabIndex" type="System.Int32, mscorlib">
-    <value>256</value>
-  </data>
-  <data name="&gt;&gt;fLPTouchSwipe.Name" xml:space="preserve">
-    <value>fLPTouchSwipe</value>
-  </data>
-  <data name="&gt;&gt;fLPTouchSwipe.Type" xml:space="preserve">
-    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;fLPTouchSwipe.Parent" xml:space="preserve">
-    <value>gBTouchpad</value>
-  </data>
-  <data name="&gt;&gt;fLPTouchSwipe.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
   <metadata name="cMSPresets.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>326, 13</value>
   </metadata>
+  <data name="controlToolStripMenuItem.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="controlToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>117, 22</value>
+  </data>
+  <data name="controlToolStripMenuItem.Text" xml:space="preserve">
+    <value>Control</value>
+  </data>
+  <data name="toolStripSeparator1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>114, 6</value>
+  </data>
+  <data name="defaultToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>117, 22</value>
+  </data>
+  <data name="defaultToolStripMenuItem.Text" xml:space="preserve">
+    <value>Default</value>
+  </data>
+  <data name="tSMIDPadInverted.Size" type="System.Drawing.Size, System.Drawing">
+    <value>127, 22</value>
+  </data>
+  <data name="tSMIDPadInverted.Text" xml:space="preserve">
+    <value>Inverted</value>
+  </data>
+  <data name="tSMIDPadInvertedX.Size" type="System.Drawing.Size, System.Drawing">
+    <value>127, 22</value>
+  </data>
+  <data name="tSMIDPadInvertedX.Text" xml:space="preserve">
+    <value>Inverted X</value>
+  </data>
+  <data name="tSMIDPadInvertedY.Size" type="System.Drawing.Size, System.Drawing">
+    <value>127, 22</value>
+  </data>
+  <data name="tSMIDPadInvertedY.Text" xml:space="preserve">
+    <value>Inverted Y</value>
+  </data>
+  <data name="DpadToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>117, 22</value>
+  </data>
+  <data name="DpadToolStripMenuItem.Text" xml:space="preserve">
+    <value>Dpad</value>
+  </data>
+  <data name="tSMILSInverted.Size" type="System.Drawing.Size, System.Drawing">
+    <value>127, 22</value>
+  </data>
+  <data name="tSMILSInverted.Text" xml:space="preserve">
+    <value>Inverted</value>
+  </data>
+  <data name="tSMILSInvertedX.Size" type="System.Drawing.Size, System.Drawing">
+    <value>127, 22</value>
+  </data>
+  <data name="tSMILSInvertedX.Text" xml:space="preserve">
+    <value>Inverted X</value>
+  </data>
+  <data name="tSMILSInvertedY.Size" type="System.Drawing.Size, System.Drawing">
+    <value>127, 22</value>
+  </data>
+  <data name="tSMILSInvertedY.Text" xml:space="preserve">
+    <value>Inverted Y</value>
+  </data>
+  <data name="LSToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>117, 22</value>
+  </data>
+  <data name="LSToolStripMenuItem.Text" xml:space="preserve">
+    <value>Left Stick</value>
+  </data>
+  <data name="tSMIRSInverted.Size" type="System.Drawing.Size, System.Drawing">
+    <value>127, 22</value>
+  </data>
+  <data name="tSMIRSInverted.Text" xml:space="preserve">
+    <value>Inverted</value>
+  </data>
+  <data name="tSMIRSInvertedX.Size" type="System.Drawing.Size, System.Drawing">
+    <value>127, 22</value>
+  </data>
+  <data name="tSMIRSInvertedX.Text" xml:space="preserve">
+    <value>Inverted X</value>
+  </data>
+  <data name="tSMIRSInvertedY.Size" type="System.Drawing.Size, System.Drawing">
+    <value>127, 22</value>
+  </data>
+  <data name="tSMIRSInvertedY.Text" xml:space="preserve">
+    <value>Inverted Y</value>
+  </data>
+  <data name="RSToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>117, 22</value>
+  </data>
+  <data name="RSToolStripMenuItem.Text" xml:space="preserve">
+    <value>Right Stick</value>
+  </data>
+  <data name="ABXYToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>117, 22</value>
+  </data>
+  <data name="ABXYToolStripMenuItem.Text" xml:space="preserve">
+    <value>Face Buttons</value>
+  </data>
+  <data name="wScanCodeWASDToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>147, 22</value>
+  </data>
+  <data name="wScanCodeWASDToolStripMenuItem.Text" xml:space="preserve">
+    <value>w/ Scan Code</value>
+  </data>
+  <data name="WASDToolStripMenuItem.ShowShortcutKeys" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="WASDToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>117, 22</value>
+  </data>
+  <data name="WASDToolStripMenuItem.Text" xml:space="preserve">
+    <value>WASD</value>
+  </data>
+  <data name="wScanCodeArrowKeysToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>147, 22</value>
+  </data>
+  <data name="wScanCodeArrowKeysToolStripMenuItem.Text" xml:space="preserve">
+    <value>w/ Scan Code</value>
+  </data>
+  <data name="ArrowKeysToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>117, 22</value>
+  </data>
+  <data name="ArrowKeysToolStripMenuItem.Text" xml:space="preserve">
+    <value>Arrow Keys</value>
+  </data>
+  <data name="tSMIMouseInverted.Size" type="System.Drawing.Size, System.Drawing">
+    <value>127, 22</value>
+  </data>
+  <data name="tSMIMouseInverted.Text" xml:space="preserve">
+    <value>Inverted</value>
+  </data>
+  <data name="tSMIMouseInvertedX.Size" type="System.Drawing.Size, System.Drawing">
+    <value>127, 22</value>
+  </data>
+  <data name="tSMIMouseInvertedX.Text" xml:space="preserve">
+    <value>Inverted X</value>
+  </data>
+  <data name="tSMIMouseInvertedY.Size" type="System.Drawing.Size, System.Drawing">
+    <value>127, 22</value>
+  </data>
+  <data name="tSMIMouseInvertedY.Text" xml:space="preserve">
+    <value>Inverted Y</value>
+  </data>
+  <data name="MouseToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>117, 22</value>
+  </data>
+  <data name="MouseToolStripMenuItem.Text" xml:space="preserve">
+    <value>Mouse</value>
+  </data>
   <data name="cMSPresets.Size" type="System.Drawing.Size, System.Drawing">
     <value>118, 208</value>
   </data>
@@ -1058,153 +920,6 @@
   </data>
   <data name="&gt;&gt;bnSwipeUp.ZOrder" xml:space="preserve">
     <value>0</value>
-  </data>
-  <data name="controlToolStripMenuItem.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="controlToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>117, 22</value>
-  </data>
-  <data name="controlToolStripMenuItem.Text" xml:space="preserve">
-    <value>Control</value>
-  </data>
-  <data name="toolStripSeparator1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>114, 6</value>
-  </data>
-  <data name="defaultToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>117, 22</value>
-  </data>
-  <data name="defaultToolStripMenuItem.Text" xml:space="preserve">
-    <value>Default</value>
-  </data>
-  <data name="DpadToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>117, 22</value>
-  </data>
-  <data name="DpadToolStripMenuItem.Text" xml:space="preserve">
-    <value>Dpad</value>
-  </data>
-  <data name="tSMIDPadInverted.Size" type="System.Drawing.Size, System.Drawing">
-    <value>127, 22</value>
-  </data>
-  <data name="tSMIDPadInverted.Text" xml:space="preserve">
-    <value>Inverted</value>
-  </data>
-  <data name="tSMIDPadInvertedX.Size" type="System.Drawing.Size, System.Drawing">
-    <value>127, 22</value>
-  </data>
-  <data name="tSMIDPadInvertedX.Text" xml:space="preserve">
-    <value>Inverted X</value>
-  </data>
-  <data name="tSMIDPadInvertedY.Size" type="System.Drawing.Size, System.Drawing">
-    <value>127, 22</value>
-  </data>
-  <data name="tSMIDPadInvertedY.Text" xml:space="preserve">
-    <value>Inverted Y</value>
-  </data>
-  <data name="LSToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>117, 22</value>
-  </data>
-  <data name="LSToolStripMenuItem.Text" xml:space="preserve">
-    <value>Left Stick</value>
-  </data>
-  <data name="tSMILSInverted.Size" type="System.Drawing.Size, System.Drawing">
-    <value>127, 22</value>
-  </data>
-  <data name="tSMILSInverted.Text" xml:space="preserve">
-    <value>Inverted</value>
-  </data>
-  <data name="tSMILSInvertedX.Size" type="System.Drawing.Size, System.Drawing">
-    <value>127, 22</value>
-  </data>
-  <data name="tSMILSInvertedX.Text" xml:space="preserve">
-    <value>Inverted X</value>
-  </data>
-  <data name="tSMILSInvertedY.Size" type="System.Drawing.Size, System.Drawing">
-    <value>127, 22</value>
-  </data>
-  <data name="tSMILSInvertedY.Text" xml:space="preserve">
-    <value>Inverted Y</value>
-  </data>
-  <data name="RSToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>117, 22</value>
-  </data>
-  <data name="RSToolStripMenuItem.Text" xml:space="preserve">
-    <value>Right Stick</value>
-  </data>
-  <data name="tSMIRSInverted.Size" type="System.Drawing.Size, System.Drawing">
-    <value>127, 22</value>
-  </data>
-  <data name="tSMIRSInverted.Text" xml:space="preserve">
-    <value>Inverted</value>
-  </data>
-  <data name="tSMIRSInvertedX.Size" type="System.Drawing.Size, System.Drawing">
-    <value>127, 22</value>
-  </data>
-  <data name="tSMIRSInvertedX.Text" xml:space="preserve">
-    <value>Inverted X</value>
-  </data>
-  <data name="tSMIRSInvertedY.Size" type="System.Drawing.Size, System.Drawing">
-    <value>127, 22</value>
-  </data>
-  <data name="tSMIRSInvertedY.Text" xml:space="preserve">
-    <value>Inverted Y</value>
-  </data>
-  <data name="ABXYToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>117, 22</value>
-  </data>
-  <data name="ABXYToolStripMenuItem.Text" xml:space="preserve">
-    <value>Face Buttons</value>
-  </data>
-  <data name="WASDToolStripMenuItem.ShowShortcutKeys" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="WASDToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>117, 22</value>
-  </data>
-  <data name="WASDToolStripMenuItem.Text" xml:space="preserve">
-    <value>WASD</value>
-  </data>
-  <data name="wScanCodeWASDToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>147, 22</value>
-  </data>
-  <data name="wScanCodeWASDToolStripMenuItem.Text" xml:space="preserve">
-    <value>w/ Scan Code</value>
-  </data>
-  <data name="ArrowKeysToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>117, 22</value>
-  </data>
-  <data name="ArrowKeysToolStripMenuItem.Text" xml:space="preserve">
-    <value>Arrow Keys</value>
-  </data>
-  <data name="wScanCodeArrowKeysToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>147, 22</value>
-  </data>
-  <data name="wScanCodeArrowKeysToolStripMenuItem.Text" xml:space="preserve">
-    <value>w/ Scan Code</value>
-  </data>
-  <data name="MouseToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>117, 22</value>
-  </data>
-  <data name="MouseToolStripMenuItem.Text" xml:space="preserve">
-    <value>Mouse</value>
-  </data>
-  <data name="tSMIMouseInverted.Size" type="System.Drawing.Size, System.Drawing">
-    <value>127, 22</value>
-  </data>
-  <data name="tSMIMouseInverted.Text" xml:space="preserve">
-    <value>Inverted</value>
-  </data>
-  <data name="tSMIMouseInvertedX.Size" type="System.Drawing.Size, System.Drawing">
-    <value>127, 22</value>
-  </data>
-  <data name="tSMIMouseInvertedX.Text" xml:space="preserve">
-    <value>Inverted X</value>
-  </data>
-  <data name="tSMIMouseInvertedY.Size" type="System.Drawing.Size, System.Drawing">
-    <value>127, 22</value>
-  </data>
-  <data name="tSMIMouseInvertedY.Text" xml:space="preserve">
-    <value>Inverted Y</value>
   </data>
   <data name="lbSwipeUp.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -1428,228 +1143,54 @@
   <data name="&gt;&gt;lbSwipeRight.ZOrder" xml:space="preserve">
     <value>7</value>
   </data>
+  <data name="fLPTouchSwipe.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 40</value>
+  </data>
+  <data name="fLPTouchSwipe.Size" type="System.Drawing.Size, System.Drawing">
+    <value>260, 148</value>
+  </data>
+  <data name="fLPTouchSwipe.TabIndex" type="System.Int32, mscorlib">
+    <value>256</value>
+  </data>
+  <data name="&gt;&gt;fLPTouchSwipe.Name" xml:space="preserve">
+    <value>fLPTouchSwipe</value>
+  </data>
+  <data name="&gt;&gt;fLPTouchSwipe.Type" xml:space="preserve">
+    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;fLPTouchSwipe.Parent" xml:space="preserve">
+    <value>gBTouchpad</value>
+  </data>
+  <data name="&gt;&gt;fLPTouchSwipe.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="gBTouchpad.Location" type="System.Drawing.Point, System.Drawing">
+    <value>2, 259</value>
+  </data>
+  <data name="gBTouchpad.Size" type="System.Drawing.Size, System.Drawing">
+    <value>270, 190</value>
+  </data>
+  <data name="gBTouchpad.TabIndex" type="System.Int32, mscorlib">
+    <value>246</value>
+  </data>
+  <data name="gBTouchpad.Text" xml:space="preserve">
+    <value>Touchpad</value>
+  </data>
+  <data name="&gt;&gt;gBTouchpad.Name" xml:space="preserve">
+    <value>gBTouchpad</value>
+  </data>
+  <data name="&gt;&gt;gBTouchpad.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;gBTouchpad.Parent" xml:space="preserve">
+    <value>tPControls</value>
+  </data>
+  <data name="&gt;&gt;gBTouchpad.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
   <metadata name="openFileDialog1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>153, 17</value>
   </metadata>
-  <data name="&gt;&gt;pnlSATrack.Name" xml:space="preserve">
-    <value>pnlSATrack</value>
-  </data>
-  <data name="&gt;&gt;pnlSATrack.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;pnlSATrack.Parent" xml:space="preserve">
-    <value>lbL2TrackS</value>
-  </data>
-  <data name="&gt;&gt;pnlSATrack.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;lbL2Track.Name" xml:space="preserve">
-    <value>lbL2Track</value>
-  </data>
-  <data name="&gt;&gt;lbL2Track.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbL2Track.Parent" xml:space="preserve">
-    <value>lbL2TrackS</value>
-  </data>
-  <data name="&gt;&gt;lbL2Track.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;lbRSTip.Name" xml:space="preserve">
-    <value>lbRSTip</value>
-  </data>
-  <data name="&gt;&gt;lbRSTip.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbRSTip.Parent" xml:space="preserve">
-    <value>lbL2TrackS</value>
-  </data>
-  <data name="&gt;&gt;lbRSTip.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;lbInputDelay.Name" xml:space="preserve">
-    <value>lbInputDelay</value>
-  </data>
-  <data name="&gt;&gt;lbInputDelay.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbInputDelay.Parent" xml:space="preserve">
-    <value>lbL2TrackS</value>
-  </data>
-  <data name="&gt;&gt;lbInputDelay.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;lbR2Track.Name" xml:space="preserve">
-    <value>lbR2Track</value>
-  </data>
-  <data name="&gt;&gt;lbR2Track.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbR2Track.Parent" xml:space="preserve">
-    <value>lbL2TrackS</value>
-  </data>
-  <data name="&gt;&gt;lbR2Track.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;lbLSTip.Name" xml:space="preserve">
-    <value>lbLSTip</value>
-  </data>
-  <data name="&gt;&gt;lbLSTip.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbLSTip.Parent" xml:space="preserve">
-    <value>lbL2TrackS</value>
-  </data>
-  <data name="&gt;&gt;lbLSTip.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;lbSATip.Name" xml:space="preserve">
-    <value>lbSATip</value>
-  </data>
-  <data name="&gt;&gt;lbSATip.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbSATip.Parent" xml:space="preserve">
-    <value>lbL2TrackS</value>
-  </data>
-  <data name="&gt;&gt;lbSATip.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;tBR2.Name" xml:space="preserve">
-    <value>tBR2</value>
-  </data>
-  <data name="&gt;&gt;tBR2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TrackBar, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tBR2.Parent" xml:space="preserve">
-    <value>lbL2TrackS</value>
-  </data>
-  <data name="&gt;&gt;tBR2.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="&gt;&gt;tBL2.Name" xml:space="preserve">
-    <value>tBL2</value>
-  </data>
-  <data name="&gt;&gt;tBL2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TrackBar, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tBL2.Parent" xml:space="preserve">
-    <value>lbL2TrackS</value>
-  </data>
-  <data name="&gt;&gt;tBL2.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;pnlSixaxis.Name" xml:space="preserve">
-    <value>pnlSixaxis</value>
-  </data>
-  <data name="&gt;&gt;pnlSixaxis.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;pnlSixaxis.Parent" xml:space="preserve">
-    <value>lbL2TrackS</value>
-  </data>
-  <data name="&gt;&gt;pnlSixaxis.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="&gt;&gt;pnlLSTrack.Name" xml:space="preserve">
-    <value>pnlLSTrack</value>
-  </data>
-  <data name="&gt;&gt;pnlLSTrack.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;pnlLSTrack.Parent" xml:space="preserve">
-    <value>lbL2TrackS</value>
-  </data>
-  <data name="&gt;&gt;pnlLSTrack.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="&gt;&gt;pnlRSTrack.Name" xml:space="preserve">
-    <value>pnlRSTrack</value>
-  </data>
-  <data name="&gt;&gt;pnlRSTrack.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;pnlRSTrack.Parent" xml:space="preserve">
-    <value>lbL2TrackS</value>
-  </data>
-  <data name="&gt;&gt;pnlRSTrack.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
-  <data name="lbL2TrackS.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="lbL2TrackS.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="lbL2TrackS.Size" type="System.Drawing.Size, System.Drawing">
-    <value>438, 485</value>
-  </data>
-  <data name="lbL2TrackS.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="lbL2TrackS.Text" xml:space="preserve">
-    <value>Controller Readings</value>
-  </data>
-  <data name="&gt;&gt;lbL2TrackS.Name" xml:space="preserve">
-    <value>lbL2TrackS</value>
-  </data>
-  <data name="&gt;&gt;lbL2TrackS.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbL2TrackS.Parent" xml:space="preserve">
-    <value>tCControls</value>
-  </data>
-  <data name="&gt;&gt;lbL2TrackS.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;btnSATrack.Name" xml:space="preserve">
-    <value>btnSATrack</value>
-  </data>
-  <data name="&gt;&gt;btnSATrack.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnSATrack.Parent" xml:space="preserve">
-    <value>pnlSATrack</value>
-  </data>
-  <data name="&gt;&gt;btnSATrack.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;btnSATrackS.Name" xml:space="preserve">
-    <value>btnSATrackS</value>
-  </data>
-  <data name="&gt;&gt;btnSATrackS.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnSATrackS.Parent" xml:space="preserve">
-    <value>pnlSATrack</value>
-  </data>
-  <data name="&gt;&gt;btnSATrackS.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="pnlSATrack.Location" type="System.Drawing.Point, System.Drawing">
-    <value>300, 88</value>
-  </data>
-  <data name="pnlSATrack.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>2, 2, 2, 2</value>
-  </data>
-  <data name="pnlSATrack.Size" type="System.Drawing.Size, System.Drawing">
-    <value>125, 125</value>
-  </data>
-  <data name="pnlSATrack.TabIndex" type="System.Int32, mscorlib">
-    <value>252</value>
-  </data>
-  <data name="&gt;&gt;pnlSATrack.Name" xml:space="preserve">
-    <value>pnlSATrack</value>
-  </data>
-  <data name="&gt;&gt;pnlSATrack.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;pnlSATrack.Parent" xml:space="preserve">
-    <value>lbL2TrackS</value>
-  </data>
-  <data name="&gt;&gt;pnlSATrack.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="btnSATrack.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
@@ -1712,6 +1253,30 @@
   </data>
   <data name="&gt;&gt;btnSATrackS.ZOrder" xml:space="preserve">
     <value>1</value>
+  </data>
+  <data name="pnlSATrack.Location" type="System.Drawing.Point, System.Drawing">
+    <value>300, 88</value>
+  </data>
+  <data name="pnlSATrack.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 2, 2, 2</value>
+  </data>
+  <data name="pnlSATrack.Size" type="System.Drawing.Size, System.Drawing">
+    <value>125, 125</value>
+  </data>
+  <data name="pnlSATrack.TabIndex" type="System.Int32, mscorlib">
+    <value>252</value>
+  </data>
+  <data name="&gt;&gt;pnlSATrack.Name" xml:space="preserve">
+    <value>pnlSATrack</value>
+  </data>
+  <data name="&gt;&gt;pnlSATrack.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pnlSATrack.Parent" xml:space="preserve">
+    <value>lbL2TrackS</value>
+  </data>
+  <data name="&gt;&gt;pnlSATrack.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="lbL2Track.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1977,123 +1542,6 @@
   <data name="&gt;&gt;tBL2.ZOrder" xml:space="preserve">
     <value>8</value>
   </data>
-  <data name="&gt;&gt;tBsixaxisAccelX.Name" xml:space="preserve">
-    <value>tBsixaxisAccelX</value>
-  </data>
-  <data name="&gt;&gt;tBsixaxisAccelX.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TrackBar, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tBsixaxisAccelX.Parent" xml:space="preserve">
-    <value>pnlSixaxis</value>
-  </data>
-  <data name="&gt;&gt;tBsixaxisAccelX.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;lb6Accel.Name" xml:space="preserve">
-    <value>lb6Accel</value>
-  </data>
-  <data name="&gt;&gt;lb6Accel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lb6Accel.Parent" xml:space="preserve">
-    <value>pnlSixaxis</value>
-  </data>
-  <data name="&gt;&gt;lb6Accel.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;tBsixaxisGyroX.Name" xml:space="preserve">
-    <value>tBsixaxisGyroX</value>
-  </data>
-  <data name="&gt;&gt;tBsixaxisGyroX.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TrackBar, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tBsixaxisGyroX.Parent" xml:space="preserve">
-    <value>pnlSixaxis</value>
-  </data>
-  <data name="&gt;&gt;tBsixaxisGyroX.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;lb6Gryo.Name" xml:space="preserve">
-    <value>lb6Gryo</value>
-  </data>
-  <data name="&gt;&gt;lb6Gryo.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lb6Gryo.Parent" xml:space="preserve">
-    <value>pnlSixaxis</value>
-  </data>
-  <data name="&gt;&gt;lb6Gryo.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;tBsixaxisGyroY.Name" xml:space="preserve">
-    <value>tBsixaxisGyroY</value>
-  </data>
-  <data name="&gt;&gt;tBsixaxisGyroY.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TrackBar, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tBsixaxisGyroY.Parent" xml:space="preserve">
-    <value>pnlSixaxis</value>
-  </data>
-  <data name="&gt;&gt;tBsixaxisGyroY.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;tBsixaxisGyroZ.Name" xml:space="preserve">
-    <value>tBsixaxisGyroZ</value>
-  </data>
-  <data name="&gt;&gt;tBsixaxisGyroZ.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TrackBar, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tBsixaxisGyroZ.Parent" xml:space="preserve">
-    <value>pnlSixaxis</value>
-  </data>
-  <data name="&gt;&gt;tBsixaxisGyroZ.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;tBsixaxisAccelY.Name" xml:space="preserve">
-    <value>tBsixaxisAccelY</value>
-  </data>
-  <data name="&gt;&gt;tBsixaxisAccelY.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TrackBar, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tBsixaxisAccelY.Parent" xml:space="preserve">
-    <value>pnlSixaxis</value>
-  </data>
-  <data name="&gt;&gt;tBsixaxisAccelY.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;tBsixaxisAccelZ.Name" xml:space="preserve">
-    <value>tBsixaxisAccelZ</value>
-  </data>
-  <data name="&gt;&gt;tBsixaxisAccelZ.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TrackBar, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tBsixaxisAccelZ.Parent" xml:space="preserve">
-    <value>pnlSixaxis</value>
-  </data>
-  <data name="&gt;&gt;tBsixaxisAccelZ.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="pnlSixaxis.Location" type="System.Drawing.Point, System.Drawing">
-    <value>300, 233</value>
-  </data>
-  <data name="pnlSixaxis.Size" type="System.Drawing.Size, System.Drawing">
-    <value>125, 125</value>
-  </data>
-  <data name="pnlSixaxis.TabIndex" type="System.Int32, mscorlib">
-    <value>236</value>
-  </data>
-  <data name="&gt;&gt;pnlSixaxis.Name" xml:space="preserve">
-    <value>pnlSixaxis</value>
-  </data>
-  <data name="&gt;&gt;pnlSixaxis.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;pnlSixaxis.Parent" xml:space="preserve">
-    <value>lbL2TrackS</value>
-  </data>
-  <data name="&gt;&gt;pnlSixaxis.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
   <data name="tBsixaxisAccelX.AutoSize" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
@@ -2316,53 +1764,26 @@
   <data name="&gt;&gt;tBsixaxisAccelZ.ZOrder" xml:space="preserve">
     <value>7</value>
   </data>
-  <data name="&gt;&gt;btnLSTrack.Name" xml:space="preserve">
-    <value>btnLSTrack</value>
+  <data name="pnlSixaxis.Location" type="System.Drawing.Point, System.Drawing">
+    <value>300, 233</value>
   </data>
-  <data name="&gt;&gt;btnLSTrack.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnLSTrack.Parent" xml:space="preserve">
-    <value>pnlLSTrack</value>
-  </data>
-  <data name="&gt;&gt;btnLSTrack.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;btnLSTrackS.Name" xml:space="preserve">
-    <value>btnLSTrackS</value>
-  </data>
-  <data name="&gt;&gt;btnLSTrackS.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnLSTrackS.Parent" xml:space="preserve">
-    <value>pnlLSTrack</value>
-  </data>
-  <data name="&gt;&gt;btnLSTrackS.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="pnlLSTrack.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 88</value>
-  </data>
-  <data name="pnlLSTrack.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>2, 2, 2, 2</value>
-  </data>
-  <data name="pnlLSTrack.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="pnlSixaxis.Size" type="System.Drawing.Size, System.Drawing">
     <value>125, 125</value>
   </data>
-  <data name="pnlLSTrack.TabIndex" type="System.Int32, mscorlib">
-    <value>250</value>
+  <data name="pnlSixaxis.TabIndex" type="System.Int32, mscorlib">
+    <value>236</value>
   </data>
-  <data name="&gt;&gt;pnlLSTrack.Name" xml:space="preserve">
-    <value>pnlLSTrack</value>
+  <data name="&gt;&gt;pnlSixaxis.Name" xml:space="preserve">
+    <value>pnlSixaxis</value>
   </data>
-  <data name="&gt;&gt;pnlLSTrack.Type" xml:space="preserve">
+  <data name="&gt;&gt;pnlSixaxis.Type" xml:space="preserve">
     <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;pnlLSTrack.Parent" xml:space="preserve">
+  <data name="&gt;&gt;pnlSixaxis.Parent" xml:space="preserve">
     <value>lbL2TrackS</value>
   </data>
-  <data name="&gt;&gt;pnlLSTrack.ZOrder" xml:space="preserve">
-    <value>10</value>
+  <data name="&gt;&gt;pnlSixaxis.ZOrder" xml:space="preserve">
+    <value>9</value>
   </data>
   <data name="btnLSTrack.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -2427,53 +1848,29 @@
   <data name="&gt;&gt;btnLSTrackS.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="&gt;&gt;btnRSTrackS.Name" xml:space="preserve">
-    <value>btnRSTrackS</value>
+  <data name="pnlLSTrack.Location" type="System.Drawing.Point, System.Drawing">
+    <value>5, 88</value>
   </data>
-  <data name="&gt;&gt;btnRSTrackS.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnRSTrackS.Parent" xml:space="preserve">
-    <value>pnlRSTrack</value>
-  </data>
-  <data name="&gt;&gt;btnRSTrackS.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;btnRSTrack.Name" xml:space="preserve">
-    <value>btnRSTrack</value>
-  </data>
-  <data name="&gt;&gt;btnRSTrack.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnRSTrack.Parent" xml:space="preserve">
-    <value>pnlRSTrack</value>
-  </data>
-  <data name="&gt;&gt;btnRSTrack.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="pnlRSTrack.Location" type="System.Drawing.Point, System.Drawing">
-    <value>151, 88</value>
-  </data>
-  <data name="pnlRSTrack.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="pnlLSTrack.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>2, 2, 2, 2</value>
   </data>
-  <data name="pnlRSTrack.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="pnlLSTrack.Size" type="System.Drawing.Size, System.Drawing">
     <value>125, 125</value>
   </data>
-  <data name="pnlRSTrack.TabIndex" type="System.Int32, mscorlib">
-    <value>251</value>
+  <data name="pnlLSTrack.TabIndex" type="System.Int32, mscorlib">
+    <value>250</value>
   </data>
-  <data name="&gt;&gt;pnlRSTrack.Name" xml:space="preserve">
-    <value>pnlRSTrack</value>
+  <data name="&gt;&gt;pnlLSTrack.Name" xml:space="preserve">
+    <value>pnlLSTrack</value>
   </data>
-  <data name="&gt;&gt;pnlRSTrack.Type" xml:space="preserve">
+  <data name="&gt;&gt;pnlLSTrack.Type" xml:space="preserve">
     <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;pnlRSTrack.Parent" xml:space="preserve">
+  <data name="&gt;&gt;pnlLSTrack.Parent" xml:space="preserve">
     <value>lbL2TrackS</value>
   </data>
-  <data name="&gt;&gt;pnlRSTrack.ZOrder" xml:space="preserve">
-    <value>11</value>
+  <data name="&gt;&gt;pnlLSTrack.ZOrder" xml:space="preserve">
+    <value>10</value>
   </data>
   <data name="btnRSTrackS.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -2538,119 +1935,59 @@
   <data name="&gt;&gt;btnRSTrack.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="&gt;&gt;tPControls.Name" xml:space="preserve">
-    <value>tPControls</value>
+  <data name="pnlRSTrack.Location" type="System.Drawing.Point, System.Drawing">
+    <value>151, 88</value>
   </data>
-  <data name="&gt;&gt;tPControls.Type" xml:space="preserve">
+  <data name="pnlRSTrack.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 2, 2, 2</value>
+  </data>
+  <data name="pnlRSTrack.Size" type="System.Drawing.Size, System.Drawing">
+    <value>125, 125</value>
+  </data>
+  <data name="pnlRSTrack.TabIndex" type="System.Int32, mscorlib">
+    <value>251</value>
+  </data>
+  <data name="&gt;&gt;pnlRSTrack.Name" xml:space="preserve">
+    <value>pnlRSTrack</value>
+  </data>
+  <data name="&gt;&gt;pnlRSTrack.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pnlRSTrack.Parent" xml:space="preserve">
+    <value>lbL2TrackS</value>
+  </data>
+  <data name="&gt;&gt;pnlRSTrack.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
+  <data name="lbL2TrackS.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="lbL2TrackS.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="lbL2TrackS.Size" type="System.Drawing.Size, System.Drawing">
+    <value>438, 485</value>
+  </data>
+  <data name="lbL2TrackS.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="lbL2TrackS.Text" xml:space="preserve">
+    <value>Controller Readings</value>
+  </data>
+  <data name="&gt;&gt;lbL2TrackS.Name" xml:space="preserve">
+    <value>lbL2TrackS</value>
+  </data>
+  <data name="&gt;&gt;lbL2TrackS.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tPControls.Parent" xml:space="preserve">
+  <data name="&gt;&gt;lbL2TrackS.Parent" xml:space="preserve">
     <value>tCControls</value>
   </data>
-  <data name="&gt;&gt;tPControls.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;tPSpecial.Name" xml:space="preserve">
-    <value>tPSpecial</value>
-  </data>
-  <data name="&gt;&gt;tPSpecial.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tPSpecial.Parent" xml:space="preserve">
-    <value>tCControls</value>
-  </data>
-  <data name="&gt;&gt;tPSpecial.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="tCControls.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Left</value>
-  </data>
-  <data name="tCControls.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="tCControls.Size" type="System.Drawing.Size, System.Drawing">
-    <value>446, 511</value>
-  </data>
-  <data name="tCControls.TabIndex" type="System.Int32, mscorlib">
-    <value>253</value>
-  </data>
-  <data name="&gt;&gt;tCControls.Name" xml:space="preserve">
-    <value>tCControls</value>
-  </data>
-  <data name="&gt;&gt;tCControls.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tCControls.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;tCControls.ZOrder" xml:space="preserve">
-    <value>4</value>
+  <data name="&gt;&gt;lbL2TrackS.ZOrder" xml:space="preserve">
+    <value>2</value>
   </data>
   <data name="tPControls.AutoScroll" type="System.Boolean, mscorlib">
     <value>True</value>
-  </data>
-  <data name="&gt;&gt;lBControls.Name" xml:space="preserve">
-    <value>lBControls</value>
-  </data>
-  <data name="&gt;&gt;lBControls.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lBControls.Parent" xml:space="preserve">
-    <value>tPControls</value>
-  </data>
-  <data name="&gt;&gt;lBControls.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;lbControlTip.Name" xml:space="preserve">
-    <value>lbControlTip</value>
-  </data>
-  <data name="&gt;&gt;lbControlTip.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbControlTip.Parent" xml:space="preserve">
-    <value>tPControls</value>
-  </data>
-  <data name="&gt;&gt;lbControlTip.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;pnlController.Name" xml:space="preserve">
-    <value>pnlController</value>
-  </data>
-  <data name="&gt;&gt;pnlController.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;pnlController.Parent" xml:space="preserve">
-    <value>tPControls</value>
-  </data>
-  <data name="&gt;&gt;pnlController.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="tPControls.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="tPControls.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tPControls.Size" type="System.Drawing.Size, System.Drawing">
-    <value>438, 485</value>
-  </data>
-  <data name="tPControls.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="tPControls.Text" xml:space="preserve">
-    <value>Controls</value>
-  </data>
-  <data name="&gt;&gt;tPControls.Name" xml:space="preserve">
-    <value>tPControls</value>
-  </data>
-  <data name="&gt;&gt;tPControls.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tPControls.Parent" xml:space="preserve">
-    <value>tCControls</value>
-  </data>
-  <data name="&gt;&gt;tPControls.ZOrder" xml:space="preserve">
-    <value>0</value>
   </data>
   <data name="lBControls.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Bottom, Left</value>
@@ -2810,654 +2147,6 @@
   </data>
   <data name="pnlController.BackgroundImageLayout" type="System.Windows.Forms.ImageLayout, System.Windows.Forms">
     <value>Zoom</value>
-  </data>
-  <data name="&gt;&gt;pBHoveredButton.Name" xml:space="preserve">
-    <value>pBHoveredButton</value>
-  </data>
-  <data name="&gt;&gt;pBHoveredButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;pBHoveredButton.Parent" xml:space="preserve">
-    <value>pnlController</value>
-  </data>
-  <data name="&gt;&gt;pBHoveredButton.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;lbLRS.Name" xml:space="preserve">
-    <value>lbLRS</value>
-  </data>
-  <data name="&gt;&gt;lbLRS.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbLRS.Parent" xml:space="preserve">
-    <value>pnlController</value>
-  </data>
-  <data name="&gt;&gt;lbLRS.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;lbLLS.Name" xml:space="preserve">
-    <value>lbLLS</value>
-  </data>
-  <data name="&gt;&gt;lbLLS.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbLLS.Parent" xml:space="preserve">
-    <value>pnlController</value>
-  </data>
-  <data name="&gt;&gt;lbLLS.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;bnRSDown.Name" xml:space="preserve">
-    <value>bnRSDown</value>
-  </data>
-  <data name="&gt;&gt;bnRSDown.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;bnRSDown.Parent" xml:space="preserve">
-    <value>pnlController</value>
-  </data>
-  <data name="&gt;&gt;bnRSDown.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;lbLTouchUpper.Name" xml:space="preserve">
-    <value>lbLTouchUpper</value>
-  </data>
-  <data name="&gt;&gt;lbLTouchUpper.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbLTouchUpper.Parent" xml:space="preserve">
-    <value>pnlController</value>
-  </data>
-  <data name="&gt;&gt;lbLTouchUpper.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;lbLTouchRight.Name" xml:space="preserve">
-    <value>lbLTouchRight</value>
-  </data>
-  <data name="&gt;&gt;lbLTouchRight.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbLTouchRight.Parent" xml:space="preserve">
-    <value>pnlController</value>
-  </data>
-  <data name="&gt;&gt;lbLTouchRight.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;bnL3.Name" xml:space="preserve">
-    <value>bnL3</value>
-  </data>
-  <data name="&gt;&gt;bnL3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;bnL3.Parent" xml:space="preserve">
-    <value>pnlController</value>
-  </data>
-  <data name="&gt;&gt;bnL3.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;lbLTouchLM.Name" xml:space="preserve">
-    <value>lbLTouchLM</value>
-  </data>
-  <data name="&gt;&gt;lbLTouchLM.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbLTouchLM.Parent" xml:space="preserve">
-    <value>pnlController</value>
-  </data>
-  <data name="&gt;&gt;lbLTouchLM.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="&gt;&gt;bnRSUp.Name" xml:space="preserve">
-    <value>bnRSUp</value>
-  </data>
-  <data name="&gt;&gt;bnRSUp.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;bnRSUp.Parent" xml:space="preserve">
-    <value>pnlController</value>
-  </data>
-  <data name="&gt;&gt;bnRSUp.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;lbLR2.Name" xml:space="preserve">
-    <value>lbLR2</value>
-  </data>
-  <data name="&gt;&gt;lbLR2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbLR2.Parent" xml:space="preserve">
-    <value>pnlController</value>
-  </data>
-  <data name="&gt;&gt;lbLR2.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="&gt;&gt;bnRSRight.Name" xml:space="preserve">
-    <value>bnRSRight</value>
-  </data>
-  <data name="&gt;&gt;bnRSRight.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;bnRSRight.Parent" xml:space="preserve">
-    <value>pnlController</value>
-  </data>
-  <data name="&gt;&gt;bnRSRight.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="&gt;&gt;lbLL2.Name" xml:space="preserve">
-    <value>lbLL2</value>
-  </data>
-  <data name="&gt;&gt;lbLL2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbLL2.Parent" xml:space="preserve">
-    <value>pnlController</value>
-  </data>
-  <data name="&gt;&gt;lbLL2.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
-  <data name="&gt;&gt;bnR3.Name" xml:space="preserve">
-    <value>bnR3</value>
-  </data>
-  <data name="&gt;&gt;bnR3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;bnR3.Parent" xml:space="preserve">
-    <value>pnlController</value>
-  </data>
-  <data name="&gt;&gt;bnR3.ZOrder" xml:space="preserve">
-    <value>12</value>
-  </data>
-  <data name="&gt;&gt;lbLR1.Name" xml:space="preserve">
-    <value>lbLR1</value>
-  </data>
-  <data name="&gt;&gt;lbLR1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbLR1.Parent" xml:space="preserve">
-    <value>pnlController</value>
-  </data>
-  <data name="&gt;&gt;lbLR1.ZOrder" xml:space="preserve">
-    <value>13</value>
-  </data>
-  <data name="&gt;&gt;bnRSLeft.Name" xml:space="preserve">
-    <value>bnRSLeft</value>
-  </data>
-  <data name="&gt;&gt;bnRSLeft.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;bnRSLeft.Parent" xml:space="preserve">
-    <value>pnlController</value>
-  </data>
-  <data name="&gt;&gt;bnRSLeft.ZOrder" xml:space="preserve">
-    <value>14</value>
-  </data>
-  <data name="&gt;&gt;lbLL1.Name" xml:space="preserve">
-    <value>lbLL1</value>
-  </data>
-  <data name="&gt;&gt;lbLL1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbLL1.Parent" xml:space="preserve">
-    <value>pnlController</value>
-  </data>
-  <data name="&gt;&gt;lbLL1.ZOrder" xml:space="preserve">
-    <value>15</value>
-  </data>
-  <data name="&gt;&gt;bnLSLeft.Name" xml:space="preserve">
-    <value>bnLSLeft</value>
-  </data>
-  <data name="&gt;&gt;bnLSLeft.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;bnLSLeft.Parent" xml:space="preserve">
-    <value>pnlController</value>
-  </data>
-  <data name="&gt;&gt;bnLSLeft.ZOrder" xml:space="preserve">
-    <value>16</value>
-  </data>
-  <data name="&gt;&gt;lbLPS.Name" xml:space="preserve">
-    <value>lbLPS</value>
-  </data>
-  <data name="&gt;&gt;lbLPS.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbLPS.Parent" xml:space="preserve">
-    <value>pnlController</value>
-  </data>
-  <data name="&gt;&gt;lbLPS.ZOrder" xml:space="preserve">
-    <value>17</value>
-  </data>
-  <data name="&gt;&gt;bnLSUp.Name" xml:space="preserve">
-    <value>bnLSUp</value>
-  </data>
-  <data name="&gt;&gt;bnLSUp.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;bnLSUp.Parent" xml:space="preserve">
-    <value>pnlController</value>
-  </data>
-  <data name="&gt;&gt;bnLSUp.ZOrder" xml:space="preserve">
-    <value>18</value>
-  </data>
-  <data name="&gt;&gt;lbLLeft.Name" xml:space="preserve">
-    <value>lbLLeft</value>
-  </data>
-  <data name="&gt;&gt;lbLLeft.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbLLeft.Parent" xml:space="preserve">
-    <value>pnlController</value>
-  </data>
-  <data name="&gt;&gt;lbLLeft.ZOrder" xml:space="preserve">
-    <value>19</value>
-  </data>
-  <data name="&gt;&gt;bnLSRight.Name" xml:space="preserve">
-    <value>bnLSRight</value>
-  </data>
-  <data name="&gt;&gt;bnLSRight.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;bnLSRight.Parent" xml:space="preserve">
-    <value>pnlController</value>
-  </data>
-  <data name="&gt;&gt;bnLSRight.ZOrder" xml:space="preserve">
-    <value>20</value>
-  </data>
-  <data name="&gt;&gt;lbLright.Name" xml:space="preserve">
-    <value>lbLright</value>
-  </data>
-  <data name="&gt;&gt;lbLright.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbLright.Parent" xml:space="preserve">
-    <value>pnlController</value>
-  </data>
-  <data name="&gt;&gt;lbLright.ZOrder" xml:space="preserve">
-    <value>21</value>
-  </data>
-  <data name="&gt;&gt;bnLSDown.Name" xml:space="preserve">
-    <value>bnLSDown</value>
-  </data>
-  <data name="&gt;&gt;bnLSDown.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;bnLSDown.Parent" xml:space="preserve">
-    <value>pnlController</value>
-  </data>
-  <data name="&gt;&gt;bnLSDown.ZOrder" xml:space="preserve">
-    <value>22</value>
-  </data>
-  <data name="&gt;&gt;lbLDown.Name" xml:space="preserve">
-    <value>lbLDown</value>
-  </data>
-  <data name="&gt;&gt;lbLDown.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbLDown.Parent" xml:space="preserve">
-    <value>pnlController</value>
-  </data>
-  <data name="&gt;&gt;lbLDown.ZOrder" xml:space="preserve">
-    <value>23</value>
-  </data>
-  <data name="&gt;&gt;bnR2.Name" xml:space="preserve">
-    <value>bnR2</value>
-  </data>
-  <data name="&gt;&gt;bnR2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;bnR2.Parent" xml:space="preserve">
-    <value>pnlController</value>
-  </data>
-  <data name="&gt;&gt;bnR2.ZOrder" xml:space="preserve">
-    <value>24</value>
-  </data>
-  <data name="&gt;&gt;bnUp.Name" xml:space="preserve">
-    <value>bnUp</value>
-  </data>
-  <data name="&gt;&gt;bnUp.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;bnUp.Parent" xml:space="preserve">
-    <value>pnlController</value>
-  </data>
-  <data name="&gt;&gt;bnUp.ZOrder" xml:space="preserve">
-    <value>25</value>
-  </data>
-  <data name="&gt;&gt;bnDown.Name" xml:space="preserve">
-    <value>bnDown</value>
-  </data>
-  <data name="&gt;&gt;bnDown.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;bnDown.Parent" xml:space="preserve">
-    <value>pnlController</value>
-  </data>
-  <data name="&gt;&gt;bnDown.ZOrder" xml:space="preserve">
-    <value>26</value>
-  </data>
-  <data name="&gt;&gt;bnTriangle.Name" xml:space="preserve">
-    <value>bnTriangle</value>
-  </data>
-  <data name="&gt;&gt;bnTriangle.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;bnTriangle.Parent" xml:space="preserve">
-    <value>pnlController</value>
-  </data>
-  <data name="&gt;&gt;bnTriangle.ZOrder" xml:space="preserve">
-    <value>27</value>
-  </data>
-  <data name="&gt;&gt;bnR1.Name" xml:space="preserve">
-    <value>bnR1</value>
-  </data>
-  <data name="&gt;&gt;bnR1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;bnR1.Parent" xml:space="preserve">
-    <value>pnlController</value>
-  </data>
-  <data name="&gt;&gt;bnR1.ZOrder" xml:space="preserve">
-    <value>28</value>
-  </data>
-  <data name="&gt;&gt;bnSquare.Name" xml:space="preserve">
-    <value>bnSquare</value>
-  </data>
-  <data name="&gt;&gt;bnSquare.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;bnSquare.Parent" xml:space="preserve">
-    <value>pnlController</value>
-  </data>
-  <data name="&gt;&gt;bnSquare.ZOrder" xml:space="preserve">
-    <value>29</value>
-  </data>
-  <data name="&gt;&gt;bnRight.Name" xml:space="preserve">
-    <value>bnRight</value>
-  </data>
-  <data name="&gt;&gt;bnRight.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;bnRight.Parent" xml:space="preserve">
-    <value>pnlController</value>
-  </data>
-  <data name="&gt;&gt;bnRight.ZOrder" xml:space="preserve">
-    <value>30</value>
-  </data>
-  <data name="&gt;&gt;lbLUp.Name" xml:space="preserve">
-    <value>lbLUp</value>
-  </data>
-  <data name="&gt;&gt;lbLUp.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbLUp.Parent" xml:space="preserve">
-    <value>pnlController</value>
-  </data>
-  <data name="&gt;&gt;lbLUp.ZOrder" xml:space="preserve">
-    <value>31</value>
-  </data>
-  <data name="&gt;&gt;bnLeft.Name" xml:space="preserve">
-    <value>bnLeft</value>
-  </data>
-  <data name="&gt;&gt;bnLeft.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;bnLeft.Parent" xml:space="preserve">
-    <value>pnlController</value>
-  </data>
-  <data name="&gt;&gt;bnLeft.ZOrder" xml:space="preserve">
-    <value>32</value>
-  </data>
-  <data name="&gt;&gt;lbLShare.Name" xml:space="preserve">
-    <value>lbLShare</value>
-  </data>
-  <data name="&gt;&gt;lbLShare.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbLShare.Parent" xml:space="preserve">
-    <value>pnlController</value>
-  </data>
-  <data name="&gt;&gt;lbLShare.ZOrder" xml:space="preserve">
-    <value>33</value>
-  </data>
-  <data name="&gt;&gt;bnOptions.Name" xml:space="preserve">
-    <value>bnOptions</value>
-  </data>
-  <data name="&gt;&gt;bnOptions.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;bnOptions.Parent" xml:space="preserve">
-    <value>pnlController</value>
-  </data>
-  <data name="&gt;&gt;bnOptions.ZOrder" xml:space="preserve">
-    <value>34</value>
-  </data>
-  <data name="&gt;&gt;bnShare.Name" xml:space="preserve">
-    <value>bnShare</value>
-  </data>
-  <data name="&gt;&gt;bnShare.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;bnShare.Parent" xml:space="preserve">
-    <value>pnlController</value>
-  </data>
-  <data name="&gt;&gt;bnShare.ZOrder" xml:space="preserve">
-    <value>35</value>
-  </data>
-  <data name="&gt;&gt;lbLOptions.Name" xml:space="preserve">
-    <value>lbLOptions</value>
-  </data>
-  <data name="&gt;&gt;lbLOptions.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbLOptions.Parent" xml:space="preserve">
-    <value>pnlController</value>
-  </data>
-  <data name="&gt;&gt;lbLOptions.ZOrder" xml:space="preserve">
-    <value>36</value>
-  </data>
-  <data name="&gt;&gt;bnL1.Name" xml:space="preserve">
-    <value>bnL1</value>
-  </data>
-  <data name="&gt;&gt;bnL1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;bnL1.Parent" xml:space="preserve">
-    <value>pnlController</value>
-  </data>
-  <data name="&gt;&gt;bnL1.ZOrder" xml:space="preserve">
-    <value>37</value>
-  </data>
-  <data name="&gt;&gt;bnTouchRight.Name" xml:space="preserve">
-    <value>bnTouchRight</value>
-  </data>
-  <data name="&gt;&gt;bnTouchRight.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;bnTouchRight.Parent" xml:space="preserve">
-    <value>pnlController</value>
-  </data>
-  <data name="&gt;&gt;bnTouchRight.ZOrder" xml:space="preserve">
-    <value>38</value>
-  </data>
-  <data name="&gt;&gt;bnL2.Name" xml:space="preserve">
-    <value>bnL2</value>
-  </data>
-  <data name="&gt;&gt;bnL2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;bnL2.Parent" xml:space="preserve">
-    <value>pnlController</value>
-  </data>
-  <data name="&gt;&gt;bnL2.ZOrder" xml:space="preserve">
-    <value>39</value>
-  </data>
-  <data name="&gt;&gt;lbLTriangle.Name" xml:space="preserve">
-    <value>lbLTriangle</value>
-  </data>
-  <data name="&gt;&gt;lbLTriangle.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbLTriangle.Parent" xml:space="preserve">
-    <value>pnlController</value>
-  </data>
-  <data name="&gt;&gt;lbLTriangle.ZOrder" xml:space="preserve">
-    <value>40</value>
-  </data>
-  <data name="&gt;&gt;bnTouchLeft.Name" xml:space="preserve">
-    <value>bnTouchLeft</value>
-  </data>
-  <data name="&gt;&gt;bnTouchLeft.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;bnTouchLeft.Parent" xml:space="preserve">
-    <value>pnlController</value>
-  </data>
-  <data name="&gt;&gt;bnTouchLeft.ZOrder" xml:space="preserve">
-    <value>41</value>
-  </data>
-  <data name="&gt;&gt;lbLSquare.Name" xml:space="preserve">
-    <value>lbLSquare</value>
-  </data>
-  <data name="&gt;&gt;lbLSquare.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbLSquare.Parent" xml:space="preserve">
-    <value>pnlController</value>
-  </data>
-  <data name="&gt;&gt;lbLSquare.ZOrder" xml:space="preserve">
-    <value>42</value>
-  </data>
-  <data name="&gt;&gt;bnTouchMulti.Name" xml:space="preserve">
-    <value>bnTouchMulti</value>
-  </data>
-  <data name="&gt;&gt;bnTouchMulti.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;bnTouchMulti.Parent" xml:space="preserve">
-    <value>pnlController</value>
-  </data>
-  <data name="&gt;&gt;bnTouchMulti.ZOrder" xml:space="preserve">
-    <value>43</value>
-  </data>
-  <data name="&gt;&gt;lbLCircle.Name" xml:space="preserve">
-    <value>lbLCircle</value>
-  </data>
-  <data name="&gt;&gt;lbLCircle.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbLCircle.Parent" xml:space="preserve">
-    <value>pnlController</value>
-  </data>
-  <data name="&gt;&gt;lbLCircle.ZOrder" xml:space="preserve">
-    <value>44</value>
-  </data>
-  <data name="&gt;&gt;lbLCross.Name" xml:space="preserve">
-    <value>lbLCross</value>
-  </data>
-  <data name="&gt;&gt;lbLCross.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbLCross.Parent" xml:space="preserve">
-    <value>pnlController</value>
-  </data>
-  <data name="&gt;&gt;lbLCross.ZOrder" xml:space="preserve">
-    <value>45</value>
-  </data>
-  <data name="&gt;&gt;bnTouchUpper.Name" xml:space="preserve">
-    <value>bnTouchUpper</value>
-  </data>
-  <data name="&gt;&gt;bnTouchUpper.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;bnTouchUpper.Parent" xml:space="preserve">
-    <value>pnlController</value>
-  </data>
-  <data name="&gt;&gt;bnTouchUpper.ZOrder" xml:space="preserve">
-    <value>46</value>
-  </data>
-  <data name="&gt;&gt;btnLightbar.Name" xml:space="preserve">
-    <value>btnLightbar</value>
-  </data>
-  <data name="&gt;&gt;btnLightbar.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnLightbar.Parent" xml:space="preserve">
-    <value>pnlController</value>
-  </data>
-  <data name="&gt;&gt;btnLightbar.ZOrder" xml:space="preserve">
-    <value>47</value>
-  </data>
-  <data name="&gt;&gt;bnPS.Name" xml:space="preserve">
-    <value>bnPS</value>
-  </data>
-  <data name="&gt;&gt;bnPS.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;bnPS.Parent" xml:space="preserve">
-    <value>pnlController</value>
-  </data>
-  <data name="&gt;&gt;bnPS.ZOrder" xml:space="preserve">
-    <value>48</value>
-  </data>
-  <data name="&gt;&gt;bnCross.Name" xml:space="preserve">
-    <value>bnCross</value>
-  </data>
-  <data name="&gt;&gt;bnCross.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;bnCross.Parent" xml:space="preserve">
-    <value>pnlController</value>
-  </data>
-  <data name="&gt;&gt;bnCross.ZOrder" xml:space="preserve">
-    <value>49</value>
-  </data>
-  <data name="&gt;&gt;bnCircle.Name" xml:space="preserve">
-    <value>bnCircle</value>
-  </data>
-  <data name="&gt;&gt;bnCircle.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;bnCircle.Parent" xml:space="preserve">
-    <value>pnlController</value>
-  </data>
-  <data name="&gt;&gt;bnCircle.ZOrder" xml:space="preserve">
-    <value>50</value>
-  </data>
-  <data name="&gt;&gt;lbControlName.Name" xml:space="preserve">
-    <value>lbControlName</value>
-  </data>
-  <data name="&gt;&gt;lbControlName.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbControlName.Parent" xml:space="preserve">
-    <value>pnlController</value>
-  </data>
-  <data name="&gt;&gt;lbControlName.ZOrder" xml:space="preserve">
-    <value>51</value>
-  </data>
-  <data name="pnlController.Location" type="System.Drawing.Point, System.Drawing">
-    <value>2, 2</value>
-  </data>
-  <data name="pnlController.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>2, 2, 2, 2</value>
-  </data>
-  <data name="pnlController.Size" type="System.Drawing.Size, System.Drawing">
-    <value>422, 230</value>
-  </data>
-  <data name="pnlController.TabIndex" type="System.Int32, mscorlib">
-    <value>282</value>
-  </data>
-  <data name="&gt;&gt;pnlController.Name" xml:space="preserve">
-    <value>pnlController</value>
-  </data>
-  <data name="&gt;&gt;pnlController.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;pnlController.Parent" xml:space="preserve">
-    <value>tPControls</value>
-  </data>
-  <data name="&gt;&gt;pnlController.ZOrder" xml:space="preserve">
-    <value>3</value>
   </data>
   <data name="pBHoveredButton.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -5109,89 +3798,74 @@
   <data name="&gt;&gt;lbControlName.ZOrder" xml:space="preserve">
     <value>51</value>
   </data>
-  <data name="&gt;&gt;pnlActions.Name" xml:space="preserve">
-    <value>pnlActions</value>
+  <data name="pnlController.Location" type="System.Drawing.Point, System.Drawing">
+    <value>2, 2</value>
   </data>
-  <data name="&gt;&gt;pnlActions.Type" xml:space="preserve">
+  <data name="pnlController.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 2, 2, 2</value>
+  </data>
+  <data name="pnlController.Size" type="System.Drawing.Size, System.Drawing">
+    <value>422, 230</value>
+  </data>
+  <data name="pnlController.TabIndex" type="System.Int32, mscorlib">
+    <value>282</value>
+  </data>
+  <data name="&gt;&gt;pnlController.Name" xml:space="preserve">
+    <value>pnlController</value>
+  </data>
+  <data name="&gt;&gt;pnlController.Type" xml:space="preserve">
     <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;pnlActions.Parent" xml:space="preserve">
-    <value>tPSpecial</value>
+  <data name="&gt;&gt;pnlController.Parent" xml:space="preserve">
+    <value>tPControls</value>
   </data>
-  <data name="&gt;&gt;pnlActions.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="tPSpecial.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="tPSpecial.Size" type="System.Drawing.Size, System.Drawing">
-    <value>438, 485</value>
-  </data>
-  <data name="tPSpecial.TabIndex" type="System.Int32, mscorlib">
+  <data name="&gt;&gt;pnlController.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
-  <data name="tPSpecial.Text" xml:space="preserve">
-    <value>Special Actions</value>
+  <data name="tPControls.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
   </data>
-  <data name="&gt;&gt;tPSpecial.Name" xml:space="preserve">
-    <value>tPSpecial</value>
+  <data name="tPControls.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
   </data>
-  <data name="&gt;&gt;tPSpecial.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tPSpecial.Parent" xml:space="preserve">
-    <value>tCControls</value>
-  </data>
-  <data name="&gt;&gt;tPSpecial.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;lVActions.Name" xml:space="preserve">
-    <value>lVActions</value>
-  </data>
-  <data name="&gt;&gt;lVActions.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ListView, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lVActions.Parent" xml:space="preserve">
-    <value>pnlActions</value>
-  </data>
-  <data name="&gt;&gt;lVActions.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;panel2.Name" xml:space="preserve">
-    <value>panel2</value>
-  </data>
-  <data name="&gt;&gt;panel2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;panel2.Parent" xml:space="preserve">
-    <value>pnlActions</value>
-  </data>
-  <data name="&gt;&gt;panel2.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="pnlActions.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="pnlActions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="pnlActions.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="tPControls.Size" type="System.Drawing.Size, System.Drawing">
     <value>438, 485</value>
   </data>
-  <data name="pnlActions.TabIndex" type="System.Int32, mscorlib">
-    <value>15</value>
-  </data>
-  <data name="&gt;&gt;pnlActions.Name" xml:space="preserve">
-    <value>pnlActions</value>
-  </data>
-  <data name="&gt;&gt;pnlActions.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;pnlActions.Parent" xml:space="preserve">
-    <value>tPSpecial</value>
-  </data>
-  <data name="&gt;&gt;pnlActions.ZOrder" xml:space="preserve">
+  <data name="tPControls.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
+  </data>
+  <data name="tPControls.Text" xml:space="preserve">
+    <value>Controls</value>
+  </data>
+  <data name="&gt;&gt;tPControls.Name" xml:space="preserve">
+    <value>tPControls</value>
+  </data>
+  <data name="&gt;&gt;tPControls.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tPControls.Parent" xml:space="preserve">
+    <value>tCControls</value>
+  </data>
+  <data name="&gt;&gt;tPControls.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="cHName.Text" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="cHName.Width" type="System.Int32, mscorlib">
+    <value>140</value>
+  </data>
+  <data name="cHTrigger.Text" xml:space="preserve">
+    <value>Trigger</value>
+  </data>
+  <data name="cHTrigger.Width" type="System.Int32, mscorlib">
+    <value>105</value>
+  </data>
+  <data name="cHAction.Text" xml:space="preserve">
+    <value>Action</value>
+  </data>
+  <data name="cHAction.Width" type="System.Int32, mscorlib">
+    <value>100</value>
   </data>
   <data name="lVActions.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -5215,135 +3889,6 @@
     <value>pnlActions</value>
   </data>
   <data name="&gt;&gt;lVActions.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="cHName.Text" xml:space="preserve">
-    <value>Name</value>
-  </data>
-  <data name="cHName.Width" type="System.Int32, mscorlib">
-    <value>140</value>
-  </data>
-  <data name="cHTrigger.Text" xml:space="preserve">
-    <value>Trigger</value>
-  </data>
-  <data name="cHTrigger.Width" type="System.Int32, mscorlib">
-    <value>105</value>
-  </data>
-  <data name="cHAction.Text" xml:space="preserve">
-    <value>Action</value>
-  </data>
-  <data name="cHAction.Width" type="System.Int32, mscorlib">
-    <value>100</value>
-  </data>
-  <data name="&gt;&gt;fLPActionButtons.Name" xml:space="preserve">
-    <value>fLPActionButtons</value>
-  </data>
-  <data name="&gt;&gt;fLPActionButtons.Type" xml:space="preserve">
-    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;fLPActionButtons.Parent" xml:space="preserve">
-    <value>panel2</value>
-  </data>
-  <data name="&gt;&gt;fLPActionButtons.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;lbActionsTip.Name" xml:space="preserve">
-    <value>lbActionsTip</value>
-  </data>
-  <data name="&gt;&gt;lbActionsTip.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbActionsTip.Parent" xml:space="preserve">
-    <value>panel2</value>
-  </data>
-  <data name="&gt;&gt;lbActionsTip.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="panel2.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="panel2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="panel2.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>2, 2, 2, 2</value>
-  </data>
-  <data name="panel2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>438, 66</value>
-  </data>
-  <data name="panel2.TabIndex" type="System.Int32, mscorlib">
-    <value>16</value>
-  </data>
-  <data name="&gt;&gt;panel2.Name" xml:space="preserve">
-    <value>panel2</value>
-  </data>
-  <data name="&gt;&gt;panel2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;panel2.Parent" xml:space="preserve">
-    <value>pnlActions</value>
-  </data>
-  <data name="&gt;&gt;panel2.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;btnNewAction.Name" xml:space="preserve">
-    <value>btnNewAction</value>
-  </data>
-  <data name="&gt;&gt;btnNewAction.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnNewAction.Parent" xml:space="preserve">
-    <value>fLPActionButtons</value>
-  </data>
-  <data name="&gt;&gt;btnNewAction.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;btnEditAction.Name" xml:space="preserve">
-    <value>btnEditAction</value>
-  </data>
-  <data name="&gt;&gt;btnEditAction.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnEditAction.Parent" xml:space="preserve">
-    <value>fLPActionButtons</value>
-  </data>
-  <data name="&gt;&gt;btnEditAction.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;btnRemAction.Name" xml:space="preserve">
-    <value>btnRemAction</value>
-  </data>
-  <data name="&gt;&gt;btnRemAction.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnRemAction.Parent" xml:space="preserve">
-    <value>fLPActionButtons</value>
-  </data>
-  <data name="&gt;&gt;btnRemAction.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="fLPActionButtons.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="fLPActionButtons.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 28</value>
-  </data>
-  <data name="fLPActionButtons.Size" type="System.Drawing.Size, System.Drawing">
-    <value>438, 38</value>
-  </data>
-  <data name="fLPActionButtons.TabIndex" type="System.Int32, mscorlib">
-    <value>15</value>
-  </data>
-  <data name="&gt;&gt;fLPActionButtons.Name" xml:space="preserve">
-    <value>fLPActionButtons</value>
-  </data>
-  <data name="&gt;&gt;fLPActionButtons.Type" xml:space="preserve">
-    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;fLPActionButtons.Parent" xml:space="preserve">
-    <value>panel2</value>
-  </data>
-  <data name="&gt;&gt;fLPActionButtons.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
   <data name="btnNewAction.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
@@ -5427,6 +3972,30 @@
   <data name="&gt;&gt;btnRemAction.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
+  <data name="fLPActionButtons.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="fLPActionButtons.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 28</value>
+  </data>
+  <data name="fLPActionButtons.Size" type="System.Drawing.Size, System.Drawing">
+    <value>438, 38</value>
+  </data>
+  <data name="fLPActionButtons.TabIndex" type="System.Int32, mscorlib">
+    <value>15</value>
+  </data>
+  <data name="&gt;&gt;fLPActionButtons.Name" xml:space="preserve">
+    <value>fLPActionButtons</value>
+  </data>
+  <data name="&gt;&gt;fLPActionButtons.Type" xml:space="preserve">
+    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;fLPActionButtons.Parent" xml:space="preserve">
+    <value>panel2</value>
+  </data>
+  <data name="&gt;&gt;fLPActionButtons.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <data name="lbActionsTip.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Top</value>
   </data>
@@ -5460,18 +4029,108 @@
   <data name="&gt;&gt;lbActionsTip.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
+  <data name="panel2.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="panel2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="panel2.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 2, 2, 2</value>
+  </data>
+  <data name="panel2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>438, 66</value>
+  </data>
+  <data name="panel2.TabIndex" type="System.Int32, mscorlib">
+    <value>16</value>
+  </data>
+  <data name="&gt;&gt;panel2.Name" xml:space="preserve">
+    <value>panel2</value>
+  </data>
+  <data name="&gt;&gt;panel2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;panel2.Parent" xml:space="preserve">
+    <value>pnlActions</value>
+  </data>
+  <data name="&gt;&gt;panel2.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="pnlActions.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="pnlActions.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="pnlActions.Size" type="System.Drawing.Size, System.Drawing">
+    <value>438, 485</value>
+  </data>
+  <data name="pnlActions.TabIndex" type="System.Int32, mscorlib">
+    <value>15</value>
+  </data>
+  <data name="&gt;&gt;pnlActions.Name" xml:space="preserve">
+    <value>pnlActions</value>
+  </data>
+  <data name="&gt;&gt;pnlActions.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pnlActions.Parent" xml:space="preserve">
+    <value>tPSpecial</value>
+  </data>
+  <data name="&gt;&gt;pnlActions.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="tPSpecial.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tPSpecial.Size" type="System.Drawing.Size, System.Drawing">
+    <value>438, 485</value>
+  </data>
+  <data name="tPSpecial.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="tPSpecial.Text" xml:space="preserve">
+    <value>Special Actions</value>
+  </data>
+  <data name="&gt;&gt;tPSpecial.Name" xml:space="preserve">
+    <value>tPSpecial</value>
+  </data>
+  <data name="&gt;&gt;tPSpecial.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tPSpecial.Parent" xml:space="preserve">
+    <value>tCControls</value>
+  </data>
+  <data name="&gt;&gt;tPSpecial.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="tCControls.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="tCControls.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="tCControls.Size" type="System.Drawing.Size, System.Drawing">
+    <value>446, 511</value>
+  </data>
+  <data name="tCControls.TabIndex" type="System.Int32, mscorlib">
+    <value>253</value>
+  </data>
+  <data name="&gt;&gt;tCControls.Name" xml:space="preserve">
+    <value>tCControls</value>
+  </data>
+  <data name="&gt;&gt;tCControls.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tCControls.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;tCControls.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
   <metadata name="cMGyroTriggers.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>482, 17</value>
   </metadata>
-  <data name="cMGyroTriggers.Size" type="System.Drawing.Size, System.Drawing">
-    <value>195, 444</value>
-  </data>
-  <data name="&gt;&gt;cMGyroTriggers.Name" xml:space="preserve">
-    <value>cMGyroTriggers</value>
-  </data>
-  <data name="&gt;&gt;cMGyroTriggers.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
   <data name="crossToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>194, 22</value>
   </data>
@@ -5592,18 +4251,18 @@
   <data name="alwaysOnToolStripMenuItem.Text" xml:space="preserve">
     <value>Always on</value>
   </data>
+  <data name="cMGyroTriggers.Size" type="System.Drawing.Size, System.Drawing">
+    <value>195, 444</value>
+  </data>
+  <data name="&gt;&gt;cMGyroTriggers.Name" xml:space="preserve">
+    <value>cMGyroTriggers</value>
+  </data>
+  <data name="&gt;&gt;cMGyroTriggers.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <metadata name="cMTouchDisableInvert.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>625, 18</value>
   </metadata>
-  <data name="cMTouchDisableInvert.Size" type="System.Drawing.Size, System.Drawing">
-    <value>195, 422</value>
-  </data>
-  <data name="&gt;&gt;cMTouchDisableInvert.Name" xml:space="preserve">
-    <value>cMTouchDisableInvert</value>
-  </data>
-  <data name="&gt;&gt;cMTouchDisableInvert.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
   <data name="crossTouchInvStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>194, 22</value>
   </data>
@@ -5718,8 +4377,227 @@
   <data name="psTouchInvStripMenuItem.Text" xml:space="preserve">
     <value>PS</value>
   </data>
+  <data name="cMTouchDisableInvert.Size" type="System.Drawing.Size, System.Drawing">
+    <value>195, 422</value>
+  </data>
+  <data name="&gt;&gt;cMTouchDisableInvert.Name" xml:space="preserve">
+    <value>cMTouchDisableInvert</value>
+  </data>
+  <data name="&gt;&gt;cMTouchDisableInvert.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="flowLayoutPanel1.AutoScroll" type="System.Boolean, mscorlib">
     <value>True</value>
+  </data>
+  <data name="lbFull.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lbFull.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lbFull.Location" type="System.Drawing.Point, System.Drawing">
+    <value>7, 7</value>
+  </data>
+  <data name="lbFull.Size" type="System.Drawing.Size, System.Drawing">
+    <value>26, 13</value>
+  </data>
+  <data name="lbFull.TabIndex" type="System.Int32, mscorlib">
+    <value>225</value>
+  </data>
+  <data name="lbFull.Text" xml:space="preserve">
+    <value>Full:</value>
+  </data>
+  <data name="&gt;&gt;lbFull.Name" xml:space="preserve">
+    <value>lbFull</value>
+  </data>
+  <data name="&gt;&gt;lbFull.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lbFull.Parent" xml:space="preserve">
+    <value>pnlFull</value>
+  </data>
+  <data name="&gt;&gt;lbFull.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="lbRed.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lbRed.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lbRed.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 27</value>
+  </data>
+  <data name="lbRed.Size" type="System.Drawing.Size, System.Drawing">
+    <value>15, 13</value>
+  </data>
+  <data name="lbRed.TabIndex" type="System.Int32, mscorlib">
+    <value>158</value>
+  </data>
+  <data name="lbRed.Text" xml:space="preserve">
+    <value>R</value>
+  </data>
+  <data name="&gt;&gt;lbRed.Name" xml:space="preserve">
+    <value>lbRed</value>
+  </data>
+  <data name="&gt;&gt;lbRed.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lbRed.Parent" xml:space="preserve">
+    <value>pnlFull</value>
+  </data>
+  <data name="&gt;&gt;lbRed.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="lbGreen.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lbGreen.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lbGreen.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 53</value>
+  </data>
+  <data name="lbGreen.Size" type="System.Drawing.Size, System.Drawing">
+    <value>15, 13</value>
+  </data>
+  <data name="lbGreen.TabIndex" type="System.Int32, mscorlib">
+    <value>159</value>
+  </data>
+  <data name="lbGreen.Text" xml:space="preserve">
+    <value>G</value>
+  </data>
+  <data name="&gt;&gt;lbGreen.Name" xml:space="preserve">
+    <value>lbGreen</value>
+  </data>
+  <data name="&gt;&gt;lbGreen.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lbGreen.Parent" xml:space="preserve">
+    <value>pnlFull</value>
+  </data>
+  <data name="&gt;&gt;lbGreen.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="lbBlue.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lbBlue.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lbBlue.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 76</value>
+  </data>
+  <data name="lbBlue.Size" type="System.Drawing.Size, System.Drawing">
+    <value>14, 13</value>
+  </data>
+  <data name="lbBlue.TabIndex" type="System.Int32, mscorlib">
+    <value>160</value>
+  </data>
+  <data name="lbBlue.Text" xml:space="preserve">
+    <value>B</value>
+  </data>
+  <data name="&gt;&gt;lbBlue.Name" xml:space="preserve">
+    <value>lbBlue</value>
+  </data>
+  <data name="&gt;&gt;lbBlue.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lbBlue.Parent" xml:space="preserve">
+    <value>pnlFull</value>
+  </data>
+  <data name="&gt;&gt;lbBlue.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="tBRedBar.AutoSize" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="tBRedBar.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="tBRedBar.Location" type="System.Drawing.Point, System.Drawing">
+    <value>26, 24</value>
+  </data>
+  <data name="tBRedBar.Size" type="System.Drawing.Size, System.Drawing">
+    <value>100, 20</value>
+  </data>
+  <data name="tBRedBar.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="&gt;&gt;tBRedBar.Name" xml:space="preserve">
+    <value>tBRedBar</value>
+  </data>
+  <data name="&gt;&gt;tBRedBar.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TrackBar, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tBRedBar.Parent" xml:space="preserve">
+    <value>pnlFull</value>
+  </data>
+  <data name="&gt;&gt;tBRedBar.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="tBGreenBar.AutoSize" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="tBGreenBar.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="tBGreenBar.Location" type="System.Drawing.Point, System.Drawing">
+    <value>26, 50</value>
+  </data>
+  <data name="tBGreenBar.Size" type="System.Drawing.Size, System.Drawing">
+    <value>100, 20</value>
+  </data>
+  <data name="tBGreenBar.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
+  </data>
+  <data name="&gt;&gt;tBGreenBar.Name" xml:space="preserve">
+    <value>tBGreenBar</value>
+  </data>
+  <data name="&gt;&gt;tBGreenBar.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TrackBar, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tBGreenBar.Parent" xml:space="preserve">
+    <value>pnlFull</value>
+  </data>
+  <data name="&gt;&gt;tBGreenBar.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="tBBlueBar.AutoSize" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="tBBlueBar.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="tBBlueBar.Location" type="System.Drawing.Point, System.Drawing">
+    <value>26, 73</value>
+  </data>
+  <data name="tBBlueBar.Size" type="System.Drawing.Size, System.Drawing">
+    <value>100, 20</value>
+  </data>
+  <data name="tBBlueBar.TabIndex" type="System.Int32, mscorlib">
+    <value>12</value>
+  </data>
+  <data name="&gt;&gt;tBBlueBar.Name" xml:space="preserve">
+    <value>tBBlueBar</value>
+  </data>
+  <data name="&gt;&gt;tBBlueBar.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TrackBar, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tBBlueBar.Parent" xml:space="preserve">
+    <value>pnlFull</value>
+  </data>
+  <data name="&gt;&gt;tBBlueBar.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="pnlFull.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 1</value>
+  </data>
+  <data name="pnlFull.Size" type="System.Drawing.Size, System.Drawing">
+    <value>134, 96</value>
+  </data>
+  <data name="pnlFull.TabIndex" type="System.Int32, mscorlib">
+    <value>239</value>
   </data>
   <data name="&gt;&gt;pnlFull.Name" xml:space="preserve">
     <value>pnlFull</value>
@@ -5732,6 +4610,243 @@
   </data>
   <data name="&gt;&gt;pnlFull.ZOrder" xml:space="preserve">
     <value>0</value>
+  </data>
+  <data name="lowColorChooserButton.FlatStyle" type="System.Windows.Forms.FlatStyle, System.Windows.Forms">
+    <value>Flat</value>
+  </data>
+  <data name="lowColorChooserButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lowColorChooserButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>44, 9</value>
+  </data>
+  <data name="lowColorChooserButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>13, 13</value>
+  </data>
+  <data name="lowColorChooserButton.TabIndex" type="System.Int32, mscorlib">
+    <value>49</value>
+  </data>
+  <data name="&gt;&gt;lowColorChooserButton.Name" xml:space="preserve">
+    <value>lowColorChooserButton</value>
+  </data>
+  <data name="&gt;&gt;lowColorChooserButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lowColorChooserButton.Parent" xml:space="preserve">
+    <value>pnlLowBattery</value>
+  </data>
+  <data name="&gt;&gt;lowColorChooserButton.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="lbLowRed.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lbLowRed.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lbLowRed.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 30</value>
+  </data>
+  <data name="lbLowRed.Size" type="System.Drawing.Size, System.Drawing">
+    <value>15, 13</value>
+  </data>
+  <data name="lbLowRed.TabIndex" type="System.Int32, mscorlib">
+    <value>158</value>
+  </data>
+  <data name="lbLowRed.Text" xml:space="preserve">
+    <value>R</value>
+  </data>
+  <data name="&gt;&gt;lbLowRed.Name" xml:space="preserve">
+    <value>lbLowRed</value>
+  </data>
+  <data name="&gt;&gt;lbLowRed.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lbLowRed.Parent" xml:space="preserve">
+    <value>pnlLowBattery</value>
+  </data>
+  <data name="&gt;&gt;lbLowRed.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="lbLowGreen.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lbLowGreen.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lbLowGreen.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 53</value>
+  </data>
+  <data name="lbLowGreen.Size" type="System.Drawing.Size, System.Drawing">
+    <value>15, 13</value>
+  </data>
+  <data name="lbLowGreen.TabIndex" type="System.Int32, mscorlib">
+    <value>159</value>
+  </data>
+  <data name="lbLowGreen.Text" xml:space="preserve">
+    <value>G</value>
+  </data>
+  <data name="&gt;&gt;lbLowGreen.Name" xml:space="preserve">
+    <value>lbLowGreen</value>
+  </data>
+  <data name="&gt;&gt;lbLowGreen.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lbLowGreen.Parent" xml:space="preserve">
+    <value>pnlLowBattery</value>
+  </data>
+  <data name="&gt;&gt;lbLowGreen.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="lbLowBlue.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lbLowBlue.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lbLowBlue.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 76</value>
+  </data>
+  <data name="lbLowBlue.Size" type="System.Drawing.Size, System.Drawing">
+    <value>14, 13</value>
+  </data>
+  <data name="lbLowBlue.TabIndex" type="System.Int32, mscorlib">
+    <value>160</value>
+  </data>
+  <data name="lbLowBlue.Text" xml:space="preserve">
+    <value>B</value>
+  </data>
+  <data name="&gt;&gt;lbLowBlue.Name" xml:space="preserve">
+    <value>lbLowBlue</value>
+  </data>
+  <data name="&gt;&gt;lbLowBlue.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lbLowBlue.Parent" xml:space="preserve">
+    <value>pnlLowBattery</value>
+  </data>
+  <data name="&gt;&gt;lbLowBlue.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="tBLowRedBar.AutoSize" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="tBLowRedBar.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="tBLowRedBar.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 26</value>
+  </data>
+  <data name="tBLowRedBar.Size" type="System.Drawing.Size, System.Drawing">
+    <value>100, 20</value>
+  </data>
+  <data name="tBLowRedBar.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="&gt;&gt;tBLowRedBar.Name" xml:space="preserve">
+    <value>tBLowRedBar</value>
+  </data>
+  <data name="&gt;&gt;tBLowRedBar.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TrackBar, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tBLowRedBar.Parent" xml:space="preserve">
+    <value>pnlLowBattery</value>
+  </data>
+  <data name="&gt;&gt;tBLowRedBar.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="tBLowGreenBar.AutoSize" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="tBLowGreenBar.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="tBLowGreenBar.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 49</value>
+  </data>
+  <data name="tBLowGreenBar.Size" type="System.Drawing.Size, System.Drawing">
+    <value>100, 20</value>
+  </data>
+  <data name="tBLowGreenBar.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
+  </data>
+  <data name="&gt;&gt;tBLowGreenBar.Name" xml:space="preserve">
+    <value>tBLowGreenBar</value>
+  </data>
+  <data name="&gt;&gt;tBLowGreenBar.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TrackBar, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tBLowGreenBar.Parent" xml:space="preserve">
+    <value>pnlLowBattery</value>
+  </data>
+  <data name="&gt;&gt;tBLowGreenBar.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="tBLowBlueBar.AutoSize" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="tBLowBlueBar.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="tBLowBlueBar.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 72</value>
+  </data>
+  <data name="tBLowBlueBar.Size" type="System.Drawing.Size, System.Drawing">
+    <value>100, 20</value>
+  </data>
+  <data name="tBLowBlueBar.TabIndex" type="System.Int32, mscorlib">
+    <value>12</value>
+  </data>
+  <data name="&gt;&gt;tBLowBlueBar.Name" xml:space="preserve">
+    <value>tBLowBlueBar</value>
+  </data>
+  <data name="&gt;&gt;tBLowBlueBar.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TrackBar, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tBLowBlueBar.Parent" xml:space="preserve">
+    <value>pnlLowBattery</value>
+  </data>
+  <data name="&gt;&gt;tBLowBlueBar.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="lbEmpty.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lbEmpty.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lbEmpty.Location" type="System.Drawing.Point, System.Drawing">
+    <value>7, 9</value>
+  </data>
+  <data name="lbEmpty.Size" type="System.Drawing.Size, System.Drawing">
+    <value>39, 13</value>
+  </data>
+  <data name="lbEmpty.TabIndex" type="System.Int32, mscorlib">
+    <value>225</value>
+  </data>
+  <data name="lbEmpty.Text" xml:space="preserve">
+    <value>Empty:</value>
+  </data>
+  <data name="&gt;&gt;lbEmpty.Name" xml:space="preserve">
+    <value>lbEmpty</value>
+  </data>
+  <data name="&gt;&gt;lbEmpty.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lbEmpty.Parent" xml:space="preserve">
+    <value>pnlLowBattery</value>
+  </data>
+  <data name="&gt;&gt;lbEmpty.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="pnlLowBattery.Location" type="System.Drawing.Point, System.Drawing">
+    <value>160, 0</value>
+  </data>
+  <data name="pnlLowBattery.Size" type="System.Drawing.Size, System.Drawing">
+    <value>126, 97</value>
+  </data>
+  <data name="pnlLowBattery.TabIndex" type="System.Int32, mscorlib">
+    <value>238</value>
   </data>
   <data name="&gt;&gt;pnlLowBattery.Name" xml:space="preserve">
     <value>pnlLowBattery</value>
@@ -5766,6 +4881,21 @@
   <data name="&gt;&gt;panel1.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
+  <data name="cBFlashType.Items" xml:space="preserve">
+    <value>Flash at</value>
+  </data>
+  <data name="cBFlashType.Items1" xml:space="preserve">
+    <value>Pulse at</value>
+  </data>
+  <data name="cBFlashType.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 10</value>
+  </data>
+  <data name="cBFlashType.Size" type="System.Drawing.Size, System.Drawing">
+    <value>68, 21</value>
+  </data>
+  <data name="cBFlashType.TabIndex" type="System.Int32, mscorlib">
+    <value>244</value>
+  </data>
   <data name="&gt;&gt;cBFlashType.Name" xml:space="preserve">
     <value>cBFlashType</value>
   </data>
@@ -5777,6 +4907,24 @@
   </data>
   <data name="&gt;&gt;cBFlashType.ZOrder" xml:space="preserve">
     <value>0</value>
+  </data>
+  <data name="btnFlashColor.BackgroundImageLayout" type="System.Windows.Forms.ImageLayout, System.Windows.Forms">
+    <value>Zoom</value>
+  </data>
+  <data name="btnFlashColor.FlatStyle" type="System.Windows.Forms.FlatStyle, System.Windows.Forms">
+    <value>Flat</value>
+  </data>
+  <data name="btnFlashColor.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="btnFlashColor.Location" type="System.Drawing.Point, System.Drawing">
+    <value>152, 14</value>
+  </data>
+  <data name="btnFlashColor.Size" type="System.Drawing.Size, System.Drawing">
+    <value>13, 13</value>
+  </data>
+  <data name="btnFlashColor.TabIndex" type="System.Int32, mscorlib">
+    <value>241</value>
   </data>
   <data name="&gt;&gt;btnFlashColor.Name" xml:space="preserve">
     <value>btnFlashColor</value>
@@ -5790,6 +4938,24 @@
   <data name="&gt;&gt;btnFlashColor.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
+  <data name="lbPercentFlashBar.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lbPercentFlashBar.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lbPercentFlashBar.Location" type="System.Drawing.Point, System.Drawing">
+    <value>133, 14</value>
+  </data>
+  <data name="lbPercentFlashBar.Size" type="System.Drawing.Size, System.Drawing">
+    <value>15, 13</value>
+  </data>
+  <data name="lbPercentFlashBar.TabIndex" type="System.Int32, mscorlib">
+    <value>243</value>
+  </data>
+  <data name="lbPercentFlashBar.Text" xml:space="preserve">
+    <value>%</value>
+  </data>
   <data name="&gt;&gt;lbPercentFlashBar.Name" xml:space="preserve">
     <value>lbPercentFlashBar</value>
   </data>
@@ -5801,6 +4967,15 @@
   </data>
   <data name="&gt;&gt;lbPercentFlashBar.ZOrder" xml:space="preserve">
     <value>2</value>
+  </data>
+  <data name="nUDflashLED.Location" type="System.Drawing.Point, System.Drawing">
+    <value>84, 11</value>
+  </data>
+  <data name="nUDflashLED.Size" type="System.Drawing.Size, System.Drawing">
+    <value>43, 20</value>
+  </data>
+  <data name="nUDflashLED.TabIndex" type="System.Int32, mscorlib">
+    <value>242</value>
   </data>
   <data name="&gt;&gt;nUDflashLED.Name" xml:space="preserve">
     <value>nUDflashLED</value>
@@ -5835,6 +5010,27 @@
   <data name="&gt;&gt;panel3.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
+  <data name="cBWhileCharging.Items" xml:space="preserve">
+    <value>Normal</value>
+  </data>
+  <data name="cBWhileCharging.Items1" xml:space="preserve">
+    <value>Pulse</value>
+  </data>
+  <data name="cBWhileCharging.Items2" xml:space="preserve">
+    <value>Rainbow</value>
+  </data>
+  <data name="cBWhileCharging.Items3" xml:space="preserve">
+    <value>Color</value>
+  </data>
+  <data name="cBWhileCharging.Location" type="System.Drawing.Point, System.Drawing">
+    <value>96, 11</value>
+  </data>
+  <data name="cBWhileCharging.Size" type="System.Drawing.Size, System.Drawing">
+    <value>121, 21</value>
+  </data>
+  <data name="cBWhileCharging.TabIndex" type="System.Int32, mscorlib">
+    <value>242</value>
+  </data>
   <data name="&gt;&gt;cBWhileCharging.Name" xml:space="preserve">
     <value>cBWhileCharging</value>
   </data>
@@ -5847,6 +5043,24 @@
   <data name="&gt;&gt;cBWhileCharging.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
+  <data name="btnChargingColor.FlatStyle" type="System.Windows.Forms.FlatStyle, System.Windows.Forms">
+    <value>Flat</value>
+  </data>
+  <data name="btnChargingColor.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="btnChargingColor.Location" type="System.Drawing.Point, System.Drawing">
+    <value>223, 13</value>
+  </data>
+  <data name="btnChargingColor.Size" type="System.Drawing.Size, System.Drawing">
+    <value>13, 13</value>
+  </data>
+  <data name="btnChargingColor.TabIndex" type="System.Int32, mscorlib">
+    <value>240</value>
+  </data>
+  <data name="btnChargingColor.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
   <data name="&gt;&gt;btnChargingColor.Name" xml:space="preserve">
     <value>btnChargingColor</value>
   </data>
@@ -5858,6 +5072,24 @@
   </data>
   <data name="&gt;&gt;btnChargingColor.ZOrder" xml:space="preserve">
     <value>1</value>
+  </data>
+  <data name="lbWhileCharging.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lbWhileCharging.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lbWhileCharging.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 12</value>
+  </data>
+  <data name="lbWhileCharging.Size" type="System.Drawing.Size, System.Drawing">
+    <value>82, 13</value>
+  </data>
+  <data name="lbWhileCharging.TabIndex" type="System.Int32, mscorlib">
+    <value>241</value>
+  </data>
+  <data name="lbWhileCharging.Text" xml:space="preserve">
+    <value>While Charging:</value>
   </data>
   <data name="&gt;&gt;lbWhileCharging.Name" xml:space="preserve">
     <value>lbWhileCharging</value>
@@ -6096,6 +5328,2172 @@
   <data name="&gt;&gt;tabLightbar.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
+  <data name="flowLayoutPanel3.AutoScroll" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label4.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label4.Location" type="System.Drawing.Point, System.Drawing">
+    <value>13, 192</value>
+  </data>
+  <data name="label4.Size" type="System.Drawing.Size, System.Drawing">
+    <value>71, 13</value>
+  </data>
+  <data name="label4.TabIndex" type="System.Int32, mscorlib">
+    <value>235</value>
+  </data>
+  <data name="label4.Text" xml:space="preserve">
+    <value>Square Stick:</value>
+  </data>
+  <data name="&gt;&gt;label4.Name" xml:space="preserve">
+    <value>label4</value>
+  </data>
+  <data name="&gt;&gt;label4.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label4.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;label4.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="nUDRSRotation.Location" type="System.Drawing.Point, System.Drawing">
+    <value>262, 249</value>
+  </data>
+  <data name="nUDRSRotation.Size" type="System.Drawing.Size, System.Drawing">
+    <value>59, 20</value>
+  </data>
+  <data name="nUDRSRotation.TabIndex" type="System.Int32, mscorlib">
+    <value>227</value>
+  </data>
+  <data name="&gt;&gt;nUDRSRotation.Name" xml:space="preserve">
+    <value>nUDRSRotation</value>
+  </data>
+  <data name="&gt;&gt;nUDRSRotation.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nUDRSRotation.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;nUDRSRotation.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="btnRSCurveEditor.FlatStyle" type="System.Windows.Forms.FlatStyle, System.Windows.Forms">
+    <value>System</value>
+  </data>
+  <data name="btnRSCurveEditor.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Microsoft Sans Serif, 8.25pt, style=Bold</value>
+  </data>
+  <data name="btnRSCurveEditor.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="btnRSCurveEditor.Location" type="System.Drawing.Point, System.Drawing">
+    <value>376, 159</value>
+  </data>
+  <data name="btnRSCurveEditor.Size" type="System.Drawing.Size, System.Drawing">
+    <value>22, 23</value>
+  </data>
+  <data name="btnRSCurveEditor.TabIndex" type="System.Int32, mscorlib">
+    <value>234</value>
+  </data>
+  <data name="btnRSCurveEditor.Text" xml:space="preserve">
+    <value>...</value>
+  </data>
+  <data name="&gt;&gt;btnRSCurveEditor.Name" xml:space="preserve">
+    <value>btnRSCurveEditor</value>
+  </data>
+  <data name="&gt;&gt;btnRSCurveEditor.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnRSCurveEditor.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;btnRSCurveEditor.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="lbRSCurvePercent.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lbRSCurvePercent.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lbRSCurvePercent.Location" type="System.Drawing.Point, System.Drawing">
+    <value>323, 222</value>
+  </data>
+  <data name="lbRSCurvePercent.Size" type="System.Drawing.Size, System.Drawing">
+    <value>15, 13</value>
+  </data>
+  <data name="lbRSCurvePercent.TabIndex" type="System.Int32, mscorlib">
+    <value>225</value>
+  </data>
+  <data name="lbRSCurvePercent.Text" xml:space="preserve">
+    <value>%</value>
+  </data>
+  <data name="&gt;&gt;lbRSCurvePercent.Name" xml:space="preserve">
+    <value>lbRSCurvePercent</value>
+  </data>
+  <data name="&gt;&gt;lbRSCurvePercent.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lbRSCurvePercent.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;lbRSCurvePercent.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="tBRSCustomOutputCurve.Location" type="System.Drawing.Point, System.Drawing">
+    <value>262, 161</value>
+  </data>
+  <data name="tBRSCustomOutputCurve.Size" type="System.Drawing.Size, System.Drawing">
+    <value>113, 20</value>
+  </data>
+  <data name="tBRSCustomOutputCurve.TabIndex" type="System.Int32, mscorlib">
+    <value>232</value>
+  </data>
+  <data name="tBRSCustomOutputCurve.Text" xml:space="preserve">
+    <value>0.00, 0.00, 1.00, 1.00</value>
+  </data>
+  <data name="&gt;&gt;tBRSCustomOutputCurve.Name" xml:space="preserve">
+    <value>tBRSCustomOutputCurve</value>
+  </data>
+  <data name="&gt;&gt;tBRSCustomOutputCurve.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tBRSCustomOutputCurve.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;tBRSCustomOutputCurve.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="nUDRSCurve.Location" type="System.Drawing.Point, System.Drawing">
+    <value>262, 220</value>
+  </data>
+  <data name="nUDRSCurve.RightToLeft" type="System.Windows.Forms.RightToLeft, System.Windows.Forms">
+    <value>No</value>
+  </data>
+  <data name="nUDRSCurve.Size" type="System.Drawing.Size, System.Drawing">
+    <value>59, 20</value>
+  </data>
+  <data name="nUDRSCurve.TabIndex" type="System.Int32, mscorlib">
+    <value>224</value>
+  </data>
+  <data name="&gt;&gt;nUDRSCurve.Name" xml:space="preserve">
+    <value>nUDRSCurve</value>
+  </data>
+  <data name="&gt;&gt;nUDRSCurve.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nUDRSCurve.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;nUDRSCurve.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="BtnLSCurveEditor.FlatStyle" type="System.Windows.Forms.FlatStyle, System.Windows.Forms">
+    <value>System</value>
+  </data>
+  <data name="BtnLSCurveEditor.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Microsoft Sans Serif, 8.25pt, style=Bold</value>
+  </data>
+  <data name="BtnLSCurveEditor.Location" type="System.Drawing.Point, System.Drawing">
+    <value>219, 159</value>
+  </data>
+  <data name="BtnLSCurveEditor.Size" type="System.Drawing.Size, System.Drawing">
+    <value>22, 23</value>
+  </data>
+  <data name="BtnLSCurveEditor.TabIndex" type="System.Int32, mscorlib">
+    <value>233</value>
+  </data>
+  <data name="BtnLSCurveEditor.Text" xml:space="preserve">
+    <value>...</value>
+  </data>
+  <data name="&gt;&gt;BtnLSCurveEditor.Name" xml:space="preserve">
+    <value>BtnLSCurveEditor</value>
+  </data>
+  <data name="&gt;&gt;BtnLSCurveEditor.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;BtnLSCurveEditor.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;BtnLSCurveEditor.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="label3.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label3.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Microsoft Sans Serif, 8.25pt, style=Bold</value>
+  </data>
+  <data name="label3.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label3.Location" type="System.Drawing.Point, System.Drawing">
+    <value>259, 8</value>
+  </data>
+  <data name="label3.Size" type="System.Drawing.Size, System.Drawing">
+    <value>24, 13</value>
+  </data>
+  <data name="label3.TabIndex" type="System.Int32, mscorlib">
+    <value>232</value>
+  </data>
+  <data name="label3.Text" xml:space="preserve">
+    <value>RS</value>
+  </data>
+  <data name="&gt;&gt;label3.Name" xml:space="preserve">
+    <value>label3</value>
+  </data>
+  <data name="&gt;&gt;label3.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label3.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;label3.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="rsSquStickCk.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="rsSquStickCk.Location" type="System.Drawing.Point, System.Drawing">
+    <value>262, 188</value>
+  </data>
+  <data name="rsSquStickCk.RightToLeft" type="System.Windows.Forms.RightToLeft, System.Windows.Forms">
+    <value>No</value>
+  </data>
+  <data name="rsSquStickCk.Size" type="System.Drawing.Size, System.Drawing">
+    <value>23, 24</value>
+  </data>
+  <data name="rsSquStickCk.TabIndex" type="System.Int32, mscorlib">
+    <value>222</value>
+  </data>
+  <data name="&gt;&gt;rsSquStickCk.Name" xml:space="preserve">
+    <value>rsSquStickCk</value>
+  </data>
+  <data name="&gt;&gt;rsSquStickCk.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;rsSquStickCk.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;rsSquStickCk.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="numericUpDown1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>285, 190</value>
+  </data>
+  <data name="numericUpDown1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>44, 20</value>
+  </data>
+  <data name="numericUpDown1.TabIndex" type="System.Int32, mscorlib">
+    <value>221</value>
+  </data>
+  <data name="&gt;&gt;numericUpDown1.Name" xml:space="preserve">
+    <value>numericUpDown1</value>
+  </data>
+  <data name="&gt;&gt;numericUpDown1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;numericUpDown1.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;numericUpDown1.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="label2.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label2.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Microsoft Sans Serif, 8.25pt, style=Bold</value>
+  </data>
+  <data name="label2.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>102, 8</value>
+  </data>
+  <data name="label2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>22, 13</value>
+  </data>
+  <data name="label2.TabIndex" type="System.Int32, mscorlib">
+    <value>231</value>
+  </data>
+  <data name="label2.Text" xml:space="preserve">
+    <value>LS</value>
+  </data>
+  <data name="&gt;&gt;label2.Name" xml:space="preserve">
+    <value>label2</value>
+  </data>
+  <data name="&gt;&gt;label2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label2.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;label2.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="tBLSCustomOutputCurve.Location" type="System.Drawing.Point, System.Drawing">
+    <value>105, 161</value>
+  </data>
+  <data name="tBLSCustomOutputCurve.Size" type="System.Drawing.Size, System.Drawing">
+    <value>113, 20</value>
+  </data>
+  <data name="tBLSCustomOutputCurve.TabIndex" type="System.Int32, mscorlib">
+    <value>225</value>
+  </data>
+  <data name="tBLSCustomOutputCurve.Text" xml:space="preserve">
+    <value>0.00, 0.00, 1.00, 1.00</value>
+  </data>
+  <data name="&gt;&gt;tBLSCustomOutputCurve.Name" xml:space="preserve">
+    <value>tBLSCustomOutputCurve</value>
+  </data>
+  <data name="&gt;&gt;tBLSCustomOutputCurve.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tBLSCustomOutputCurve.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;tBLSCustomOutputCurve.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
+  <data name="rsOutCurveComboBox.Items" xml:space="preserve">
+    <value>Linear</value>
+  </data>
+  <data name="rsOutCurveComboBox.Items1" xml:space="preserve">
+    <value>Enhanced Precison</value>
+  </data>
+  <data name="rsOutCurveComboBox.Items2" xml:space="preserve">
+    <value>Quadratic</value>
+  </data>
+  <data name="rsOutCurveComboBox.Items3" xml:space="preserve">
+    <value>Cubic</value>
+  </data>
+  <data name="rsOutCurveComboBox.Items4" xml:space="preserve">
+    <value>Easeout Quad</value>
+  </data>
+  <data name="rsOutCurveComboBox.Items5" xml:space="preserve">
+    <value>Easeout Cubic</value>
+  </data>
+  <data name="rsOutCurveComboBox.Items6" xml:space="preserve">
+    <value>Custom</value>
+  </data>
+  <data name="rsOutCurveComboBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>262, 134</value>
+  </data>
+  <data name="rsOutCurveComboBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>134, 21</value>
+  </data>
+  <data name="rsOutCurveComboBox.TabIndex" type="System.Int32, mscorlib">
+    <value>228</value>
+  </data>
+  <data name="&gt;&gt;rsOutCurveComboBox.Name" xml:space="preserve">
+    <value>rsOutCurveComboBox</value>
+  </data>
+  <data name="&gt;&gt;rsOutCurveComboBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;rsOutCurveComboBox.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;rsOutCurveComboBox.ZOrder" xml:space="preserve">
+    <value>12</value>
+  </data>
+  <data name="nUDRSS.Location" type="System.Drawing.Point, System.Drawing">
+    <value>262, 104</value>
+  </data>
+  <data name="nUDRSS.RightToLeft" type="System.Windows.Forms.RightToLeft, System.Windows.Forms">
+    <value>No</value>
+  </data>
+  <data name="nUDRSS.Size" type="System.Drawing.Size, System.Drawing">
+    <value>59, 20</value>
+  </data>
+  <data name="nUDRSS.TabIndex" type="System.Int32, mscorlib">
+    <value>230</value>
+  </data>
+  <data name="&gt;&gt;nUDRSS.Name" xml:space="preserve">
+    <value>nUDRSS</value>
+  </data>
+  <data name="&gt;&gt;nUDRSS.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nUDRSS.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;nUDRSS.ZOrder" xml:space="preserve">
+    <value>13</value>
+  </data>
+  <data name="nUDLSS.Location" type="System.Drawing.Point, System.Drawing">
+    <value>105, 104</value>
+  </data>
+  <data name="nUDLSS.RightToLeft" type="System.Windows.Forms.RightToLeft, System.Windows.Forms">
+    <value>No</value>
+  </data>
+  <data name="nUDLSS.Size" type="System.Drawing.Size, System.Drawing">
+    <value>59, 20</value>
+  </data>
+  <data name="nUDLSS.TabIndex" type="System.Int32, mscorlib">
+    <value>223</value>
+  </data>
+  <data name="&gt;&gt;nUDLSS.Name" xml:space="preserve">
+    <value>nUDLSS</value>
+  </data>
+  <data name="&gt;&gt;nUDLSS.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nUDLSS.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;nUDLSS.ZOrder" xml:space="preserve">
+    <value>14</value>
+  </data>
+  <data name="label69.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label69.Location" type="System.Drawing.Point, System.Drawing">
+    <value>13, 107</value>
+  </data>
+  <data name="label69.Size" type="System.Drawing.Size, System.Drawing">
+    <value>57, 13</value>
+  </data>
+  <data name="label69.TabIndex" type="System.Int32, mscorlib">
+    <value>222</value>
+  </data>
+  <data name="label69.Text" xml:space="preserve">
+    <value>Sensitivity:</value>
+  </data>
+  <data name="&gt;&gt;label69.Name" xml:space="preserve">
+    <value>label69</value>
+  </data>
+  <data name="&gt;&gt;label69.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label69.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;label69.ZOrder" xml:space="preserve">
+    <value>15</value>
+  </data>
+  <data name="RoundnessNUpDown.Location" type="System.Drawing.Point, System.Drawing">
+    <value>127, 190</value>
+  </data>
+  <data name="RoundnessNUpDown.Size" type="System.Drawing.Size, System.Drawing">
+    <value>44, 20</value>
+  </data>
+  <data name="RoundnessNUpDown.TabIndex" type="System.Int32, mscorlib">
+    <value>220</value>
+  </data>
+  <data name="&gt;&gt;RoundnessNUpDown.Name" xml:space="preserve">
+    <value>RoundnessNUpDown</value>
+  </data>
+  <data name="&gt;&gt;RoundnessNUpDown.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;RoundnessNUpDown.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;RoundnessNUpDown.ZOrder" xml:space="preserve">
+    <value>16</value>
+  </data>
+  <data name="lsSquStickCk.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lsSquStickCk.Location" type="System.Drawing.Point, System.Drawing">
+    <value>105, 188</value>
+  </data>
+  <data name="lsSquStickCk.RightToLeft" type="System.Windows.Forms.RightToLeft, System.Windows.Forms">
+    <value>No</value>
+  </data>
+  <data name="lsSquStickCk.Size" type="System.Drawing.Size, System.Drawing">
+    <value>23, 24</value>
+  </data>
+  <data name="lsSquStickCk.TabIndex" type="System.Int32, mscorlib">
+    <value>219</value>
+  </data>
+  <data name="&gt;&gt;lsSquStickCk.Name" xml:space="preserve">
+    <value>lsSquStickCk</value>
+  </data>
+  <data name="&gt;&gt;lsSquStickCk.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lsSquStickCk.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;lsSquStickCk.ZOrder" xml:space="preserve">
+    <value>17</value>
+  </data>
+  <data name="nUDLSRotation.Location" type="System.Drawing.Point, System.Drawing">
+    <value>105, 249</value>
+  </data>
+  <data name="nUDLSRotation.Size" type="System.Drawing.Size, System.Drawing">
+    <value>59, 20</value>
+  </data>
+  <data name="nUDLSRotation.TabIndex" type="System.Int32, mscorlib">
+    <value>218</value>
+  </data>
+  <data name="&gt;&gt;nUDLSRotation.Name" xml:space="preserve">
+    <value>nUDLSRotation</value>
+  </data>
+  <data name="&gt;&gt;nUDLSRotation.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nUDLSRotation.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;nUDLSRotation.ZOrder" xml:space="preserve">
+    <value>18</value>
+  </data>
+  <data name="label45.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label45.Location" type="System.Drawing.Point, System.Drawing">
+    <value>13, 252</value>
+  </data>
+  <data name="label45.Size" type="System.Drawing.Size, System.Drawing">
+    <value>50, 13</value>
+  </data>
+  <data name="label45.TabIndex" type="System.Int32, mscorlib">
+    <value>214</value>
+  </data>
+  <data name="label45.Text" xml:space="preserve">
+    <value>Rotation:</value>
+  </data>
+  <data name="&gt;&gt;label45.Name" xml:space="preserve">
+    <value>label45</value>
+  </data>
+  <data name="&gt;&gt;label45.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label45.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;label45.ZOrder" xml:space="preserve">
+    <value>19</value>
+  </data>
+  <data name="nUDLSCurve.Location" type="System.Drawing.Point, System.Drawing">
+    <value>105, 220</value>
+  </data>
+  <data name="nUDLSCurve.RightToLeft" type="System.Windows.Forms.RightToLeft, System.Windows.Forms">
+    <value>No</value>
+  </data>
+  <data name="nUDLSCurve.Size" type="System.Drawing.Size, System.Drawing">
+    <value>59, 20</value>
+  </data>
+  <data name="nUDLSCurve.TabIndex" type="System.Int32, mscorlib">
+    <value>213</value>
+  </data>
+  <data name="&gt;&gt;nUDLSCurve.Name" xml:space="preserve">
+    <value>nUDLSCurve</value>
+  </data>
+  <data name="&gt;&gt;nUDLSCurve.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nUDLSCurve.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;nUDLSCurve.ZOrder" xml:space="preserve">
+    <value>20</value>
+  </data>
+  <data name="lbLSCurvePercent.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lbLSCurvePercent.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lbLSCurvePercent.Location" type="System.Drawing.Point, System.Drawing">
+    <value>166, 222</value>
+  </data>
+  <data name="lbLSCurvePercent.Size" type="System.Drawing.Size, System.Drawing">
+    <value>15, 13</value>
+  </data>
+  <data name="lbLSCurvePercent.TabIndex" type="System.Int32, mscorlib">
+    <value>212</value>
+  </data>
+  <data name="lbLSCurvePercent.Text" xml:space="preserve">
+    <value>%</value>
+  </data>
+  <data name="&gt;&gt;lbLSCurvePercent.Name" xml:space="preserve">
+    <value>lbLSCurvePercent</value>
+  </data>
+  <data name="&gt;&gt;lbLSCurvePercent.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lbLSCurvePercent.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;lbLSCurvePercent.ZOrder" xml:space="preserve">
+    <value>21</value>
+  </data>
+  <data name="label44.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label44.Location" type="System.Drawing.Point, System.Drawing">
+    <value>13, 223</value>
+  </data>
+  <data name="label44.Size" type="System.Drawing.Size, System.Drawing">
+    <value>71, 13</value>
+  </data>
+  <data name="label44.TabIndex" type="System.Int32, mscorlib">
+    <value>211</value>
+  </data>
+  <data name="label44.Text" xml:space="preserve">
+    <value>Curve (Input):</value>
+  </data>
+  <data name="&gt;&gt;label44.Name" xml:space="preserve">
+    <value>label44</value>
+  </data>
+  <data name="&gt;&gt;label44.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label44.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;label44.ZOrder" xml:space="preserve">
+    <value>22</value>
+  </data>
+  <data name="lsOutCurveComboBox.Items" xml:space="preserve">
+    <value>Linear</value>
+  </data>
+  <data name="lsOutCurveComboBox.Items1" xml:space="preserve">
+    <value>Enhanced Precision</value>
+  </data>
+  <data name="lsOutCurveComboBox.Items2" xml:space="preserve">
+    <value>Quadratic</value>
+  </data>
+  <data name="lsOutCurveComboBox.Items3" xml:space="preserve">
+    <value>Cubic</value>
+  </data>
+  <data name="lsOutCurveComboBox.Items4" xml:space="preserve">
+    <value>Easeout Quad</value>
+  </data>
+  <data name="lsOutCurveComboBox.Items5" xml:space="preserve">
+    <value>Easeout Cubic</value>
+  </data>
+  <data name="lsOutCurveComboBox.Items6" xml:space="preserve">
+    <value>Custom</value>
+  </data>
+  <data name="lsOutCurveComboBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>105, 134</value>
+  </data>
+  <data name="lsOutCurveComboBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>134, 21</value>
+  </data>
+  <data name="lsOutCurveComboBox.TabIndex" type="System.Int32, mscorlib">
+    <value>210</value>
+  </data>
+  <data name="&gt;&gt;lsOutCurveComboBox.Name" xml:space="preserve">
+    <value>lsOutCurveComboBox</value>
+  </data>
+  <data name="&gt;&gt;lsOutCurveComboBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lsOutCurveComboBox.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;lsOutCurveComboBox.ZOrder" xml:space="preserve">
+    <value>23</value>
+  </data>
+  <data name="label43.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label43.Location" type="System.Drawing.Point, System.Drawing">
+    <value>13, 137</value>
+  </data>
+  <data name="label43.Size" type="System.Drawing.Size, System.Drawing">
+    <value>73, 13</value>
+  </data>
+  <data name="label43.TabIndex" type="System.Int32, mscorlib">
+    <value>209</value>
+  </data>
+  <data name="label43.Text" xml:space="preserve">
+    <value>Output Curve:</value>
+  </data>
+  <data name="&gt;&gt;label43.Name" xml:space="preserve">
+    <value>label43</value>
+  </data>
+  <data name="&gt;&gt;label43.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label43.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;label43.ZOrder" xml:space="preserve">
+    <value>24</value>
+  </data>
+  <data name="nUDRSAntiDead.Location" type="System.Drawing.Point, System.Drawing">
+    <value>262, 77</value>
+  </data>
+  <data name="nUDRSAntiDead.Size" type="System.Drawing.Size, System.Drawing">
+    <value>59, 20</value>
+  </data>
+  <data name="nUDRSAntiDead.TabIndex" type="System.Int32, mscorlib">
+    <value>209</value>
+  </data>
+  <data name="&gt;&gt;nUDRSAntiDead.Name" xml:space="preserve">
+    <value>nUDRSAntiDead</value>
+  </data>
+  <data name="&gt;&gt;nUDRSAntiDead.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nUDRSAntiDead.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;nUDRSAntiDead.ZOrder" xml:space="preserve">
+    <value>25</value>
+  </data>
+  <data name="nUDLSAntiDead.Location" type="System.Drawing.Point, System.Drawing">
+    <value>105, 77</value>
+  </data>
+  <data name="nUDLSAntiDead.Size" type="System.Drawing.Size, System.Drawing">
+    <value>59, 20</value>
+  </data>
+  <data name="nUDLSAntiDead.TabIndex" type="System.Int32, mscorlib">
+    <value>208</value>
+  </data>
+  <data name="&gt;&gt;nUDLSAntiDead.Name" xml:space="preserve">
+    <value>nUDLSAntiDead</value>
+  </data>
+  <data name="&gt;&gt;nUDLSAntiDead.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nUDLSAntiDead.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;nUDLSAntiDead.ZOrder" xml:space="preserve">
+    <value>26</value>
+  </data>
+  <data name="label42.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label42.Location" type="System.Drawing.Point, System.Drawing">
+    <value>13, 80</value>
+  </data>
+  <data name="label42.Size" type="System.Drawing.Size, System.Drawing">
+    <value>83, 13</value>
+  </data>
+  <data name="label42.TabIndex" type="System.Int32, mscorlib">
+    <value>207</value>
+  </data>
+  <data name="label42.Text" xml:space="preserve">
+    <value>Anti-dead Zone:</value>
+  </data>
+  <data name="&gt;&gt;label42.Name" xml:space="preserve">
+    <value>label42</value>
+  </data>
+  <data name="&gt;&gt;label42.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label42.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;label42.ZOrder" xml:space="preserve">
+    <value>27</value>
+  </data>
+  <data name="nUDRSMaxZone.Location" type="System.Drawing.Point, System.Drawing">
+    <value>262, 50</value>
+  </data>
+  <data name="nUDRSMaxZone.Size" type="System.Drawing.Size, System.Drawing">
+    <value>59, 20</value>
+  </data>
+  <data name="nUDRSMaxZone.TabIndex" type="System.Int32, mscorlib">
+    <value>207</value>
+  </data>
+  <data name="&gt;&gt;nUDRSMaxZone.Name" xml:space="preserve">
+    <value>nUDRSMaxZone</value>
+  </data>
+  <data name="&gt;&gt;nUDRSMaxZone.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nUDRSMaxZone.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;nUDRSMaxZone.ZOrder" xml:space="preserve">
+    <value>28</value>
+  </data>
+  <data name="nUDLSMaxZone.Location" type="System.Drawing.Point, System.Drawing">
+    <value>105, 50</value>
+  </data>
+  <data name="nUDLSMaxZone.Size" type="System.Drawing.Size, System.Drawing">
+    <value>59, 20</value>
+  </data>
+  <data name="nUDLSMaxZone.TabIndex" type="System.Int32, mscorlib">
+    <value>206</value>
+  </data>
+  <data name="&gt;&gt;nUDLSMaxZone.Name" xml:space="preserve">
+    <value>nUDLSMaxZone</value>
+  </data>
+  <data name="&gt;&gt;nUDLSMaxZone.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nUDLSMaxZone.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;nUDLSMaxZone.ZOrder" xml:space="preserve">
+    <value>29</value>
+  </data>
+  <data name="label41.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label41.Location" type="System.Drawing.Point, System.Drawing">
+    <value>13, 53</value>
+  </data>
+  <data name="label41.Size" type="System.Drawing.Size, System.Drawing">
+    <value>58, 13</value>
+  </data>
+  <data name="label41.TabIndex" type="System.Int32, mscorlib">
+    <value>205</value>
+  </data>
+  <data name="label41.Text" xml:space="preserve">
+    <value>Max Zone:</value>
+  </data>
+  <data name="&gt;&gt;label41.Name" xml:space="preserve">
+    <value>label41</value>
+  </data>
+  <data name="&gt;&gt;label41.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label41.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;label41.ZOrder" xml:space="preserve">
+    <value>30</value>
+  </data>
+  <data name="nUDRS.Location" type="System.Drawing.Point, System.Drawing">
+    <value>262, 23</value>
+  </data>
+  <data name="nUDRS.RightToLeft" type="System.Windows.Forms.RightToLeft, System.Windows.Forms">
+    <value>No</value>
+  </data>
+  <data name="nUDRS.Size" type="System.Drawing.Size, System.Drawing">
+    <value>59, 20</value>
+  </data>
+  <data name="nUDRS.TabIndex" type="System.Int32, mscorlib">
+    <value>204</value>
+  </data>
+  <data name="&gt;&gt;nUDRS.Name" xml:space="preserve">
+    <value>nUDRS</value>
+  </data>
+  <data name="&gt;&gt;nUDRS.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nUDRS.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;nUDRS.ZOrder" xml:space="preserve">
+    <value>31</value>
+  </data>
+  <data name="nUDLS.Location" type="System.Drawing.Point, System.Drawing">
+    <value>105, 23</value>
+  </data>
+  <data name="nUDLS.RightToLeft" type="System.Windows.Forms.RightToLeft, System.Windows.Forms">
+    <value>No</value>
+  </data>
+  <data name="nUDLS.Size" type="System.Drawing.Size, System.Drawing">
+    <value>59, 20</value>
+  </data>
+  <data name="nUDLS.TabIndex" type="System.Int32, mscorlib">
+    <value>204</value>
+  </data>
+  <data name="&gt;&gt;nUDLS.Name" xml:space="preserve">
+    <value>nUDLS</value>
+  </data>
+  <data name="&gt;&gt;nUDLS.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nUDLS.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;nUDLS.ZOrder" xml:space="preserve">
+    <value>32</value>
+  </data>
+  <data name="label40.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label40.Location" type="System.Drawing.Point, System.Drawing">
+    <value>13, 26</value>
+  </data>
+  <data name="label40.Size" type="System.Drawing.Size, System.Drawing">
+    <value>64, 13</value>
+  </data>
+  <data name="label40.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="label40.Text" xml:space="preserve">
+    <value>Dead Zone:</value>
+  </data>
+  <data name="&gt;&gt;label40.Name" xml:space="preserve">
+    <value>label40</value>
+  </data>
+  <data name="&gt;&gt;label40.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label40.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;label40.ZOrder" xml:space="preserve">
+    <value>33</value>
+  </data>
+  <data name="groupBox1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 3</value>
+  </data>
+  <data name="groupBox1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>424, 278</value>
+  </data>
+  <data name="groupBox1.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="groupBox1.Text" xml:space="preserve">
+    <value>LS &amp;&amp; RS</value>
+  </data>
+  <data name="&gt;&gt;groupBox1.Name" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;groupBox1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;groupBox1.Parent" xml:space="preserve">
+    <value>flowLayoutPanel3</value>
+  </data>
+  <data name="&gt;&gt;groupBox1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="btnR2CurveEditor.FlatStyle" type="System.Windows.Forms.FlatStyle, System.Windows.Forms">
+    <value>System</value>
+  </data>
+  <data name="btnR2CurveEditor.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Microsoft Sans Serif, 8.25pt, style=Bold</value>
+  </data>
+  <data name="btnR2CurveEditor.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="btnR2CurveEditor.Location" type="System.Drawing.Point, System.Drawing">
+    <value>376, 159</value>
+  </data>
+  <data name="btnR2CurveEditor.Size" type="System.Drawing.Size, System.Drawing">
+    <value>22, 23</value>
+  </data>
+  <data name="btnR2CurveEditor.TabIndex" type="System.Int32, mscorlib">
+    <value>237</value>
+  </data>
+  <data name="btnR2CurveEditor.Text" xml:space="preserve">
+    <value>...</value>
+  </data>
+  <data name="&gt;&gt;btnR2CurveEditor.Name" xml:space="preserve">
+    <value>btnR2CurveEditor</value>
+  </data>
+  <data name="&gt;&gt;btnR2CurveEditor.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnR2CurveEditor.Parent" xml:space="preserve">
+    <value>groupBox3</value>
+  </data>
+  <data name="&gt;&gt;btnR2CurveEditor.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="btnL2CurveEditor.FlatStyle" type="System.Windows.Forms.FlatStyle, System.Windows.Forms">
+    <value>System</value>
+  </data>
+  <data name="btnL2CurveEditor.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Microsoft Sans Serif, 8.25pt, style=Bold</value>
+  </data>
+  <data name="btnL2CurveEditor.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="btnL2CurveEditor.Location" type="System.Drawing.Point, System.Drawing">
+    <value>219, 159</value>
+  </data>
+  <data name="btnL2CurveEditor.Size" type="System.Drawing.Size, System.Drawing">
+    <value>22, 23</value>
+  </data>
+  <data name="btnL2CurveEditor.TabIndex" type="System.Int32, mscorlib">
+    <value>236</value>
+  </data>
+  <data name="btnL2CurveEditor.Text" xml:space="preserve">
+    <value>...</value>
+  </data>
+  <data name="&gt;&gt;btnL2CurveEditor.Name" xml:space="preserve">
+    <value>btnL2CurveEditor</value>
+  </data>
+  <data name="&gt;&gt;btnL2CurveEditor.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnL2CurveEditor.Parent" xml:space="preserve">
+    <value>groupBox3</value>
+  </data>
+  <data name="&gt;&gt;btnL2CurveEditor.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="tBR2CustomOutputCurve.Location" type="System.Drawing.Point, System.Drawing">
+    <value>262, 161</value>
+  </data>
+  <data name="tBR2CustomOutputCurve.Size" type="System.Drawing.Size, System.Drawing">
+    <value>113, 20</value>
+  </data>
+  <data name="tBR2CustomOutputCurve.TabIndex" type="System.Int32, mscorlib">
+    <value>234</value>
+  </data>
+  <data name="tBR2CustomOutputCurve.Text" xml:space="preserve">
+    <value>0.00, 0.00, 1.00, 1.00</value>
+  </data>
+  <data name="&gt;&gt;tBR2CustomOutputCurve.Name" xml:space="preserve">
+    <value>tBR2CustomOutputCurve</value>
+  </data>
+  <data name="&gt;&gt;tBR2CustomOutputCurve.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tBR2CustomOutputCurve.Parent" xml:space="preserve">
+    <value>groupBox3</value>
+  </data>
+  <data name="&gt;&gt;tBR2CustomOutputCurve.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="label6.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label6.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Microsoft Sans Serif, 8.25pt, style=Bold</value>
+  </data>
+  <data name="label6.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label6.Location" type="System.Drawing.Point, System.Drawing">
+    <value>259, 8</value>
+  </data>
+  <data name="label6.Size" type="System.Drawing.Size, System.Drawing">
+    <value>23, 13</value>
+  </data>
+  <data name="label6.TabIndex" type="System.Int32, mscorlib">
+    <value>235</value>
+  </data>
+  <data name="label6.Text" xml:space="preserve">
+    <value>R2</value>
+  </data>
+  <data name="&gt;&gt;label6.Name" xml:space="preserve">
+    <value>label6</value>
+  </data>
+  <data name="&gt;&gt;label6.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label6.Parent" xml:space="preserve">
+    <value>groupBox3</value>
+  </data>
+  <data name="&gt;&gt;label6.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="label5.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label5.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Microsoft Sans Serif, 8.25pt, style=Bold</value>
+  </data>
+  <data name="label5.Location" type="System.Drawing.Point, System.Drawing">
+    <value>102, 8</value>
+  </data>
+  <data name="label5.Size" type="System.Drawing.Size, System.Drawing">
+    <value>21, 13</value>
+  </data>
+  <data name="label5.TabIndex" type="System.Int32, mscorlib">
+    <value>234</value>
+  </data>
+  <data name="label5.Text" xml:space="preserve">
+    <value>L2</value>
+  </data>
+  <data name="&gt;&gt;label5.Name" xml:space="preserve">
+    <value>label5</value>
+  </data>
+  <data name="&gt;&gt;label5.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label5.Parent" xml:space="preserve">
+    <value>groupBox3</value>
+  </data>
+  <data name="&gt;&gt;label5.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="nUDR2S.Location" type="System.Drawing.Point, System.Drawing">
+    <value>262, 104</value>
+  </data>
+  <data name="nUDR2S.Size" type="System.Drawing.Size, System.Drawing">
+    <value>59, 20</value>
+  </data>
+  <data name="nUDR2S.TabIndex" type="System.Int32, mscorlib">
+    <value>232</value>
+  </data>
+  <data name="&gt;&gt;nUDR2S.Name" xml:space="preserve">
+    <value>nUDR2S</value>
+  </data>
+  <data name="&gt;&gt;nUDR2S.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nUDR2S.Parent" xml:space="preserve">
+    <value>groupBox3</value>
+  </data>
+  <data name="&gt;&gt;nUDR2S.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="tBL2CustomOutputCurve.Location" type="System.Drawing.Point, System.Drawing">
+    <value>105, 161</value>
+  </data>
+  <data name="tBL2CustomOutputCurve.Size" type="System.Drawing.Size, System.Drawing">
+    <value>113, 20</value>
+  </data>
+  <data name="tBL2CustomOutputCurve.TabIndex" type="System.Int32, mscorlib">
+    <value>233</value>
+  </data>
+  <data name="tBL2CustomOutputCurve.Text" xml:space="preserve">
+    <value>0.00, 0.00, 1.00, 1.00</value>
+  </data>
+  <data name="&gt;&gt;tBL2CustomOutputCurve.Name" xml:space="preserve">
+    <value>tBL2CustomOutputCurve</value>
+  </data>
+  <data name="&gt;&gt;tBL2CustomOutputCurve.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tBL2CustomOutputCurve.Parent" xml:space="preserve">
+    <value>groupBox3</value>
+  </data>
+  <data name="&gt;&gt;tBL2CustomOutputCurve.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="cBR2OutputCurve.Items" xml:space="preserve">
+    <value>Linear</value>
+  </data>
+  <data name="cBR2OutputCurve.Items1" xml:space="preserve">
+    <value>Enhanced Precison</value>
+  </data>
+  <data name="cBR2OutputCurve.Items2" xml:space="preserve">
+    <value>Quadratic</value>
+  </data>
+  <data name="cBR2OutputCurve.Items3" xml:space="preserve">
+    <value>Cubic</value>
+  </data>
+  <data name="cBR2OutputCurve.Items4" xml:space="preserve">
+    <value>Easeout Quad</value>
+  </data>
+  <data name="cBR2OutputCurve.Items5" xml:space="preserve">
+    <value>Easeout Cubic</value>
+  </data>
+  <data name="cBR2OutputCurve.Items6" xml:space="preserve">
+    <value>Custom</value>
+  </data>
+  <data name="cBR2OutputCurve.Location" type="System.Drawing.Point, System.Drawing">
+    <value>262, 134</value>
+  </data>
+  <data name="cBR2OutputCurve.Size" type="System.Drawing.Size, System.Drawing">
+    <value>134, 21</value>
+  </data>
+  <data name="cBR2OutputCurve.TabIndex" type="System.Int32, mscorlib">
+    <value>223</value>
+  </data>
+  <data name="&gt;&gt;cBR2OutputCurve.Name" xml:space="preserve">
+    <value>cBR2OutputCurve</value>
+  </data>
+  <data name="&gt;&gt;cBR2OutputCurve.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cBR2OutputCurve.Parent" xml:space="preserve">
+    <value>groupBox3</value>
+  </data>
+  <data name="&gt;&gt;cBR2OutputCurve.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="nUDL2S.Location" type="System.Drawing.Point, System.Drawing">
+    <value>105, 104</value>
+  </data>
+  <data name="nUDL2S.RightToLeft" type="System.Windows.Forms.RightToLeft, System.Windows.Forms">
+    <value>No</value>
+  </data>
+  <data name="nUDL2S.Size" type="System.Drawing.Size, System.Drawing">
+    <value>59, 20</value>
+  </data>
+  <data name="nUDL2S.TabIndex" type="System.Int32, mscorlib">
+    <value>231</value>
+  </data>
+  <data name="&gt;&gt;nUDL2S.Name" xml:space="preserve">
+    <value>nUDL2S</value>
+  </data>
+  <data name="&gt;&gt;nUDL2S.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nUDL2S.Parent" xml:space="preserve">
+    <value>groupBox3</value>
+  </data>
+  <data name="&gt;&gt;nUDL2S.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="nUDR2AntiDead.Location" type="System.Drawing.Point, System.Drawing">
+    <value>262, 77</value>
+  </data>
+  <data name="nUDR2AntiDead.Size" type="System.Drawing.Size, System.Drawing">
+    <value>59, 20</value>
+  </data>
+  <data name="nUDR2AntiDead.TabIndex" type="System.Int32, mscorlib">
+    <value>222</value>
+  </data>
+  <data name="&gt;&gt;nUDR2AntiDead.Name" xml:space="preserve">
+    <value>nUDR2AntiDead</value>
+  </data>
+  <data name="&gt;&gt;nUDR2AntiDead.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nUDR2AntiDead.Parent" xml:space="preserve">
+    <value>groupBox3</value>
+  </data>
+  <data name="&gt;&gt;nUDR2AntiDead.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="label71.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label71.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label71.Location" type="System.Drawing.Point, System.Drawing">
+    <value>13, 107</value>
+  </data>
+  <data name="label71.Size" type="System.Drawing.Size, System.Drawing">
+    <value>57, 13</value>
+  </data>
+  <data name="label71.TabIndex" type="System.Int32, mscorlib">
+    <value>230</value>
+  </data>
+  <data name="label71.Text" xml:space="preserve">
+    <value>Sensitivity:</value>
+  </data>
+  <data name="&gt;&gt;label71.Name" xml:space="preserve">
+    <value>label71</value>
+  </data>
+  <data name="&gt;&gt;label71.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label71.Parent" xml:space="preserve">
+    <value>groupBox3</value>
+  </data>
+  <data name="&gt;&gt;label71.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="nUDR2Maxzone.Location" type="System.Drawing.Point, System.Drawing">
+    <value>262, 50</value>
+  </data>
+  <data name="nUDR2Maxzone.Size" type="System.Drawing.Size, System.Drawing">
+    <value>59, 20</value>
+  </data>
+  <data name="nUDR2Maxzone.TabIndex" type="System.Int32, mscorlib">
+    <value>221</value>
+  </data>
+  <data name="&gt;&gt;nUDR2Maxzone.Name" xml:space="preserve">
+    <value>nUDR2Maxzone</value>
+  </data>
+  <data name="&gt;&gt;nUDR2Maxzone.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nUDR2Maxzone.Parent" xml:space="preserve">
+    <value>groupBox3</value>
+  </data>
+  <data name="&gt;&gt;nUDR2Maxzone.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
+  <data name="cBL2OutputCurve.Items" xml:space="preserve">
+    <value>Linear</value>
+  </data>
+  <data name="cBL2OutputCurve.Items1" xml:space="preserve">
+    <value>Enhanced Precison</value>
+  </data>
+  <data name="cBL2OutputCurve.Items2" xml:space="preserve">
+    <value>Quadratic</value>
+  </data>
+  <data name="cBL2OutputCurve.Items3" xml:space="preserve">
+    <value>Cubic</value>
+  </data>
+  <data name="cBL2OutputCurve.Items4" xml:space="preserve">
+    <value>Easeout Quad</value>
+  </data>
+  <data name="cBL2OutputCurve.Items5" xml:space="preserve">
+    <value>Easeout Cubic</value>
+  </data>
+  <data name="cBL2OutputCurve.Items6" xml:space="preserve">
+    <value>Custom</value>
+  </data>
+  <data name="cBL2OutputCurve.Location" type="System.Drawing.Point, System.Drawing">
+    <value>105, 134</value>
+  </data>
+  <data name="cBL2OutputCurve.Size" type="System.Drawing.Size, System.Drawing">
+    <value>134, 21</value>
+  </data>
+  <data name="cBL2OutputCurve.TabIndex" type="System.Int32, mscorlib">
+    <value>220</value>
+  </data>
+  <data name="&gt;&gt;cBL2OutputCurve.Name" xml:space="preserve">
+    <value>cBL2OutputCurve</value>
+  </data>
+  <data name="&gt;&gt;cBL2OutputCurve.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cBL2OutputCurve.Parent" xml:space="preserve">
+    <value>groupBox3</value>
+  </data>
+  <data name="&gt;&gt;cBL2OutputCurve.ZOrder" xml:space="preserve">
+    <value>12</value>
+  </data>
+  <data name="nUDR2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>262, 23</value>
+  </data>
+  <data name="nUDR2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>59, 20</value>
+  </data>
+  <data name="nUDR2.TabIndex" type="System.Int32, mscorlib">
+    <value>220</value>
+  </data>
+  <data name="&gt;&gt;nUDR2.Name" xml:space="preserve">
+    <value>nUDR2</value>
+  </data>
+  <data name="&gt;&gt;nUDR2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nUDR2.Parent" xml:space="preserve">
+    <value>groupBox3</value>
+  </data>
+  <data name="&gt;&gt;nUDR2.ZOrder" xml:space="preserve">
+    <value>13</value>
+  </data>
+  <data name="nUDL2AntiDead.Location" type="System.Drawing.Point, System.Drawing">
+    <value>105, 77</value>
+  </data>
+  <data name="nUDL2AntiDead.Size" type="System.Drawing.Size, System.Drawing">
+    <value>59, 20</value>
+  </data>
+  <data name="nUDL2AntiDead.TabIndex" type="System.Int32, mscorlib">
+    <value>219</value>
+  </data>
+  <data name="&gt;&gt;nUDL2AntiDead.Name" xml:space="preserve">
+    <value>nUDL2AntiDead</value>
+  </data>
+  <data name="&gt;&gt;nUDL2AntiDead.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nUDL2AntiDead.Parent" xml:space="preserve">
+    <value>groupBox3</value>
+  </data>
+  <data name="&gt;&gt;nUDL2AntiDead.ZOrder" xml:space="preserve">
+    <value>14</value>
+  </data>
+  <data name="nUDL2Maxzone.Location" type="System.Drawing.Point, System.Drawing">
+    <value>105, 50</value>
+  </data>
+  <data name="nUDL2Maxzone.Size" type="System.Drawing.Size, System.Drawing">
+    <value>59, 20</value>
+  </data>
+  <data name="nUDL2Maxzone.TabIndex" type="System.Int32, mscorlib">
+    <value>218</value>
+  </data>
+  <data name="&gt;&gt;nUDL2Maxzone.Name" xml:space="preserve">
+    <value>nUDL2Maxzone</value>
+  </data>
+  <data name="&gt;&gt;nUDL2Maxzone.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nUDL2Maxzone.Parent" xml:space="preserve">
+    <value>groupBox3</value>
+  </data>
+  <data name="&gt;&gt;nUDL2Maxzone.ZOrder" xml:space="preserve">
+    <value>15</value>
+  </data>
+  <data name="nUDL2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>105, 23</value>
+  </data>
+  <data name="nUDL2.RightToLeft" type="System.Windows.Forms.RightToLeft, System.Windows.Forms">
+    <value>No</value>
+  </data>
+  <data name="nUDL2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>59, 20</value>
+  </data>
+  <data name="nUDL2.TabIndex" type="System.Int32, mscorlib">
+    <value>217</value>
+  </data>
+  <data name="&gt;&gt;nUDL2.Name" xml:space="preserve">
+    <value>nUDL2</value>
+  </data>
+  <data name="&gt;&gt;nUDL2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nUDL2.Parent" xml:space="preserve">
+    <value>groupBox3</value>
+  </data>
+  <data name="&gt;&gt;nUDL2.ZOrder" xml:space="preserve">
+    <value>16</value>
+  </data>
+  <data name="label54.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label54.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label54.Location" type="System.Drawing.Point, System.Drawing">
+    <value>13, 137</value>
+  </data>
+  <data name="label54.Size" type="System.Drawing.Size, System.Drawing">
+    <value>73, 13</value>
+  </data>
+  <data name="label54.TabIndex" type="System.Int32, mscorlib">
+    <value>215</value>
+  </data>
+  <data name="label54.Text" xml:space="preserve">
+    <value>Output Curve:</value>
+  </data>
+  <data name="&gt;&gt;label54.Name" xml:space="preserve">
+    <value>label54</value>
+  </data>
+  <data name="&gt;&gt;label54.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label54.Parent" xml:space="preserve">
+    <value>groupBox3</value>
+  </data>
+  <data name="&gt;&gt;label54.ZOrder" xml:space="preserve">
+    <value>17</value>
+  </data>
+  <data name="label55.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label55.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label55.Location" type="System.Drawing.Point, System.Drawing">
+    <value>13, 80</value>
+  </data>
+  <data name="label55.Size" type="System.Drawing.Size, System.Drawing">
+    <value>83, 13</value>
+  </data>
+  <data name="label55.TabIndex" type="System.Int32, mscorlib">
+    <value>214</value>
+  </data>
+  <data name="label55.Text" xml:space="preserve">
+    <value>Anti-dead Zone:</value>
+  </data>
+  <data name="&gt;&gt;label55.Name" xml:space="preserve">
+    <value>label55</value>
+  </data>
+  <data name="&gt;&gt;label55.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label55.Parent" xml:space="preserve">
+    <value>groupBox3</value>
+  </data>
+  <data name="&gt;&gt;label55.ZOrder" xml:space="preserve">
+    <value>18</value>
+  </data>
+  <data name="label56.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label56.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label56.Location" type="System.Drawing.Point, System.Drawing">
+    <value>13, 53</value>
+  </data>
+  <data name="label56.Size" type="System.Drawing.Size, System.Drawing">
+    <value>58, 13</value>
+  </data>
+  <data name="label56.TabIndex" type="System.Int32, mscorlib">
+    <value>213</value>
+  </data>
+  <data name="label56.Text" xml:space="preserve">
+    <value>Max Zone:</value>
+  </data>
+  <data name="&gt;&gt;label56.Name" xml:space="preserve">
+    <value>label56</value>
+  </data>
+  <data name="&gt;&gt;label56.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label56.Parent" xml:space="preserve">
+    <value>groupBox3</value>
+  </data>
+  <data name="&gt;&gt;label56.ZOrder" xml:space="preserve">
+    <value>19</value>
+  </data>
+  <data name="label57.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label57.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label57.Location" type="System.Drawing.Point, System.Drawing">
+    <value>13, 26</value>
+  </data>
+  <data name="label57.Size" type="System.Drawing.Size, System.Drawing">
+    <value>64, 13</value>
+  </data>
+  <data name="label57.TabIndex" type="System.Int32, mscorlib">
+    <value>212</value>
+  </data>
+  <data name="label57.Text" xml:space="preserve">
+    <value>Dead Zone:</value>
+  </data>
+  <data name="&gt;&gt;label57.Name" xml:space="preserve">
+    <value>label57</value>
+  </data>
+  <data name="&gt;&gt;label57.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label57.Parent" xml:space="preserve">
+    <value>groupBox3</value>
+  </data>
+  <data name="&gt;&gt;label57.ZOrder" xml:space="preserve">
+    <value>20</value>
+  </data>
+  <data name="groupBox3.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 287</value>
+  </data>
+  <data name="groupBox3.Size" type="System.Drawing.Size, System.Drawing">
+    <value>424, 190</value>
+  </data>
+  <data name="groupBox3.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="groupBox3.Text" xml:space="preserve">
+    <value>L2 &amp;&amp; R2</value>
+  </data>
+  <data name="&gt;&gt;groupBox3.Name" xml:space="preserve">
+    <value>groupBox3</value>
+  </data>
+  <data name="&gt;&gt;groupBox3.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;groupBox3.Parent" xml:space="preserve">
+    <value>flowLayoutPanel3</value>
+  </data>
+  <data name="&gt;&gt;groupBox3.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="btnSixZCurveEditor.FlatStyle" type="System.Windows.Forms.FlatStyle, System.Windows.Forms">
+    <value>System</value>
+  </data>
+  <data name="btnSixZCurveEditor.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Microsoft Sans Serif, 8.25pt, style=Bold</value>
+  </data>
+  <data name="btnSixZCurveEditor.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="btnSixZCurveEditor.Location" type="System.Drawing.Point, System.Drawing">
+    <value>376, 159</value>
+  </data>
+  <data name="btnSixZCurveEditor.Size" type="System.Drawing.Size, System.Drawing">
+    <value>22, 23</value>
+  </data>
+  <data name="btnSixZCurveEditor.TabIndex" type="System.Int32, mscorlib">
+    <value>244</value>
+  </data>
+  <data name="btnSixZCurveEditor.Text" xml:space="preserve">
+    <value>...</value>
+  </data>
+  <data name="&gt;&gt;btnSixZCurveEditor.Name" xml:space="preserve">
+    <value>btnSixZCurveEditor</value>
+  </data>
+  <data name="&gt;&gt;btnSixZCurveEditor.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnSixZCurveEditor.Parent" xml:space="preserve">
+    <value>groupBox5</value>
+  </data>
+  <data name="&gt;&gt;btnSixZCurveEditor.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="btnSixXCurveEditor.FlatStyle" type="System.Windows.Forms.FlatStyle, System.Windows.Forms">
+    <value>System</value>
+  </data>
+  <data name="btnSixXCurveEditor.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Microsoft Sans Serif, 8.25pt, style=Bold</value>
+  </data>
+  <data name="btnSixXCurveEditor.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="btnSixXCurveEditor.Location" type="System.Drawing.Point, System.Drawing">
+    <value>219, 159</value>
+  </data>
+  <data name="btnSixXCurveEditor.Size" type="System.Drawing.Size, System.Drawing">
+    <value>22, 23</value>
+  </data>
+  <data name="btnSixXCurveEditor.TabIndex" type="System.Int32, mscorlib">
+    <value>243</value>
+  </data>
+  <data name="btnSixXCurveEditor.Text" xml:space="preserve">
+    <value>...</value>
+  </data>
+  <data name="&gt;&gt;btnSixXCurveEditor.Name" xml:space="preserve">
+    <value>btnSixXCurveEditor</value>
+  </data>
+  <data name="&gt;&gt;btnSixXCurveEditor.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnSixXCurveEditor.Parent" xml:space="preserve">
+    <value>groupBox5</value>
+  </data>
+  <data name="&gt;&gt;btnSixXCurveEditor.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="label8.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label8.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Microsoft Sans Serif, 8.25pt, style=Bold</value>
+  </data>
+  <data name="label8.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label8.Location" type="System.Drawing.Point, System.Drawing">
+    <value>259, 8</value>
+  </data>
+  <data name="label8.Size" type="System.Drawing.Size, System.Drawing">
+    <value>15, 13</value>
+  </data>
+  <data name="label8.TabIndex" type="System.Int32, mscorlib">
+    <value>242</value>
+  </data>
+  <data name="label8.Text" xml:space="preserve">
+    <value>Z</value>
+  </data>
+  <data name="&gt;&gt;label8.Name" xml:space="preserve">
+    <value>label8</value>
+  </data>
+  <data name="&gt;&gt;label8.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label8.Parent" xml:space="preserve">
+    <value>groupBox5</value>
+  </data>
+  <data name="&gt;&gt;label8.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="label7.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label7.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Microsoft Sans Serif, 8.25pt, style=Bold</value>
+  </data>
+  <data name="label7.Location" type="System.Drawing.Point, System.Drawing">
+    <value>102, 8</value>
+  </data>
+  <data name="label7.Size" type="System.Drawing.Size, System.Drawing">
+    <value>15, 13</value>
+  </data>
+  <data name="label7.TabIndex" type="System.Int32, mscorlib">
+    <value>241</value>
+  </data>
+  <data name="label7.Text" xml:space="preserve">
+    <value>X</value>
+  </data>
+  <data name="&gt;&gt;label7.Name" xml:space="preserve">
+    <value>label7</value>
+  </data>
+  <data name="&gt;&gt;label7.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label7.Parent" xml:space="preserve">
+    <value>groupBox5</value>
+  </data>
+  <data name="&gt;&gt;label7.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="tBSixZCustomOutputCurve.Location" type="System.Drawing.Point, System.Drawing">
+    <value>262, 161</value>
+  </data>
+  <data name="tBSixZCustomOutputCurve.Size" type="System.Drawing.Size, System.Drawing">
+    <value>113, 20</value>
+  </data>
+  <data name="tBSixZCustomOutputCurve.TabIndex" type="System.Int32, mscorlib">
+    <value>240</value>
+  </data>
+  <data name="tBSixZCustomOutputCurve.Text" xml:space="preserve">
+    <value>0.00, 0.00, 1.00, 1.00</value>
+  </data>
+  <data name="&gt;&gt;tBSixZCustomOutputCurve.Name" xml:space="preserve">
+    <value>tBSixZCustomOutputCurve</value>
+  </data>
+  <data name="&gt;&gt;tBSixZCustomOutputCurve.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tBSixZCustomOutputCurve.Parent" xml:space="preserve">
+    <value>groupBox5</value>
+  </data>
+  <data name="&gt;&gt;tBSixZCustomOutputCurve.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="tBSixXCustomOutputCurve.Location" type="System.Drawing.Point, System.Drawing">
+    <value>105, 161</value>
+  </data>
+  <data name="tBSixXCustomOutputCurve.Size" type="System.Drawing.Size, System.Drawing">
+    <value>113, 20</value>
+  </data>
+  <data name="tBSixXCustomOutputCurve.TabIndex" type="System.Int32, mscorlib">
+    <value>238</value>
+  </data>
+  <data name="tBSixXCustomOutputCurve.Text" xml:space="preserve">
+    <value>0.00, 0.00, 1.00, 1.00</value>
+  </data>
+  <data name="&gt;&gt;tBSixXCustomOutputCurve.Name" xml:space="preserve">
+    <value>tBSixXCustomOutputCurve</value>
+  </data>
+  <data name="&gt;&gt;tBSixXCustomOutputCurve.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tBSixXCustomOutputCurve.Parent" xml:space="preserve">
+    <value>groupBox5</value>
+  </data>
+  <data name="&gt;&gt;tBSixXCustomOutputCurve.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="nUDSZS.Location" type="System.Drawing.Point, System.Drawing">
+    <value>262, 104</value>
+  </data>
+  <data name="nUDSZS.RightToLeft" type="System.Windows.Forms.RightToLeft, System.Windows.Forms">
+    <value>No</value>
+  </data>
+  <data name="nUDSZS.Size" type="System.Drawing.Size, System.Drawing">
+    <value>59, 20</value>
+  </data>
+  <data name="nUDSZS.TabIndex" type="System.Int32, mscorlib">
+    <value>236</value>
+  </data>
+  <data name="&gt;&gt;nUDSZS.Name" xml:space="preserve">
+    <value>nUDSZS</value>
+  </data>
+  <data name="&gt;&gt;nUDSZS.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nUDSZS.Parent" xml:space="preserve">
+    <value>groupBox5</value>
+  </data>
+  <data name="&gt;&gt;nUDSZS.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="nUDSXS.Location" type="System.Drawing.Point, System.Drawing">
+    <value>105, 104</value>
+  </data>
+  <data name="nUDSXS.Size" type="System.Drawing.Size, System.Drawing">
+    <value>59, 20</value>
+  </data>
+  <data name="nUDSXS.TabIndex" type="System.Int32, mscorlib">
+    <value>235</value>
+  </data>
+  <data name="&gt;&gt;nUDSXS.Name" xml:space="preserve">
+    <value>nUDSXS</value>
+  </data>
+  <data name="&gt;&gt;nUDSXS.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nUDSXS.Parent" xml:space="preserve">
+    <value>groupBox5</value>
+  </data>
+  <data name="&gt;&gt;nUDSXS.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="label73.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label73.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label73.Location" type="System.Drawing.Point, System.Drawing">
+    <value>13, 107</value>
+  </data>
+  <data name="label73.Size" type="System.Drawing.Size, System.Drawing">
+    <value>57, 13</value>
+  </data>
+  <data name="label73.TabIndex" type="System.Int32, mscorlib">
+    <value>233</value>
+  </data>
+  <data name="label73.Text" xml:space="preserve">
+    <value>Sensitivity:</value>
+  </data>
+  <data name="&gt;&gt;label73.Name" xml:space="preserve">
+    <value>label73</value>
+  </data>
+  <data name="&gt;&gt;label73.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label73.Parent" xml:space="preserve">
+    <value>groupBox5</value>
+  </data>
+  <data name="&gt;&gt;label73.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="cBSixaxisZOutputCurve.Items" xml:space="preserve">
+    <value>Linear</value>
+  </data>
+  <data name="cBSixaxisZOutputCurve.Items1" xml:space="preserve">
+    <value>Enhanced Precison</value>
+  </data>
+  <data name="cBSixaxisZOutputCurve.Items2" xml:space="preserve">
+    <value>Quadratic</value>
+  </data>
+  <data name="cBSixaxisZOutputCurve.Items3" xml:space="preserve">
+    <value>Cubic</value>
+  </data>
+  <data name="cBSixaxisZOutputCurve.Items4" xml:space="preserve">
+    <value>Easeout Quad</value>
+  </data>
+  <data name="cBSixaxisZOutputCurve.Items5" xml:space="preserve">
+    <value>Easeout Cubic</value>
+  </data>
+  <data name="cBSixaxisZOutputCurve.Items6" xml:space="preserve">
+    <value>Custom</value>
+  </data>
+  <data name="cBSixaxisZOutputCurve.Location" type="System.Drawing.Point, System.Drawing">
+    <value>262, 134</value>
+  </data>
+  <data name="cBSixaxisZOutputCurve.Size" type="System.Drawing.Size, System.Drawing">
+    <value>134, 21</value>
+  </data>
+  <data name="cBSixaxisZOutputCurve.TabIndex" type="System.Int32, mscorlib">
+    <value>232</value>
+  </data>
+  <data name="&gt;&gt;cBSixaxisZOutputCurve.Name" xml:space="preserve">
+    <value>cBSixaxisZOutputCurve</value>
+  </data>
+  <data name="&gt;&gt;cBSixaxisZOutputCurve.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cBSixaxisZOutputCurve.Parent" xml:space="preserve">
+    <value>groupBox5</value>
+  </data>
+  <data name="&gt;&gt;cBSixaxisZOutputCurve.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="cBSixaxisXOutputCurve.Items" xml:space="preserve">
+    <value>Linear</value>
+  </data>
+  <data name="cBSixaxisXOutputCurve.Items1" xml:space="preserve">
+    <value>Enhanced Precison</value>
+  </data>
+  <data name="cBSixaxisXOutputCurve.Items2" xml:space="preserve">
+    <value>Quadratic</value>
+  </data>
+  <data name="cBSixaxisXOutputCurve.Items3" xml:space="preserve">
+    <value>Cubic</value>
+  </data>
+  <data name="cBSixaxisXOutputCurve.Items4" xml:space="preserve">
+    <value>Easeout Quad</value>
+  </data>
+  <data name="cBSixaxisXOutputCurve.Items5" xml:space="preserve">
+    <value>Easeout Cubic</value>
+  </data>
+  <data name="cBSixaxisXOutputCurve.Items6" xml:space="preserve">
+    <value>Custom</value>
+  </data>
+  <data name="cBSixaxisXOutputCurve.Location" type="System.Drawing.Point, System.Drawing">
+    <value>105, 134</value>
+  </data>
+  <data name="cBSixaxisXOutputCurve.Size" type="System.Drawing.Size, System.Drawing">
+    <value>134, 21</value>
+  </data>
+  <data name="cBSixaxisXOutputCurve.TabIndex" type="System.Int32, mscorlib">
+    <value>230</value>
+  </data>
+  <data name="&gt;&gt;cBSixaxisXOutputCurve.Name" xml:space="preserve">
+    <value>cBSixaxisXOutputCurve</value>
+  </data>
+  <data name="&gt;&gt;cBSixaxisXOutputCurve.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cBSixaxisXOutputCurve.Parent" xml:space="preserve">
+    <value>groupBox5</value>
+  </data>
+  <data name="&gt;&gt;cBSixaxisXOutputCurve.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="label67.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label67.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label67.Location" type="System.Drawing.Point, System.Drawing">
+    <value>13, 137</value>
+  </data>
+  <data name="label67.Size" type="System.Drawing.Size, System.Drawing">
+    <value>73, 13</value>
+  </data>
+  <data name="label67.TabIndex" type="System.Int32, mscorlib">
+    <value>229</value>
+  </data>
+  <data name="label67.Text" xml:space="preserve">
+    <value>Output Curve:</value>
+  </data>
+  <data name="&gt;&gt;label67.Name" xml:space="preserve">
+    <value>label67</value>
+  </data>
+  <data name="&gt;&gt;label67.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label67.Parent" xml:space="preserve">
+    <value>groupBox5</value>
+  </data>
+  <data name="&gt;&gt;label67.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
+  <data name="nUDSixaxisZAntiDead.Location" type="System.Drawing.Point, System.Drawing">
+    <value>262, 77</value>
+  </data>
+  <data name="nUDSixaxisZAntiDead.Size" type="System.Drawing.Size, System.Drawing">
+    <value>59, 20</value>
+  </data>
+  <data name="nUDSixaxisZAntiDead.TabIndex" type="System.Int32, mscorlib">
+    <value>228</value>
+  </data>
+  <data name="&gt;&gt;nUDSixaxisZAntiDead.Name" xml:space="preserve">
+    <value>nUDSixaxisZAntiDead</value>
+  </data>
+  <data name="&gt;&gt;nUDSixaxisZAntiDead.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nUDSixaxisZAntiDead.Parent" xml:space="preserve">
+    <value>groupBox5</value>
+  </data>
+  <data name="&gt;&gt;nUDSixaxisZAntiDead.ZOrder" xml:space="preserve">
+    <value>12</value>
+  </data>
+  <data name="nUDSixaxisXAntiDead.Location" type="System.Drawing.Point, System.Drawing">
+    <value>105, 77</value>
+  </data>
+  <data name="nUDSixaxisXAntiDead.Size" type="System.Drawing.Size, System.Drawing">
+    <value>59, 20</value>
+  </data>
+  <data name="nUDSixaxisXAntiDead.TabIndex" type="System.Int32, mscorlib">
+    <value>226</value>
+  </data>
+  <data name="&gt;&gt;nUDSixaxisXAntiDead.Name" xml:space="preserve">
+    <value>nUDSixaxisXAntiDead</value>
+  </data>
+  <data name="&gt;&gt;nUDSixaxisXAntiDead.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nUDSixaxisXAntiDead.Parent" xml:space="preserve">
+    <value>groupBox5</value>
+  </data>
+  <data name="&gt;&gt;nUDSixaxisXAntiDead.ZOrder" xml:space="preserve">
+    <value>13</value>
+  </data>
+  <data name="label65.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label65.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label65.Location" type="System.Drawing.Point, System.Drawing">
+    <value>13, 80</value>
+  </data>
+  <data name="label65.Size" type="System.Drawing.Size, System.Drawing">
+    <value>83, 13</value>
+  </data>
+  <data name="label65.TabIndex" type="System.Int32, mscorlib">
+    <value>225</value>
+  </data>
+  <data name="label65.Text" xml:space="preserve">
+    <value>Anti-dead Zone:</value>
+  </data>
+  <data name="&gt;&gt;label65.Name" xml:space="preserve">
+    <value>label65</value>
+  </data>
+  <data name="&gt;&gt;label65.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label65.Parent" xml:space="preserve">
+    <value>groupBox5</value>
+  </data>
+  <data name="&gt;&gt;label65.ZOrder" xml:space="preserve">
+    <value>14</value>
+  </data>
+  <data name="nUDSixAxisZMaxZone.Location" type="System.Drawing.Point, System.Drawing">
+    <value>262, 50</value>
+  </data>
+  <data name="nUDSixAxisZMaxZone.Size" type="System.Drawing.Size, System.Drawing">
+    <value>59, 20</value>
+  </data>
+  <data name="nUDSixAxisZMaxZone.TabIndex" type="System.Int32, mscorlib">
+    <value>224</value>
+  </data>
+  <data name="&gt;&gt;nUDSixAxisZMaxZone.Name" xml:space="preserve">
+    <value>nUDSixAxisZMaxZone</value>
+  </data>
+  <data name="&gt;&gt;nUDSixAxisZMaxZone.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nUDSixAxisZMaxZone.Parent" xml:space="preserve">
+    <value>groupBox5</value>
+  </data>
+  <data name="&gt;&gt;nUDSixAxisZMaxZone.ZOrder" xml:space="preserve">
+    <value>15</value>
+  </data>
+  <data name="nUDSixAxisXMaxZone.Location" type="System.Drawing.Point, System.Drawing">
+    <value>105, 50</value>
+  </data>
+  <data name="nUDSixAxisXMaxZone.Size" type="System.Drawing.Size, System.Drawing">
+    <value>59, 20</value>
+  </data>
+  <data name="nUDSixAxisXMaxZone.TabIndex" type="System.Int32, mscorlib">
+    <value>222</value>
+  </data>
+  <data name="&gt;&gt;nUDSixAxisXMaxZone.Name" xml:space="preserve">
+    <value>nUDSixAxisXMaxZone</value>
+  </data>
+  <data name="&gt;&gt;nUDSixAxisXMaxZone.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nUDSixAxisXMaxZone.Parent" xml:space="preserve">
+    <value>groupBox5</value>
+  </data>
+  <data name="&gt;&gt;nUDSixAxisXMaxZone.ZOrder" xml:space="preserve">
+    <value>16</value>
+  </data>
+  <data name="label63.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label63.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label63.Location" type="System.Drawing.Point, System.Drawing">
+    <value>13, 53</value>
+  </data>
+  <data name="label63.Size" type="System.Drawing.Size, System.Drawing">
+    <value>58, 13</value>
+  </data>
+  <data name="label63.TabIndex" type="System.Int32, mscorlib">
+    <value>221</value>
+  </data>
+  <data name="label63.Text" xml:space="preserve">
+    <value>Max Zone:</value>
+  </data>
+  <data name="&gt;&gt;label63.Name" xml:space="preserve">
+    <value>label63</value>
+  </data>
+  <data name="&gt;&gt;label63.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label63.Parent" xml:space="preserve">
+    <value>groupBox5</value>
+  </data>
+  <data name="&gt;&gt;label63.ZOrder" xml:space="preserve">
+    <value>17</value>
+  </data>
+  <data name="nUDSZ.Location" type="System.Drawing.Point, System.Drawing">
+    <value>262, 23</value>
+  </data>
+  <data name="nUDSZ.RightToLeft" type="System.Windows.Forms.RightToLeft, System.Windows.Forms">
+    <value>No</value>
+  </data>
+  <data name="nUDSZ.Size" type="System.Drawing.Size, System.Drawing">
+    <value>59, 20</value>
+  </data>
+  <data name="nUDSZ.TabIndex" type="System.Int32, mscorlib">
+    <value>220</value>
+  </data>
+  <data name="&gt;&gt;nUDSZ.Name" xml:space="preserve">
+    <value>nUDSZ</value>
+  </data>
+  <data name="&gt;&gt;nUDSZ.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nUDSZ.Parent" xml:space="preserve">
+    <value>groupBox5</value>
+  </data>
+  <data name="&gt;&gt;nUDSZ.ZOrder" xml:space="preserve">
+    <value>18</value>
+  </data>
+  <data name="nUDSX.Location" type="System.Drawing.Point, System.Drawing">
+    <value>105, 23</value>
+  </data>
+  <data name="nUDSX.Size" type="System.Drawing.Size, System.Drawing">
+    <value>59, 20</value>
+  </data>
+  <data name="nUDSX.TabIndex" type="System.Int32, mscorlib">
+    <value>218</value>
+  </data>
+  <data name="&gt;&gt;nUDSX.Name" xml:space="preserve">
+    <value>nUDSX</value>
+  </data>
+  <data name="&gt;&gt;nUDSX.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nUDSX.Parent" xml:space="preserve">
+    <value>groupBox5</value>
+  </data>
+  <data name="&gt;&gt;nUDSX.ZOrder" xml:space="preserve">
+    <value>19</value>
+  </data>
+  <data name="label61.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label61.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label61.Location" type="System.Drawing.Point, System.Drawing">
+    <value>13, 26</value>
+  </data>
+  <data name="label61.Size" type="System.Drawing.Size, System.Drawing">
+    <value>64, 13</value>
+  </data>
+  <data name="label61.TabIndex" type="System.Int32, mscorlib">
+    <value>217</value>
+  </data>
+  <data name="label61.Text" xml:space="preserve">
+    <value>Dead Zone:</value>
+  </data>
+  <data name="&gt;&gt;label61.Name" xml:space="preserve">
+    <value>label61</value>
+  </data>
+  <data name="&gt;&gt;label61.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label61.Parent" xml:space="preserve">
+    <value>groupBox5</value>
+  </data>
+  <data name="&gt;&gt;label61.ZOrder" xml:space="preserve">
+    <value>20</value>
+  </data>
+  <data name="groupBox5.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 483</value>
+  </data>
+  <data name="groupBox5.Size" type="System.Drawing.Size, System.Drawing">
+    <value>424, 190</value>
+  </data>
+  <data name="groupBox5.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="groupBox5.Text" xml:space="preserve">
+    <value>SixAxis</value>
+  </data>
+  <data name="&gt;&gt;groupBox5.Name" xml:space="preserve">
+    <value>groupBox5</value>
+  </data>
+  <data name="&gt;&gt;groupBox5.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;groupBox5.Parent" xml:space="preserve">
+    <value>flowLayoutPanel3</value>
+  </data>
+  <data name="&gt;&gt;groupBox5.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="flowLayoutPanel3.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="flowLayoutPanel3.FlowDirection" type="System.Windows.Forms.FlowDirection, System.Windows.Forms">
+    <value>TopDown</value>
+  </data>
+  <data name="flowLayoutPanel3.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 3</value>
+  </data>
+  <data name="flowLayoutPanel3.Size" type="System.Drawing.Size, System.Drawing">
+    <value>551, 479</value>
+  </data>
+  <data name="flowLayoutPanel3.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="flowLayoutPanel3.WrapContents" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
   <data name="&gt;&gt;flowLayoutPanel3.Name" xml:space="preserve">
     <value>flowLayoutPanel3</value>
   </data>
@@ -6135,4766 +7533,8 @@
   <data name="&gt;&gt;tabAxis.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="&gt;&gt;flowLayoutPanel2.Name" xml:space="preserve">
-    <value>flowLayoutPanel2</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanel2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanel2.Parent" xml:space="preserve">
-    <value>tabGyro</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanel2.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="tabGyro.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="tabGyro.Size" type="System.Drawing.Size, System.Drawing">
-    <value>557, 485</value>
-  </data>
-  <data name="tabGyro.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="tabGyro.Text" xml:space="preserve">
-    <value>Gyro</value>
-  </data>
-  <data name="&gt;&gt;tabGyro.Name" xml:space="preserve">
-    <value>tabGyro</value>
-  </data>
-  <data name="&gt;&gt;tabGyro.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tabGyro.Parent" xml:space="preserve">
-    <value>tabControl1</value>
-  </data>
-  <data name="&gt;&gt;tabGyro.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanel4.Name" xml:space="preserve">
-    <value>flowLayoutPanel4</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanel4.Type" xml:space="preserve">
-    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanel4.Parent" xml:space="preserve">
-    <value>tabOther</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanel4.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="tabOther.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="tabOther.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tabOther.Size" type="System.Drawing.Size, System.Drawing">
-    <value>557, 485</value>
-  </data>
-  <data name="tabOther.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="tabOther.Text" xml:space="preserve">
-    <value>Other</value>
-  </data>
-  <data name="&gt;&gt;tabOther.Name" xml:space="preserve">
-    <value>tabOther</value>
-  </data>
-  <data name="&gt;&gt;tabOther.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tabOther.Parent" xml:space="preserve">
-    <value>tabControl1</value>
-  </data>
-  <data name="&gt;&gt;tabOther.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="tabControl1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="tabControl1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>446, 0</value>
-  </data>
-  <data name="tabControl1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>565, 511</value>
-  </data>
-  <data name="tabControl1.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;tabControl1.Name" xml:space="preserve">
-    <value>tabControl1</value>
-  </data>
-  <data name="&gt;&gt;tabControl1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tabControl1.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;tabControl1.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;lbFull.Name" xml:space="preserve">
-    <value>lbFull</value>
-  </data>
-  <data name="&gt;&gt;lbFull.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbFull.Parent" xml:space="preserve">
-    <value>pnlFull</value>
-  </data>
-  <data name="&gt;&gt;lbFull.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;lbRed.Name" xml:space="preserve">
-    <value>lbRed</value>
-  </data>
-  <data name="&gt;&gt;lbRed.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbRed.Parent" xml:space="preserve">
-    <value>pnlFull</value>
-  </data>
-  <data name="&gt;&gt;lbRed.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;lbGreen.Name" xml:space="preserve">
-    <value>lbGreen</value>
-  </data>
-  <data name="&gt;&gt;lbGreen.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbGreen.Parent" xml:space="preserve">
-    <value>pnlFull</value>
-  </data>
-  <data name="&gt;&gt;lbGreen.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;lbBlue.Name" xml:space="preserve">
-    <value>lbBlue</value>
-  </data>
-  <data name="&gt;&gt;lbBlue.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbBlue.Parent" xml:space="preserve">
-    <value>pnlFull</value>
-  </data>
-  <data name="&gt;&gt;lbBlue.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;tBRedBar.Name" xml:space="preserve">
-    <value>tBRedBar</value>
-  </data>
-  <data name="&gt;&gt;tBRedBar.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TrackBar, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tBRedBar.Parent" xml:space="preserve">
-    <value>pnlFull</value>
-  </data>
-  <data name="&gt;&gt;tBRedBar.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;tBGreenBar.Name" xml:space="preserve">
-    <value>tBGreenBar</value>
-  </data>
-  <data name="&gt;&gt;tBGreenBar.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TrackBar, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tBGreenBar.Parent" xml:space="preserve">
-    <value>pnlFull</value>
-  </data>
-  <data name="&gt;&gt;tBGreenBar.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;tBBlueBar.Name" xml:space="preserve">
-    <value>tBBlueBar</value>
-  </data>
-  <data name="&gt;&gt;tBBlueBar.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TrackBar, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tBBlueBar.Parent" xml:space="preserve">
-    <value>pnlFull</value>
-  </data>
-  <data name="&gt;&gt;tBBlueBar.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="pnlFull.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 1</value>
-  </data>
-  <data name="pnlFull.Size" type="System.Drawing.Size, System.Drawing">
-    <value>134, 96</value>
-  </data>
-  <data name="pnlFull.TabIndex" type="System.Int32, mscorlib">
-    <value>239</value>
-  </data>
-  <data name="&gt;&gt;pnlFull.Name" xml:space="preserve">
-    <value>pnlFull</value>
-  </data>
-  <data name="&gt;&gt;pnlFull.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;pnlFull.Parent" xml:space="preserve">
-    <value>panel1</value>
-  </data>
-  <data name="&gt;&gt;pnlFull.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="lbFull.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lbFull.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lbFull.Location" type="System.Drawing.Point, System.Drawing">
-    <value>7, 7</value>
-  </data>
-  <data name="lbFull.Size" type="System.Drawing.Size, System.Drawing">
-    <value>26, 13</value>
-  </data>
-  <data name="lbFull.TabIndex" type="System.Int32, mscorlib">
-    <value>225</value>
-  </data>
-  <data name="lbFull.Text" xml:space="preserve">
-    <value>Full:</value>
-  </data>
-  <data name="&gt;&gt;lbFull.Name" xml:space="preserve">
-    <value>lbFull</value>
-  </data>
-  <data name="&gt;&gt;lbFull.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbFull.Parent" xml:space="preserve">
-    <value>pnlFull</value>
-  </data>
-  <data name="&gt;&gt;lbFull.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="lbRed.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lbRed.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lbRed.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 27</value>
-  </data>
-  <data name="lbRed.Size" type="System.Drawing.Size, System.Drawing">
-    <value>15, 13</value>
-  </data>
-  <data name="lbRed.TabIndex" type="System.Int32, mscorlib">
-    <value>158</value>
-  </data>
-  <data name="lbRed.Text" xml:space="preserve">
-    <value>R</value>
-  </data>
-  <data name="&gt;&gt;lbRed.Name" xml:space="preserve">
-    <value>lbRed</value>
-  </data>
-  <data name="&gt;&gt;lbRed.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbRed.Parent" xml:space="preserve">
-    <value>pnlFull</value>
-  </data>
-  <data name="&gt;&gt;lbRed.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="lbGreen.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lbGreen.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lbGreen.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 53</value>
-  </data>
-  <data name="lbGreen.Size" type="System.Drawing.Size, System.Drawing">
-    <value>15, 13</value>
-  </data>
-  <data name="lbGreen.TabIndex" type="System.Int32, mscorlib">
-    <value>159</value>
-  </data>
-  <data name="lbGreen.Text" xml:space="preserve">
-    <value>G</value>
-  </data>
-  <data name="&gt;&gt;lbGreen.Name" xml:space="preserve">
-    <value>lbGreen</value>
-  </data>
-  <data name="&gt;&gt;lbGreen.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbGreen.Parent" xml:space="preserve">
-    <value>pnlFull</value>
-  </data>
-  <data name="&gt;&gt;lbGreen.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="lbBlue.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lbBlue.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lbBlue.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 76</value>
-  </data>
-  <data name="lbBlue.Size" type="System.Drawing.Size, System.Drawing">
-    <value>14, 13</value>
-  </data>
-  <data name="lbBlue.TabIndex" type="System.Int32, mscorlib">
-    <value>160</value>
-  </data>
-  <data name="lbBlue.Text" xml:space="preserve">
-    <value>B</value>
-  </data>
-  <data name="&gt;&gt;lbBlue.Name" xml:space="preserve">
-    <value>lbBlue</value>
-  </data>
-  <data name="&gt;&gt;lbBlue.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbBlue.Parent" xml:space="preserve">
-    <value>pnlFull</value>
-  </data>
-  <data name="&gt;&gt;lbBlue.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="tBRedBar.AutoSize" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="tBRedBar.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="tBRedBar.Location" type="System.Drawing.Point, System.Drawing">
-    <value>26, 24</value>
-  </data>
-  <data name="tBRedBar.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 20</value>
-  </data>
-  <data name="tBRedBar.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
-  </data>
-  <data name="&gt;&gt;tBRedBar.Name" xml:space="preserve">
-    <value>tBRedBar</value>
-  </data>
-  <data name="&gt;&gt;tBRedBar.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TrackBar, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tBRedBar.Parent" xml:space="preserve">
-    <value>pnlFull</value>
-  </data>
-  <data name="&gt;&gt;tBRedBar.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="tBGreenBar.AutoSize" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="tBGreenBar.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="tBGreenBar.Location" type="System.Drawing.Point, System.Drawing">
-    <value>26, 50</value>
-  </data>
-  <data name="tBGreenBar.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 20</value>
-  </data>
-  <data name="tBGreenBar.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
-  </data>
-  <data name="&gt;&gt;tBGreenBar.Name" xml:space="preserve">
-    <value>tBGreenBar</value>
-  </data>
-  <data name="&gt;&gt;tBGreenBar.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TrackBar, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tBGreenBar.Parent" xml:space="preserve">
-    <value>pnlFull</value>
-  </data>
-  <data name="&gt;&gt;tBGreenBar.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="tBBlueBar.AutoSize" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="tBBlueBar.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="tBBlueBar.Location" type="System.Drawing.Point, System.Drawing">
-    <value>26, 73</value>
-  </data>
-  <data name="tBBlueBar.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 20</value>
-  </data>
-  <data name="tBBlueBar.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
-  </data>
-  <data name="&gt;&gt;tBBlueBar.Name" xml:space="preserve">
-    <value>tBBlueBar</value>
-  </data>
-  <data name="&gt;&gt;tBBlueBar.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TrackBar, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tBBlueBar.Parent" xml:space="preserve">
-    <value>pnlFull</value>
-  </data>
-  <data name="&gt;&gt;tBBlueBar.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;lowColorChooserButton.Name" xml:space="preserve">
-    <value>lowColorChooserButton</value>
-  </data>
-  <data name="&gt;&gt;lowColorChooserButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lowColorChooserButton.Parent" xml:space="preserve">
-    <value>pnlLowBattery</value>
-  </data>
-  <data name="&gt;&gt;lowColorChooserButton.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;lbLowRed.Name" xml:space="preserve">
-    <value>lbLowRed</value>
-  </data>
-  <data name="&gt;&gt;lbLowRed.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbLowRed.Parent" xml:space="preserve">
-    <value>pnlLowBattery</value>
-  </data>
-  <data name="&gt;&gt;lbLowRed.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;lbLowGreen.Name" xml:space="preserve">
-    <value>lbLowGreen</value>
-  </data>
-  <data name="&gt;&gt;lbLowGreen.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbLowGreen.Parent" xml:space="preserve">
-    <value>pnlLowBattery</value>
-  </data>
-  <data name="&gt;&gt;lbLowGreen.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;lbLowBlue.Name" xml:space="preserve">
-    <value>lbLowBlue</value>
-  </data>
-  <data name="&gt;&gt;lbLowBlue.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbLowBlue.Parent" xml:space="preserve">
-    <value>pnlLowBattery</value>
-  </data>
-  <data name="&gt;&gt;lbLowBlue.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;tBLowRedBar.Name" xml:space="preserve">
-    <value>tBLowRedBar</value>
-  </data>
-  <data name="&gt;&gt;tBLowRedBar.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TrackBar, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tBLowRedBar.Parent" xml:space="preserve">
-    <value>pnlLowBattery</value>
-  </data>
-  <data name="&gt;&gt;tBLowRedBar.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;tBLowGreenBar.Name" xml:space="preserve">
-    <value>tBLowGreenBar</value>
-  </data>
-  <data name="&gt;&gt;tBLowGreenBar.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TrackBar, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tBLowGreenBar.Parent" xml:space="preserve">
-    <value>pnlLowBattery</value>
-  </data>
-  <data name="&gt;&gt;tBLowGreenBar.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;tBLowBlueBar.Name" xml:space="preserve">
-    <value>tBLowBlueBar</value>
-  </data>
-  <data name="&gt;&gt;tBLowBlueBar.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TrackBar, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tBLowBlueBar.Parent" xml:space="preserve">
-    <value>pnlLowBattery</value>
-  </data>
-  <data name="&gt;&gt;tBLowBlueBar.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;lbEmpty.Name" xml:space="preserve">
-    <value>lbEmpty</value>
-  </data>
-  <data name="&gt;&gt;lbEmpty.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbEmpty.Parent" xml:space="preserve">
-    <value>pnlLowBattery</value>
-  </data>
-  <data name="&gt;&gt;lbEmpty.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="pnlLowBattery.Location" type="System.Drawing.Point, System.Drawing">
-    <value>160, 0</value>
-  </data>
-  <data name="pnlLowBattery.Size" type="System.Drawing.Size, System.Drawing">
-    <value>126, 97</value>
-  </data>
-  <data name="pnlLowBattery.TabIndex" type="System.Int32, mscorlib">
-    <value>238</value>
-  </data>
-  <data name="&gt;&gt;pnlLowBattery.Name" xml:space="preserve">
-    <value>pnlLowBattery</value>
-  </data>
-  <data name="&gt;&gt;pnlLowBattery.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;pnlLowBattery.Parent" xml:space="preserve">
-    <value>panel1</value>
-  </data>
-  <data name="&gt;&gt;pnlLowBattery.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="lowColorChooserButton.FlatStyle" type="System.Windows.Forms.FlatStyle, System.Windows.Forms">
-    <value>Flat</value>
-  </data>
-  <data name="lowColorChooserButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lowColorChooserButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>44, 9</value>
-  </data>
-  <data name="lowColorChooserButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>13, 13</value>
-  </data>
-  <data name="lowColorChooserButton.TabIndex" type="System.Int32, mscorlib">
-    <value>49</value>
-  </data>
-  <data name="&gt;&gt;lowColorChooserButton.Name" xml:space="preserve">
-    <value>lowColorChooserButton</value>
-  </data>
-  <data name="&gt;&gt;lowColorChooserButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lowColorChooserButton.Parent" xml:space="preserve">
-    <value>pnlLowBattery</value>
-  </data>
-  <data name="&gt;&gt;lowColorChooserButton.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="lbLowRed.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lbLowRed.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lbLowRed.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 30</value>
-  </data>
-  <data name="lbLowRed.Size" type="System.Drawing.Size, System.Drawing">
-    <value>15, 13</value>
-  </data>
-  <data name="lbLowRed.TabIndex" type="System.Int32, mscorlib">
-    <value>158</value>
-  </data>
-  <data name="lbLowRed.Text" xml:space="preserve">
-    <value>R</value>
-  </data>
-  <data name="&gt;&gt;lbLowRed.Name" xml:space="preserve">
-    <value>lbLowRed</value>
-  </data>
-  <data name="&gt;&gt;lbLowRed.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbLowRed.Parent" xml:space="preserve">
-    <value>pnlLowBattery</value>
-  </data>
-  <data name="&gt;&gt;lbLowRed.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="lbLowGreen.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lbLowGreen.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lbLowGreen.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 53</value>
-  </data>
-  <data name="lbLowGreen.Size" type="System.Drawing.Size, System.Drawing">
-    <value>15, 13</value>
-  </data>
-  <data name="lbLowGreen.TabIndex" type="System.Int32, mscorlib">
-    <value>159</value>
-  </data>
-  <data name="lbLowGreen.Text" xml:space="preserve">
-    <value>G</value>
-  </data>
-  <data name="&gt;&gt;lbLowGreen.Name" xml:space="preserve">
-    <value>lbLowGreen</value>
-  </data>
-  <data name="&gt;&gt;lbLowGreen.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbLowGreen.Parent" xml:space="preserve">
-    <value>pnlLowBattery</value>
-  </data>
-  <data name="&gt;&gt;lbLowGreen.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="lbLowBlue.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lbLowBlue.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lbLowBlue.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 76</value>
-  </data>
-  <data name="lbLowBlue.Size" type="System.Drawing.Size, System.Drawing">
-    <value>14, 13</value>
-  </data>
-  <data name="lbLowBlue.TabIndex" type="System.Int32, mscorlib">
-    <value>160</value>
-  </data>
-  <data name="lbLowBlue.Text" xml:space="preserve">
-    <value>B</value>
-  </data>
-  <data name="&gt;&gt;lbLowBlue.Name" xml:space="preserve">
-    <value>lbLowBlue</value>
-  </data>
-  <data name="&gt;&gt;lbLowBlue.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbLowBlue.Parent" xml:space="preserve">
-    <value>pnlLowBattery</value>
-  </data>
-  <data name="&gt;&gt;lbLowBlue.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="tBLowRedBar.AutoSize" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="tBLowRedBar.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="tBLowRedBar.Location" type="System.Drawing.Point, System.Drawing">
-    <value>22, 26</value>
-  </data>
-  <data name="tBLowRedBar.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 20</value>
-  </data>
-  <data name="tBLowRedBar.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
-  </data>
-  <data name="&gt;&gt;tBLowRedBar.Name" xml:space="preserve">
-    <value>tBLowRedBar</value>
-  </data>
-  <data name="&gt;&gt;tBLowRedBar.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TrackBar, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tBLowRedBar.Parent" xml:space="preserve">
-    <value>pnlLowBattery</value>
-  </data>
-  <data name="&gt;&gt;tBLowRedBar.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="tBLowGreenBar.AutoSize" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="tBLowGreenBar.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="tBLowGreenBar.Location" type="System.Drawing.Point, System.Drawing">
-    <value>22, 49</value>
-  </data>
-  <data name="tBLowGreenBar.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 20</value>
-  </data>
-  <data name="tBLowGreenBar.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
-  </data>
-  <data name="&gt;&gt;tBLowGreenBar.Name" xml:space="preserve">
-    <value>tBLowGreenBar</value>
-  </data>
-  <data name="&gt;&gt;tBLowGreenBar.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TrackBar, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tBLowGreenBar.Parent" xml:space="preserve">
-    <value>pnlLowBattery</value>
-  </data>
-  <data name="&gt;&gt;tBLowGreenBar.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="tBLowBlueBar.AutoSize" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="tBLowBlueBar.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="tBLowBlueBar.Location" type="System.Drawing.Point, System.Drawing">
-    <value>22, 72</value>
-  </data>
-  <data name="tBLowBlueBar.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 20</value>
-  </data>
-  <data name="tBLowBlueBar.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
-  </data>
-  <data name="&gt;&gt;tBLowBlueBar.Name" xml:space="preserve">
-    <value>tBLowBlueBar</value>
-  </data>
-  <data name="&gt;&gt;tBLowBlueBar.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TrackBar, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tBLowBlueBar.Parent" xml:space="preserve">
-    <value>pnlLowBattery</value>
-  </data>
-  <data name="&gt;&gt;tBLowBlueBar.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="lbEmpty.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lbEmpty.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lbEmpty.Location" type="System.Drawing.Point, System.Drawing">
-    <value>7, 9</value>
-  </data>
-  <data name="lbEmpty.Size" type="System.Drawing.Size, System.Drawing">
-    <value>39, 13</value>
-  </data>
-  <data name="lbEmpty.TabIndex" type="System.Int32, mscorlib">
-    <value>225</value>
-  </data>
-  <data name="lbEmpty.Text" xml:space="preserve">
-    <value>Empty:</value>
-  </data>
-  <data name="&gt;&gt;lbEmpty.Name" xml:space="preserve">
-    <value>lbEmpty</value>
-  </data>
-  <data name="&gt;&gt;lbEmpty.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbEmpty.Parent" xml:space="preserve">
-    <value>pnlLowBattery</value>
-  </data>
-  <data name="&gt;&gt;lbEmpty.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="cBFlashType.Items" xml:space="preserve">
-    <value>Flash at</value>
-  </data>
-  <data name="cBFlashType.Items1" xml:space="preserve">
-    <value>Pulse at</value>
-  </data>
-  <data name="cBFlashType.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 10</value>
-  </data>
-  <data name="cBFlashType.Size" type="System.Drawing.Size, System.Drawing">
-    <value>68, 21</value>
-  </data>
-  <data name="cBFlashType.TabIndex" type="System.Int32, mscorlib">
-    <value>244</value>
-  </data>
-  <data name="&gt;&gt;cBFlashType.Name" xml:space="preserve">
-    <value>cBFlashType</value>
-  </data>
-  <data name="&gt;&gt;cBFlashType.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cBFlashType.Parent" xml:space="preserve">
-    <value>panel3</value>
-  </data>
-  <data name="&gt;&gt;cBFlashType.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="btnFlashColor.BackgroundImageLayout" type="System.Windows.Forms.ImageLayout, System.Windows.Forms">
-    <value>Zoom</value>
-  </data>
-  <data name="btnFlashColor.FlatStyle" type="System.Windows.Forms.FlatStyle, System.Windows.Forms">
-    <value>Flat</value>
-  </data>
-  <data name="btnFlashColor.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="btnFlashColor.Location" type="System.Drawing.Point, System.Drawing">
-    <value>152, 14</value>
-  </data>
-  <data name="btnFlashColor.Size" type="System.Drawing.Size, System.Drawing">
-    <value>13, 13</value>
-  </data>
-  <data name="btnFlashColor.TabIndex" type="System.Int32, mscorlib">
-    <value>241</value>
-  </data>
-  <data name="&gt;&gt;btnFlashColor.Name" xml:space="preserve">
-    <value>btnFlashColor</value>
-  </data>
-  <data name="&gt;&gt;btnFlashColor.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnFlashColor.Parent" xml:space="preserve">
-    <value>panel3</value>
-  </data>
-  <data name="&gt;&gt;btnFlashColor.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="lbPercentFlashBar.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lbPercentFlashBar.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lbPercentFlashBar.Location" type="System.Drawing.Point, System.Drawing">
-    <value>133, 14</value>
-  </data>
-  <data name="lbPercentFlashBar.Size" type="System.Drawing.Size, System.Drawing">
-    <value>15, 13</value>
-  </data>
-  <data name="lbPercentFlashBar.TabIndex" type="System.Int32, mscorlib">
-    <value>243</value>
-  </data>
-  <data name="lbPercentFlashBar.Text" xml:space="preserve">
-    <value>%</value>
-  </data>
-  <data name="&gt;&gt;lbPercentFlashBar.Name" xml:space="preserve">
-    <value>lbPercentFlashBar</value>
-  </data>
-  <data name="&gt;&gt;lbPercentFlashBar.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbPercentFlashBar.Parent" xml:space="preserve">
-    <value>panel3</value>
-  </data>
-  <data name="&gt;&gt;lbPercentFlashBar.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="nUDflashLED.Location" type="System.Drawing.Point, System.Drawing">
-    <value>84, 11</value>
-  </data>
-  <data name="nUDflashLED.Size" type="System.Drawing.Size, System.Drawing">
-    <value>43, 20</value>
-  </data>
-  <data name="nUDflashLED.TabIndex" type="System.Int32, mscorlib">
-    <value>242</value>
-  </data>
-  <data name="&gt;&gt;nUDflashLED.Name" xml:space="preserve">
-    <value>nUDflashLED</value>
-  </data>
-  <data name="&gt;&gt;nUDflashLED.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDflashLED.Parent" xml:space="preserve">
-    <value>panel3</value>
-  </data>
-  <data name="&gt;&gt;nUDflashLED.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="cBWhileCharging.Items" xml:space="preserve">
-    <value>Normal</value>
-  </data>
-  <data name="cBWhileCharging.Items1" xml:space="preserve">
-    <value>Pulse</value>
-  </data>
-  <data name="cBWhileCharging.Items2" xml:space="preserve">
-    <value>Rainbow</value>
-  </data>
-  <data name="cBWhileCharging.Items3" xml:space="preserve">
-    <value>Color</value>
-  </data>
-  <data name="cBWhileCharging.Location" type="System.Drawing.Point, System.Drawing">
-    <value>96, 11</value>
-  </data>
-  <data name="cBWhileCharging.Size" type="System.Drawing.Size, System.Drawing">
-    <value>121, 21</value>
-  </data>
-  <data name="cBWhileCharging.TabIndex" type="System.Int32, mscorlib">
-    <value>242</value>
-  </data>
-  <data name="&gt;&gt;cBWhileCharging.Name" xml:space="preserve">
-    <value>cBWhileCharging</value>
-  </data>
-  <data name="&gt;&gt;cBWhileCharging.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cBWhileCharging.Parent" xml:space="preserve">
-    <value>panel4</value>
-  </data>
-  <data name="&gt;&gt;cBWhileCharging.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="btnChargingColor.FlatStyle" type="System.Windows.Forms.FlatStyle, System.Windows.Forms">
-    <value>Flat</value>
-  </data>
-  <data name="btnChargingColor.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="btnChargingColor.Location" type="System.Drawing.Point, System.Drawing">
-    <value>223, 13</value>
-  </data>
-  <data name="btnChargingColor.Size" type="System.Drawing.Size, System.Drawing">
-    <value>13, 13</value>
-  </data>
-  <data name="btnChargingColor.TabIndex" type="System.Int32, mscorlib">
-    <value>240</value>
-  </data>
-  <data name="btnChargingColor.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="&gt;&gt;btnChargingColor.Name" xml:space="preserve">
-    <value>btnChargingColor</value>
-  </data>
-  <data name="&gt;&gt;btnChargingColor.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnChargingColor.Parent" xml:space="preserve">
-    <value>panel4</value>
-  </data>
-  <data name="&gt;&gt;btnChargingColor.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="lbWhileCharging.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lbWhileCharging.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lbWhileCharging.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 12</value>
-  </data>
-  <data name="lbWhileCharging.Size" type="System.Drawing.Size, System.Drawing">
-    <value>82, 13</value>
-  </data>
-  <data name="lbWhileCharging.TabIndex" type="System.Int32, mscorlib">
-    <value>241</value>
-  </data>
-  <data name="lbWhileCharging.Text" xml:space="preserve">
-    <value>While Charging:</value>
-  </data>
-  <data name="&gt;&gt;lbWhileCharging.Name" xml:space="preserve">
-    <value>lbWhileCharging</value>
-  </data>
-  <data name="&gt;&gt;lbWhileCharging.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbWhileCharging.Parent" xml:space="preserve">
-    <value>panel4</value>
-  </data>
-  <data name="&gt;&gt;lbWhileCharging.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="flowLayoutPanel3.AutoScroll" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;groupBox1.Name" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;groupBox1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;groupBox1.Parent" xml:space="preserve">
-    <value>flowLayoutPanel3</value>
-  </data>
-  <data name="&gt;&gt;groupBox1.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;groupBox2.Name" xml:space="preserve">
-    <value>groupBox2</value>
-  </data>
-  <data name="&gt;&gt;groupBox2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;groupBox2.Parent" xml:space="preserve">
-    <value>flowLayoutPanel3</value>
-  </data>
-  <data name="&gt;&gt;groupBox2.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;groupBox3.Name" xml:space="preserve">
-    <value>groupBox3</value>
-  </data>
-  <data name="&gt;&gt;groupBox3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;groupBox3.Parent" xml:space="preserve">
-    <value>flowLayoutPanel3</value>
-  </data>
-  <data name="&gt;&gt;groupBox3.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;groupBox4.Name" xml:space="preserve">
-    <value>groupBox4</value>
-  </data>
-  <data name="&gt;&gt;groupBox4.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;groupBox4.Parent" xml:space="preserve">
-    <value>flowLayoutPanel3</value>
-  </data>
-  <data name="&gt;&gt;groupBox4.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;groupBox5.Name" xml:space="preserve">
-    <value>groupBox5</value>
-  </data>
-  <data name="&gt;&gt;groupBox5.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;groupBox5.Parent" xml:space="preserve">
-    <value>flowLayoutPanel3</value>
-  </data>
-  <data name="&gt;&gt;groupBox5.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="flowLayoutPanel3.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="flowLayoutPanel3.FlowDirection" type="System.Windows.Forms.FlowDirection, System.Windows.Forms">
-    <value>TopDown</value>
-  </data>
-  <data name="flowLayoutPanel3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 3</value>
-  </data>
-  <data name="flowLayoutPanel3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>551, 479</value>
-  </data>
-  <data name="flowLayoutPanel3.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="flowLayoutPanel3.WrapContents" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanel3.Name" xml:space="preserve">
-    <value>flowLayoutPanel3</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanel3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanel3.Parent" xml:space="preserve">
-    <value>tabAxis</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanel3.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;tBCustomOutputCurve.Name" xml:space="preserve">
-    <value>tBCustomOutputCurve</value>
-  </data>
-  <data name="&gt;&gt;tBCustomOutputCurve.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tBCustomOutputCurve.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;tBCustomOutputCurve.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;lbCurveEditorURL.Name" xml:space="preserve">
-    <value>lbCurveEditorURL</value>
-  </data>
-  <data name="&gt;&gt;lbCurveEditorURL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbCurveEditorURL.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;lbCurveEditorURL.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;nUDLSS.Name" xml:space="preserve">
-    <value>nUDLSS</value>
-  </data>
-  <data name="&gt;&gt;nUDLSS.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDLSS.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;nUDLSS.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;label69.Name" xml:space="preserve">
-    <value>label69</value>
-  </data>
-  <data name="&gt;&gt;label69.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label69.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;label69.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;label46.Name" xml:space="preserve">
-    <value>label46</value>
-  </data>
-  <data name="&gt;&gt;label46.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label46.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;label46.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;RoundnessNUpDown.Name" xml:space="preserve">
-    <value>RoundnessNUpDown</value>
-  </data>
-  <data name="&gt;&gt;RoundnessNUpDown.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;RoundnessNUpDown.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;RoundnessNUpDown.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;lsSquStickCk.Name" xml:space="preserve">
-    <value>lsSquStickCk</value>
-  </data>
-  <data name="&gt;&gt;lsSquStickCk.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lsSquStickCk.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;lsSquStickCk.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;nUDLSRotation.Name" xml:space="preserve">
-    <value>nUDLSRotation</value>
-  </data>
-  <data name="&gt;&gt;nUDLSRotation.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDLSRotation.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;nUDLSRotation.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="&gt;&gt;label45.Name" xml:space="preserve">
-    <value>label45</value>
-  </data>
-  <data name="&gt;&gt;label45.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label45.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;label45.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;nUDLSCurve.Name" xml:space="preserve">
-    <value>nUDLSCurve</value>
-  </data>
-  <data name="&gt;&gt;nUDLSCurve.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDLSCurve.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;nUDLSCurve.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="&gt;&gt;lbLSCurvePercent.Name" xml:space="preserve">
-    <value>lbLSCurvePercent</value>
-  </data>
-  <data name="&gt;&gt;lbLSCurvePercent.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbLSCurvePercent.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;lbLSCurvePercent.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="&gt;&gt;label44.Name" xml:space="preserve">
-    <value>label44</value>
-  </data>
-  <data name="&gt;&gt;label44.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label44.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;label44.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
-  <data name="&gt;&gt;lsOutCurveComboBox.Name" xml:space="preserve">
-    <value>lsOutCurveComboBox</value>
-  </data>
-  <data name="&gt;&gt;lsOutCurveComboBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lsOutCurveComboBox.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;lsOutCurveComboBox.ZOrder" xml:space="preserve">
-    <value>12</value>
-  </data>
-  <data name="&gt;&gt;label43.Name" xml:space="preserve">
-    <value>label43</value>
-  </data>
-  <data name="&gt;&gt;label43.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label43.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;label43.ZOrder" xml:space="preserve">
-    <value>13</value>
-  </data>
-  <data name="&gt;&gt;nUDLSAntiDead.Name" xml:space="preserve">
-    <value>nUDLSAntiDead</value>
-  </data>
-  <data name="&gt;&gt;nUDLSAntiDead.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDLSAntiDead.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;nUDLSAntiDead.ZOrder" xml:space="preserve">
-    <value>14</value>
-  </data>
-  <data name="&gt;&gt;label42.Name" xml:space="preserve">
-    <value>label42</value>
-  </data>
-  <data name="&gt;&gt;label42.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label42.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;label42.ZOrder" xml:space="preserve">
-    <value>15</value>
-  </data>
-  <data name="&gt;&gt;nUDLSMaxZone.Name" xml:space="preserve">
-    <value>nUDLSMaxZone</value>
-  </data>
-  <data name="&gt;&gt;nUDLSMaxZone.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDLSMaxZone.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;nUDLSMaxZone.ZOrder" xml:space="preserve">
-    <value>16</value>
-  </data>
-  <data name="&gt;&gt;label41.Name" xml:space="preserve">
-    <value>label41</value>
-  </data>
-  <data name="&gt;&gt;label41.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label41.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;label41.ZOrder" xml:space="preserve">
-    <value>17</value>
-  </data>
-  <data name="&gt;&gt;nUDLS.Name" xml:space="preserve">
-    <value>nUDLS</value>
-  </data>
-  <data name="&gt;&gt;nUDLS.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDLS.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;nUDLS.ZOrder" xml:space="preserve">
-    <value>18</value>
-  </data>
-  <data name="&gt;&gt;label40.Name" xml:space="preserve">
-    <value>label40</value>
-  </data>
-  <data name="&gt;&gt;label40.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label40.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;label40.ZOrder" xml:space="preserve">
-    <value>19</value>
-  </data>
-  <data name="groupBox1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 3</value>
-  </data>
-  <data name="groupBox1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>424, 316</value>
-  </data>
-  <data name="groupBox1.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="groupBox1.Text" xml:space="preserve">
-    <value>LS</value>
-  </data>
-  <data name="&gt;&gt;groupBox1.Name" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;groupBox1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;groupBox1.Parent" xml:space="preserve">
-    <value>flowLayoutPanel3</value>
-  </data>
-  <data name="&gt;&gt;groupBox1.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="tBCustomOutputCurve.Location" type="System.Drawing.Point, System.Drawing">
-    <value>104, 181</value>
-  </data>
-  <data name="tBCustomOutputCurve.Size" type="System.Drawing.Size, System.Drawing">
-    <value>149, 20</value>
-  </data>
-  <data name="tBCustomOutputCurve.TabIndex" type="System.Int32, mscorlib">
-    <value>225</value>
-  </data>
-  <data name="tBCustomOutputCurve.Text" xml:space="preserve">
-    <value>0.00, 0.00, 1.00, 1.00</value>
-  </data>
-  <data name="&gt;&gt;tBCustomOutputCurve.Name" xml:space="preserve">
-    <value>tBCustomOutputCurve</value>
-  </data>
-  <data name="&gt;&gt;tBCustomOutputCurve.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tBCustomOutputCurve.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;tBCustomOutputCurve.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="lbCurveEditorURL.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lbCurveEditorURL.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lbCurveEditorURL.Location" type="System.Drawing.Point, System.Drawing">
-    <value>276, 185</value>
-  </data>
-  <data name="lbCurveEditorURL.Size" type="System.Drawing.Size, System.Drawing">
-    <value>101, 13</value>
-  </data>
-  <data name="lbCurveEditorURL.TabIndex" type="System.Int32, mscorlib">
-    <value>224</value>
-  </data>
-  <data name="lbCurveEditorURL.Text" xml:space="preserve">
-    <value>Custom curve editor</value>
-  </data>
-  <data name="&gt;&gt;lbCurveEditorURL.Name" xml:space="preserve">
-    <value>lbCurveEditorURL</value>
-  </data>
-  <data name="&gt;&gt;lbCurveEditorURL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbCurveEditorURL.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;lbCurveEditorURL.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="nUDLSS.Location" type="System.Drawing.Point, System.Drawing">
-    <value>105, 107</value>
-  </data>
-  <data name="nUDLSS.RightToLeft" type="System.Windows.Forms.RightToLeft, System.Windows.Forms">
-    <value>No</value>
-  </data>
-  <data name="nUDLSS.Size" type="System.Drawing.Size, System.Drawing">
-    <value>59, 20</value>
-  </data>
-  <data name="nUDLSS.TabIndex" type="System.Int32, mscorlib">
-    <value>223</value>
-  </data>
-  <data name="&gt;&gt;nUDLSS.Name" xml:space="preserve">
-    <value>nUDLSS</value>
-  </data>
-  <data name="&gt;&gt;nUDLSS.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDLSS.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;nUDLSS.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="label69.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label69.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 104</value>
-  </data>
-  <data name="label69.Size" type="System.Drawing.Size, System.Drawing">
-    <value>57, 13</value>
-  </data>
-  <data name="label69.TabIndex" type="System.Int32, mscorlib">
-    <value>222</value>
-  </data>
-  <data name="label69.Text" xml:space="preserve">
-    <value>Sensitivity:</value>
-  </data>
-  <data name="&gt;&gt;label69.Name" xml:space="preserve">
-    <value>label69</value>
-  </data>
-  <data name="&gt;&gt;label69.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label69.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;label69.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="label46.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label46.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label46.Location" type="System.Drawing.Point, System.Drawing">
-    <value>111, 219</value>
-  </data>
-  <data name="label46.Size" type="System.Drawing.Size, System.Drawing">
-    <value>61, 13</value>
-  </data>
-  <data name="label46.TabIndex" type="System.Int32, mscorlib">
-    <value>221</value>
-  </data>
-  <data name="label46.Text" xml:space="preserve">
-    <value>Roundness</value>
-  </data>
-  <data name="&gt;&gt;label46.Name" xml:space="preserve">
-    <value>label46</value>
-  </data>
-  <data name="&gt;&gt;label46.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label46.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;label46.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="RoundnessNUpDown.Location" type="System.Drawing.Point, System.Drawing">
-    <value>190, 217</value>
-  </data>
-  <data name="RoundnessNUpDown.Size" type="System.Drawing.Size, System.Drawing">
-    <value>44, 20</value>
-  </data>
-  <data name="RoundnessNUpDown.TabIndex" type="System.Int32, mscorlib">
-    <value>220</value>
-  </data>
-  <data name="&gt;&gt;RoundnessNUpDown.Name" xml:space="preserve">
-    <value>RoundnessNUpDown</value>
-  </data>
-  <data name="&gt;&gt;RoundnessNUpDown.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;RoundnessNUpDown.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;RoundnessNUpDown.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="lsSquStickCk.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lsSquStickCk.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 215</value>
-  </data>
-  <data name="lsSquStickCk.RightToLeft" type="System.Windows.Forms.RightToLeft, System.Windows.Forms">
-    <value>No</value>
-  </data>
-  <data name="lsSquStickCk.Size" type="System.Drawing.Size, System.Drawing">
-    <value>111, 24</value>
-  </data>
-  <data name="lsSquStickCk.TabIndex" type="System.Int32, mscorlib">
-    <value>219</value>
-  </data>
-  <data name="lsSquStickCk.Text" xml:space="preserve">
-    <value>Square Stick</value>
-  </data>
-  <data name="&gt;&gt;lsSquStickCk.Name" xml:space="preserve">
-    <value>lsSquStickCk</value>
-  </data>
-  <data name="&gt;&gt;lsSquStickCk.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lsSquStickCk.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;lsSquStickCk.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="nUDLSRotation.Location" type="System.Drawing.Point, System.Drawing">
-    <value>96, 275</value>
-  </data>
-  <data name="nUDLSRotation.Size" type="System.Drawing.Size, System.Drawing">
-    <value>68, 20</value>
-  </data>
-  <data name="nUDLSRotation.TabIndex" type="System.Int32, mscorlib">
-    <value>218</value>
-  </data>
-  <data name="&gt;&gt;nUDLSRotation.Name" xml:space="preserve">
-    <value>nUDLSRotation</value>
-  </data>
-  <data name="&gt;&gt;nUDLSRotation.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDLSRotation.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;nUDLSRotation.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="label45.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label45.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 275</value>
-  </data>
-  <data name="label45.Size" type="System.Drawing.Size, System.Drawing">
-    <value>50, 13</value>
-  </data>
-  <data name="label45.TabIndex" type="System.Int32, mscorlib">
-    <value>214</value>
-  </data>
-  <data name="label45.Text" xml:space="preserve">
-    <value>Rotation:</value>
-  </data>
-  <data name="&gt;&gt;label45.Name" xml:space="preserve">
-    <value>label45</value>
-  </data>
-  <data name="&gt;&gt;label45.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label45.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;label45.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="nUDLSCurve.Location" type="System.Drawing.Point, System.Drawing">
-    <value>96, 246</value>
-  </data>
-  <data name="nUDLSCurve.RightToLeft" type="System.Windows.Forms.RightToLeft, System.Windows.Forms">
-    <value>No</value>
-  </data>
-  <data name="nUDLSCurve.Size" type="System.Drawing.Size, System.Drawing">
-    <value>49, 20</value>
-  </data>
-  <data name="nUDLSCurve.TabIndex" type="System.Int32, mscorlib">
-    <value>213</value>
-  </data>
-  <data name="&gt;&gt;nUDLSCurve.Name" xml:space="preserve">
-    <value>nUDLSCurve</value>
-  </data>
-  <data name="&gt;&gt;nUDLSCurve.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDLSCurve.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;nUDLSCurve.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="lbLSCurvePercent.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lbLSCurvePercent.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lbLSCurvePercent.Location" type="System.Drawing.Point, System.Drawing">
-    <value>151, 248</value>
-  </data>
-  <data name="lbLSCurvePercent.Size" type="System.Drawing.Size, System.Drawing">
-    <value>15, 13</value>
-  </data>
-  <data name="lbLSCurvePercent.TabIndex" type="System.Int32, mscorlib">
-    <value>212</value>
-  </data>
-  <data name="lbLSCurvePercent.Text" xml:space="preserve">
-    <value>%</value>
-  </data>
-  <data name="&gt;&gt;lbLSCurvePercent.Name" xml:space="preserve">
-    <value>lbLSCurvePercent</value>
-  </data>
-  <data name="&gt;&gt;lbLSCurvePercent.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbLSCurvePercent.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;lbLSCurvePercent.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="label44.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label44.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 248</value>
-  </data>
-  <data name="label44.Size" type="System.Drawing.Size, System.Drawing">
-    <value>71, 13</value>
-  </data>
-  <data name="label44.TabIndex" type="System.Int32, mscorlib">
-    <value>211</value>
-  </data>
-  <data name="label44.Text" xml:space="preserve">
-    <value>Curve (Input):</value>
-  </data>
-  <data name="&gt;&gt;label44.Name" xml:space="preserve">
-    <value>label44</value>
-  </data>
-  <data name="&gt;&gt;label44.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label44.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;label44.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
-  <data name="lsOutCurveComboBox.Items" xml:space="preserve">
-    <value>Linear</value>
-  </data>
-  <data name="lsOutCurveComboBox.Items1" xml:space="preserve">
-    <value>Enhanced Precision</value>
-  </data>
-  <data name="lsOutCurveComboBox.Items2" xml:space="preserve">
-    <value>Quadratic</value>
-  </data>
-  <data name="lsOutCurveComboBox.Items3" xml:space="preserve">
-    <value>Cubic</value>
-  </data>
-  <data name="lsOutCurveComboBox.Items4" xml:space="preserve">
-    <value>Easeout Quad</value>
-  </data>
-  <data name="lsOutCurveComboBox.Items5" xml:space="preserve">
-    <value>Easeout Cubic</value>
-  </data>
-  <data name="lsOutCurveComboBox.Items6" xml:space="preserve">
-    <value>Custom</value>
-  </data>
-  <data name="lsOutCurveComboBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>104, 141</value>
-  </data>
-  <data name="lsOutCurveComboBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>130, 21</value>
-  </data>
-  <data name="lsOutCurveComboBox.TabIndex" type="System.Int32, mscorlib">
-    <value>210</value>
-  </data>
-  <data name="&gt;&gt;lsOutCurveComboBox.Name" xml:space="preserve">
-    <value>lsOutCurveComboBox</value>
-  </data>
-  <data name="&gt;&gt;lsOutCurveComboBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lsOutCurveComboBox.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;lsOutCurveComboBox.ZOrder" xml:space="preserve">
-    <value>12</value>
-  </data>
-  <data name="label43.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label43.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 141</value>
-  </data>
-  <data name="label43.Size" type="System.Drawing.Size, System.Drawing">
-    <value>73, 13</value>
-  </data>
-  <data name="label43.TabIndex" type="System.Int32, mscorlib">
-    <value>209</value>
-  </data>
-  <data name="label43.Text" xml:space="preserve">
-    <value>Output Curve:</value>
-  </data>
-  <data name="&gt;&gt;label43.Name" xml:space="preserve">
-    <value>label43</value>
-  </data>
-  <data name="&gt;&gt;label43.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label43.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;label43.ZOrder" xml:space="preserve">
-    <value>13</value>
-  </data>
-  <data name="nUDLSAntiDead.Location" type="System.Drawing.Point, System.Drawing">
-    <value>105, 76</value>
-  </data>
-  <data name="nUDLSAntiDead.Size" type="System.Drawing.Size, System.Drawing">
-    <value>59, 20</value>
-  </data>
-  <data name="nUDLSAntiDead.TabIndex" type="System.Int32, mscorlib">
-    <value>208</value>
-  </data>
-  <data name="&gt;&gt;nUDLSAntiDead.Name" xml:space="preserve">
-    <value>nUDLSAntiDead</value>
-  </data>
-  <data name="&gt;&gt;nUDLSAntiDead.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDLSAntiDead.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;nUDLSAntiDead.ZOrder" xml:space="preserve">
-    <value>14</value>
-  </data>
-  <data name="label42.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label42.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 76</value>
-  </data>
-  <data name="label42.Size" type="System.Drawing.Size, System.Drawing">
-    <value>83, 13</value>
-  </data>
-  <data name="label42.TabIndex" type="System.Int32, mscorlib">
-    <value>207</value>
-  </data>
-  <data name="label42.Text" xml:space="preserve">
-    <value>Anti-dead Zone:</value>
-  </data>
-  <data name="&gt;&gt;label42.Name" xml:space="preserve">
-    <value>label42</value>
-  </data>
-  <data name="&gt;&gt;label42.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label42.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;label42.ZOrder" xml:space="preserve">
-    <value>15</value>
-  </data>
-  <data name="nUDLSMaxZone.Location" type="System.Drawing.Point, System.Drawing">
-    <value>105, 45</value>
-  </data>
-  <data name="nUDLSMaxZone.Size" type="System.Drawing.Size, System.Drawing">
-    <value>59, 20</value>
-  </data>
-  <data name="nUDLSMaxZone.TabIndex" type="System.Int32, mscorlib">
-    <value>206</value>
-  </data>
-  <data name="&gt;&gt;nUDLSMaxZone.Name" xml:space="preserve">
-    <value>nUDLSMaxZone</value>
-  </data>
-  <data name="&gt;&gt;nUDLSMaxZone.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDLSMaxZone.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;nUDLSMaxZone.ZOrder" xml:space="preserve">
-    <value>16</value>
-  </data>
-  <data name="label41.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label41.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 47</value>
-  </data>
-  <data name="label41.Size" type="System.Drawing.Size, System.Drawing">
-    <value>58, 13</value>
-  </data>
-  <data name="label41.TabIndex" type="System.Int32, mscorlib">
-    <value>205</value>
-  </data>
-  <data name="label41.Text" xml:space="preserve">
-    <value>Max Zone:</value>
-  </data>
-  <data name="&gt;&gt;label41.Name" xml:space="preserve">
-    <value>label41</value>
-  </data>
-  <data name="&gt;&gt;label41.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label41.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;label41.ZOrder" xml:space="preserve">
-    <value>17</value>
-  </data>
-  <data name="nUDLS.Location" type="System.Drawing.Point, System.Drawing">
-    <value>105, 18</value>
-  </data>
-  <data name="nUDLS.RightToLeft" type="System.Windows.Forms.RightToLeft, System.Windows.Forms">
-    <value>No</value>
-  </data>
-  <data name="nUDLS.Size" type="System.Drawing.Size, System.Drawing">
-    <value>59, 20</value>
-  </data>
-  <data name="nUDLS.TabIndex" type="System.Int32, mscorlib">
-    <value>204</value>
-  </data>
-  <data name="&gt;&gt;nUDLS.Name" xml:space="preserve">
-    <value>nUDLS</value>
-  </data>
-  <data name="&gt;&gt;nUDLS.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDLS.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;nUDLS.ZOrder" xml:space="preserve">
-    <value>18</value>
-  </data>
-  <data name="label40.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label40.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 20</value>
-  </data>
-  <data name="label40.Size" type="System.Drawing.Size, System.Drawing">
-    <value>64, 13</value>
-  </data>
-  <data name="label40.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="label40.Text" xml:space="preserve">
-    <value>Dead Zone:</value>
-  </data>
-  <data name="&gt;&gt;label40.Name" xml:space="preserve">
-    <value>label40</value>
-  </data>
-  <data name="&gt;&gt;label40.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label40.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;label40.ZOrder" xml:space="preserve">
-    <value>19</value>
-  </data>
-  <data name="&gt;&gt;tBRSCustomOutputCurve.Name" xml:space="preserve">
-    <value>tBRSCustomOutputCurve</value>
-  </data>
-  <data name="&gt;&gt;tBRSCustomOutputCurve.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tBRSCustomOutputCurve.Parent" xml:space="preserve">
-    <value>groupBox2</value>
-  </data>
-  <data name="&gt;&gt;tBRSCustomOutputCurve.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;lbRSCurveEditorURL.Name" xml:space="preserve">
-    <value>lbRSCurveEditorURL</value>
-  </data>
-  <data name="&gt;&gt;lbRSCurveEditorURL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbRSCurveEditorURL.Parent" xml:space="preserve">
-    <value>groupBox2</value>
-  </data>
-  <data name="&gt;&gt;lbRSCurveEditorURL.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;nUDRSS.Name" xml:space="preserve">
-    <value>nUDRSS</value>
-  </data>
-  <data name="&gt;&gt;nUDRSS.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDRSS.Parent" xml:space="preserve">
-    <value>groupBox2</value>
-  </data>
-  <data name="&gt;&gt;nUDRSS.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;label70.Name" xml:space="preserve">
-    <value>label70</value>
-  </data>
-  <data name="&gt;&gt;label70.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label70.Parent" xml:space="preserve">
-    <value>groupBox2</value>
-  </data>
-  <data name="&gt;&gt;label70.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;rsOutCurveComboBox.Name" xml:space="preserve">
-    <value>rsOutCurveComboBox</value>
-  </data>
-  <data name="&gt;&gt;rsOutCurveComboBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;rsOutCurveComboBox.Parent" xml:space="preserve">
-    <value>groupBox2</value>
-  </data>
-  <data name="&gt;&gt;rsOutCurveComboBox.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;nUDRSRotation.Name" xml:space="preserve">
-    <value>nUDRSRotation</value>
-  </data>
-  <data name="&gt;&gt;nUDRSRotation.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDRSRotation.Parent" xml:space="preserve">
-    <value>groupBox2</value>
-  </data>
-  <data name="&gt;&gt;nUDRSRotation.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;label52.Name" xml:space="preserve">
-    <value>label52</value>
-  </data>
-  <data name="&gt;&gt;label52.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label52.Parent" xml:space="preserve">
-    <value>groupBox2</value>
-  </data>
-  <data name="&gt;&gt;label52.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;lbRSCurvePercent.Name" xml:space="preserve">
-    <value>lbRSCurvePercent</value>
-  </data>
-  <data name="&gt;&gt;lbRSCurvePercent.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbRSCurvePercent.Parent" xml:space="preserve">
-    <value>groupBox2</value>
-  </data>
-  <data name="&gt;&gt;lbRSCurvePercent.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="&gt;&gt;nUDRSCurve.Name" xml:space="preserve">
-    <value>nUDRSCurve</value>
-  </data>
-  <data name="&gt;&gt;nUDRSCurve.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDRSCurve.Parent" xml:space="preserve">
-    <value>groupBox2</value>
-  </data>
-  <data name="&gt;&gt;nUDRSCurve.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;label51.Name" xml:space="preserve">
-    <value>label51</value>
-  </data>
-  <data name="&gt;&gt;label51.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label51.Parent" xml:space="preserve">
-    <value>groupBox2</value>
-  </data>
-  <data name="&gt;&gt;label51.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="&gt;&gt;rsSquStickCk.Name" xml:space="preserve">
-    <value>rsSquStickCk</value>
-  </data>
-  <data name="&gt;&gt;rsSquStickCk.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;rsSquStickCk.Parent" xml:space="preserve">
-    <value>groupBox2</value>
-  </data>
-  <data name="&gt;&gt;rsSquStickCk.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="&gt;&gt;numericUpDown1.Name" xml:space="preserve">
-    <value>numericUpDown1</value>
-  </data>
-  <data name="&gt;&gt;numericUpDown1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;numericUpDown1.Parent" xml:space="preserve">
-    <value>groupBox2</value>
-  </data>
-  <data name="&gt;&gt;numericUpDown1.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
-  <data name="&gt;&gt;label28.Name" xml:space="preserve">
-    <value>label28</value>
-  </data>
-  <data name="&gt;&gt;label28.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label28.Parent" xml:space="preserve">
-    <value>groupBox2</value>
-  </data>
-  <data name="&gt;&gt;label28.ZOrder" xml:space="preserve">
-    <value>12</value>
-  </data>
-  <data name="&gt;&gt;label50.Name" xml:space="preserve">
-    <value>label50</value>
-  </data>
-  <data name="&gt;&gt;label50.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label50.Parent" xml:space="preserve">
-    <value>groupBox2</value>
-  </data>
-  <data name="&gt;&gt;label50.ZOrder" xml:space="preserve">
-    <value>13</value>
-  </data>
-  <data name="&gt;&gt;nUDRSAntiDead.Name" xml:space="preserve">
-    <value>nUDRSAntiDead</value>
-  </data>
-  <data name="&gt;&gt;nUDRSAntiDead.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDRSAntiDead.Parent" xml:space="preserve">
-    <value>groupBox2</value>
-  </data>
-  <data name="&gt;&gt;nUDRSAntiDead.ZOrder" xml:space="preserve">
-    <value>14</value>
-  </data>
-  <data name="&gt;&gt;label49.Name" xml:space="preserve">
-    <value>label49</value>
-  </data>
-  <data name="&gt;&gt;label49.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label49.Parent" xml:space="preserve">
-    <value>groupBox2</value>
-  </data>
-  <data name="&gt;&gt;label49.ZOrder" xml:space="preserve">
-    <value>15</value>
-  </data>
-  <data name="&gt;&gt;nUDRSMaxZone.Name" xml:space="preserve">
-    <value>nUDRSMaxZone</value>
-  </data>
-  <data name="&gt;&gt;nUDRSMaxZone.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDRSMaxZone.Parent" xml:space="preserve">
-    <value>groupBox2</value>
-  </data>
-  <data name="&gt;&gt;nUDRSMaxZone.ZOrder" xml:space="preserve">
-    <value>16</value>
-  </data>
-  <data name="&gt;&gt;label48.Name" xml:space="preserve">
-    <value>label48</value>
-  </data>
-  <data name="&gt;&gt;label48.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label48.Parent" xml:space="preserve">
-    <value>groupBox2</value>
-  </data>
-  <data name="&gt;&gt;label48.ZOrder" xml:space="preserve">
-    <value>17</value>
-  </data>
-  <data name="&gt;&gt;nUDRS.Name" xml:space="preserve">
-    <value>nUDRS</value>
-  </data>
-  <data name="&gt;&gt;nUDRS.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDRS.Parent" xml:space="preserve">
-    <value>groupBox2</value>
-  </data>
-  <data name="&gt;&gt;nUDRS.ZOrder" xml:space="preserve">
-    <value>18</value>
-  </data>
-  <data name="&gt;&gt;label47.Name" xml:space="preserve">
-    <value>label47</value>
-  </data>
-  <data name="&gt;&gt;label47.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label47.Parent" xml:space="preserve">
-    <value>groupBox2</value>
-  </data>
-  <data name="&gt;&gt;label47.ZOrder" xml:space="preserve">
-    <value>19</value>
-  </data>
-  <data name="groupBox2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 325</value>
-  </data>
-  <data name="groupBox2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>424, 318</value>
-  </data>
-  <data name="groupBox2.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="groupBox2.Text" xml:space="preserve">
-    <value>RS</value>
-  </data>
-  <data name="&gt;&gt;groupBox2.Name" xml:space="preserve">
-    <value>groupBox2</value>
-  </data>
-  <data name="&gt;&gt;groupBox2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;groupBox2.Parent" xml:space="preserve">
-    <value>flowLayoutPanel3</value>
-  </data>
-  <data name="&gt;&gt;groupBox2.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="tBRSCustomOutputCurve.Location" type="System.Drawing.Point, System.Drawing">
-    <value>99, 195</value>
-  </data>
-  <data name="tBRSCustomOutputCurve.Size" type="System.Drawing.Size, System.Drawing">
-    <value>149, 20</value>
-  </data>
-  <data name="tBRSCustomOutputCurve.TabIndex" type="System.Int32, mscorlib">
-    <value>232</value>
-  </data>
-  <data name="tBRSCustomOutputCurve.Text" xml:space="preserve">
-    <value>0.00, 0.00, 1.00, 1.00</value>
-  </data>
-  <data name="&gt;&gt;tBRSCustomOutputCurve.Name" xml:space="preserve">
-    <value>tBRSCustomOutputCurve</value>
-  </data>
-  <data name="&gt;&gt;tBRSCustomOutputCurve.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tBRSCustomOutputCurve.Parent" xml:space="preserve">
-    <value>groupBox2</value>
-  </data>
-  <data name="&gt;&gt;tBRSCustomOutputCurve.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="lbRSCurveEditorURL.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lbRSCurveEditorURL.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lbRSCurveEditorURL.Location" type="System.Drawing.Point, System.Drawing">
-    <value>271, 199</value>
-  </data>
-  <data name="lbRSCurveEditorURL.Size" type="System.Drawing.Size, System.Drawing">
-    <value>101, 13</value>
-  </data>
-  <data name="lbRSCurveEditorURL.TabIndex" type="System.Int32, mscorlib">
-    <value>231</value>
-  </data>
-  <data name="lbRSCurveEditorURL.Text" xml:space="preserve">
-    <value>Custom curve editor</value>
-  </data>
-  <data name="&gt;&gt;lbRSCurveEditorURL.Name" xml:space="preserve">
-    <value>lbRSCurveEditorURL</value>
-  </data>
-  <data name="&gt;&gt;lbRSCurveEditorURL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbRSCurveEditorURL.Parent" xml:space="preserve">
-    <value>groupBox2</value>
-  </data>
-  <data name="&gt;&gt;lbRSCurveEditorURL.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="nUDRSS.Location" type="System.Drawing.Point, System.Drawing">
-    <value>102, 117</value>
-  </data>
-  <data name="nUDRSS.RightToLeft" type="System.Windows.Forms.RightToLeft, System.Windows.Forms">
-    <value>No</value>
-  </data>
-  <data name="nUDRSS.Size" type="System.Drawing.Size, System.Drawing">
-    <value>64, 20</value>
-  </data>
-  <data name="nUDRSS.TabIndex" type="System.Int32, mscorlib">
-    <value>230</value>
-  </data>
-  <data name="&gt;&gt;nUDRSS.Name" xml:space="preserve">
-    <value>nUDRSS</value>
-  </data>
-  <data name="&gt;&gt;nUDRSS.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDRSS.Parent" xml:space="preserve">
-    <value>groupBox2</value>
-  </data>
-  <data name="&gt;&gt;nUDRSS.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="label70.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label70.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label70.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 119</value>
-  </data>
-  <data name="label70.Size" type="System.Drawing.Size, System.Drawing">
-    <value>57, 13</value>
-  </data>
-  <data name="label70.TabIndex" type="System.Int32, mscorlib">
-    <value>229</value>
-  </data>
-  <data name="label70.Text" xml:space="preserve">
-    <value>Sensitivity:</value>
-  </data>
-  <data name="&gt;&gt;label70.Name" xml:space="preserve">
-    <value>label70</value>
-  </data>
-  <data name="&gt;&gt;label70.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label70.Parent" xml:space="preserve">
-    <value>groupBox2</value>
-  </data>
-  <data name="&gt;&gt;label70.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="rsOutCurveComboBox.Items" xml:space="preserve">
-    <value>Linear</value>
-  </data>
-  <data name="rsOutCurveComboBox.Items1" xml:space="preserve">
-    <value>Enhanced Precison</value>
-  </data>
-  <data name="rsOutCurveComboBox.Items2" xml:space="preserve">
-    <value>Quadratic</value>
-  </data>
-  <data name="rsOutCurveComboBox.Items3" xml:space="preserve">
-    <value>Cubic</value>
-  </data>
-  <data name="rsOutCurveComboBox.Items4" xml:space="preserve">
-    <value>Easeout Quad</value>
-  </data>
-  <data name="rsOutCurveComboBox.Items5" xml:space="preserve">
-    <value>Easeout Cubic</value>
-  </data>
-  <data name="rsOutCurveComboBox.Items6" xml:space="preserve">
-    <value>Custom</value>
-  </data>
-  <data name="rsOutCurveComboBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>101, 152</value>
-  </data>
-  <data name="rsOutCurveComboBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>125, 21</value>
-  </data>
-  <data name="rsOutCurveComboBox.TabIndex" type="System.Int32, mscorlib">
-    <value>228</value>
-  </data>
-  <data name="&gt;&gt;rsOutCurveComboBox.Name" xml:space="preserve">
-    <value>rsOutCurveComboBox</value>
-  </data>
-  <data name="&gt;&gt;rsOutCurveComboBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;rsOutCurveComboBox.Parent" xml:space="preserve">
-    <value>groupBox2</value>
-  </data>
-  <data name="&gt;&gt;rsOutCurveComboBox.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="nUDRSRotation.Location" type="System.Drawing.Point, System.Drawing">
-    <value>101, 286</value>
-  </data>
-  <data name="nUDRSRotation.Size" type="System.Drawing.Size, System.Drawing">
-    <value>74, 20</value>
-  </data>
-  <data name="nUDRSRotation.TabIndex" type="System.Int32, mscorlib">
-    <value>227</value>
-  </data>
-  <data name="&gt;&gt;nUDRSRotation.Name" xml:space="preserve">
-    <value>nUDRSRotation</value>
-  </data>
-  <data name="&gt;&gt;nUDRSRotation.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDRSRotation.Parent" xml:space="preserve">
-    <value>groupBox2</value>
-  </data>
-  <data name="&gt;&gt;nUDRSRotation.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="label52.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label52.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label52.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 288</value>
-  </data>
-  <data name="label52.Size" type="System.Drawing.Size, System.Drawing">
-    <value>50, 13</value>
-  </data>
-  <data name="label52.TabIndex" type="System.Int32, mscorlib">
-    <value>226</value>
-  </data>
-  <data name="label52.Text" xml:space="preserve">
-    <value>Rotation:</value>
-  </data>
-  <data name="&gt;&gt;label52.Name" xml:space="preserve">
-    <value>label52</value>
-  </data>
-  <data name="&gt;&gt;label52.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label52.Parent" xml:space="preserve">
-    <value>groupBox2</value>
-  </data>
-  <data name="&gt;&gt;label52.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="lbRSCurvePercent.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lbRSCurvePercent.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lbRSCurvePercent.Location" type="System.Drawing.Point, System.Drawing">
-    <value>159, 257</value>
-  </data>
-  <data name="lbRSCurvePercent.Size" type="System.Drawing.Size, System.Drawing">
-    <value>15, 13</value>
-  </data>
-  <data name="lbRSCurvePercent.TabIndex" type="System.Int32, mscorlib">
-    <value>225</value>
-  </data>
-  <data name="lbRSCurvePercent.Text" xml:space="preserve">
-    <value>%</value>
-  </data>
-  <data name="&gt;&gt;lbRSCurvePercent.Name" xml:space="preserve">
-    <value>lbRSCurvePercent</value>
-  </data>
-  <data name="&gt;&gt;lbRSCurvePercent.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbRSCurvePercent.Parent" xml:space="preserve">
-    <value>groupBox2</value>
-  </data>
-  <data name="&gt;&gt;lbRSCurvePercent.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="nUDRSCurve.Location" type="System.Drawing.Point, System.Drawing">
-    <value>101, 255</value>
-  </data>
-  <data name="nUDRSCurve.RightToLeft" type="System.Windows.Forms.RightToLeft, System.Windows.Forms">
-    <value>No</value>
-  </data>
-  <data name="nUDRSCurve.Size" type="System.Drawing.Size, System.Drawing">
-    <value>49, 20</value>
-  </data>
-  <data name="nUDRSCurve.TabIndex" type="System.Int32, mscorlib">
-    <value>224</value>
-  </data>
-  <data name="&gt;&gt;nUDRSCurve.Name" xml:space="preserve">
-    <value>nUDRSCurve</value>
-  </data>
-  <data name="&gt;&gt;nUDRSCurve.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDRSCurve.Parent" xml:space="preserve">
-    <value>groupBox2</value>
-  </data>
-  <data name="&gt;&gt;nUDRSCurve.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="label51.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label51.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label51.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 261</value>
-  </data>
-  <data name="label51.Size" type="System.Drawing.Size, System.Drawing">
-    <value>71, 13</value>
-  </data>
-  <data name="label51.TabIndex" type="System.Int32, mscorlib">
-    <value>223</value>
-  </data>
-  <data name="label51.Text" xml:space="preserve">
-    <value>Curve (Input):</value>
-  </data>
-  <data name="&gt;&gt;label51.Name" xml:space="preserve">
-    <value>label51</value>
-  </data>
-  <data name="&gt;&gt;label51.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label51.Parent" xml:space="preserve">
-    <value>groupBox2</value>
-  </data>
-  <data name="&gt;&gt;label51.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="rsSquStickCk.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="rsSquStickCk.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 225</value>
-  </data>
-  <data name="rsSquStickCk.RightToLeft" type="System.Windows.Forms.RightToLeft, System.Windows.Forms">
-    <value>No</value>
-  </data>
-  <data name="rsSquStickCk.Size" type="System.Drawing.Size, System.Drawing">
-    <value>103, 24</value>
-  </data>
-  <data name="rsSquStickCk.TabIndex" type="System.Int32, mscorlib">
-    <value>222</value>
-  </data>
-  <data name="rsSquStickCk.Text" xml:space="preserve">
-    <value>Square Stick</value>
-  </data>
-  <data name="&gt;&gt;rsSquStickCk.Name" xml:space="preserve">
-    <value>rsSquStickCk</value>
-  </data>
-  <data name="&gt;&gt;rsSquStickCk.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;rsSquStickCk.Parent" xml:space="preserve">
-    <value>groupBox2</value>
-  </data>
-  <data name="&gt;&gt;rsSquStickCk.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="numericUpDown1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>200, 229</value>
-  </data>
-  <data name="numericUpDown1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>36, 20</value>
-  </data>
-  <data name="numericUpDown1.TabIndex" type="System.Int32, mscorlib">
-    <value>221</value>
-  </data>
-  <data name="&gt;&gt;numericUpDown1.Name" xml:space="preserve">
-    <value>numericUpDown1</value>
-  </data>
-  <data name="&gt;&gt;numericUpDown1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;numericUpDown1.Parent" xml:space="preserve">
-    <value>groupBox2</value>
-  </data>
-  <data name="&gt;&gt;numericUpDown1.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
-  <data name="label28.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label28.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label28.Location" type="System.Drawing.Point, System.Drawing">
-    <value>121, 231</value>
-  </data>
-  <data name="label28.Size" type="System.Drawing.Size, System.Drawing">
-    <value>61, 13</value>
-  </data>
-  <data name="label28.TabIndex" type="System.Int32, mscorlib">
-    <value>213</value>
-  </data>
-  <data name="label28.Text" xml:space="preserve">
-    <value>Roundness</value>
-  </data>
-  <data name="&gt;&gt;label28.Name" xml:space="preserve">
-    <value>label28</value>
-  </data>
-  <data name="&gt;&gt;label28.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label28.Parent" xml:space="preserve">
-    <value>groupBox2</value>
-  </data>
-  <data name="&gt;&gt;label28.ZOrder" xml:space="preserve">
-    <value>12</value>
-  </data>
-  <data name="label50.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label50.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label50.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 155</value>
-  </data>
-  <data name="label50.Size" type="System.Drawing.Size, System.Drawing">
-    <value>73, 13</value>
-  </data>
-  <data name="label50.TabIndex" type="System.Int32, mscorlib">
-    <value>210</value>
-  </data>
-  <data name="label50.Text" xml:space="preserve">
-    <value>Output Curve:</value>
-  </data>
-  <data name="&gt;&gt;label50.Name" xml:space="preserve">
-    <value>label50</value>
-  </data>
-  <data name="&gt;&gt;label50.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label50.Parent" xml:space="preserve">
-    <value>groupBox2</value>
-  </data>
-  <data name="&gt;&gt;label50.ZOrder" xml:space="preserve">
-    <value>13</value>
-  </data>
-  <data name="nUDRSAntiDead.Location" type="System.Drawing.Point, System.Drawing">
-    <value>99, 82</value>
-  </data>
-  <data name="nUDRSAntiDead.Size" type="System.Drawing.Size, System.Drawing">
-    <value>67, 20</value>
-  </data>
-  <data name="nUDRSAntiDead.TabIndex" type="System.Int32, mscorlib">
-    <value>209</value>
-  </data>
-  <data name="&gt;&gt;nUDRSAntiDead.Name" xml:space="preserve">
-    <value>nUDRSAntiDead</value>
-  </data>
-  <data name="&gt;&gt;nUDRSAntiDead.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDRSAntiDead.Parent" xml:space="preserve">
-    <value>groupBox2</value>
-  </data>
-  <data name="&gt;&gt;nUDRSAntiDead.ZOrder" xml:space="preserve">
-    <value>14</value>
-  </data>
-  <data name="label49.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label49.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label49.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 84</value>
-  </data>
-  <data name="label49.Size" type="System.Drawing.Size, System.Drawing">
-    <value>83, 13</value>
-  </data>
-  <data name="label49.TabIndex" type="System.Int32, mscorlib">
-    <value>208</value>
-  </data>
-  <data name="label49.Text" xml:space="preserve">
-    <value>Anti-dead Zone:</value>
-  </data>
-  <data name="&gt;&gt;label49.Name" xml:space="preserve">
-    <value>label49</value>
-  </data>
-  <data name="&gt;&gt;label49.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label49.Parent" xml:space="preserve">
-    <value>groupBox2</value>
-  </data>
-  <data name="&gt;&gt;label49.ZOrder" xml:space="preserve">
-    <value>15</value>
-  </data>
-  <data name="nUDRSMaxZone.Location" type="System.Drawing.Point, System.Drawing">
-    <value>102, 49</value>
-  </data>
-  <data name="nUDRSMaxZone.Size" type="System.Drawing.Size, System.Drawing">
-    <value>64, 20</value>
-  </data>
-  <data name="nUDRSMaxZone.TabIndex" type="System.Int32, mscorlib">
-    <value>207</value>
-  </data>
-  <data name="&gt;&gt;nUDRSMaxZone.Name" xml:space="preserve">
-    <value>nUDRSMaxZone</value>
-  </data>
-  <data name="&gt;&gt;nUDRSMaxZone.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDRSMaxZone.Parent" xml:space="preserve">
-    <value>groupBox2</value>
-  </data>
-  <data name="&gt;&gt;nUDRSMaxZone.ZOrder" xml:space="preserve">
-    <value>16</value>
-  </data>
-  <data name="label48.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label48.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label48.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 51</value>
-  </data>
-  <data name="label48.Size" type="System.Drawing.Size, System.Drawing">
-    <value>58, 13</value>
-  </data>
-  <data name="label48.TabIndex" type="System.Int32, mscorlib">
-    <value>206</value>
-  </data>
-  <data name="label48.Text" xml:space="preserve">
-    <value>Max Zone:</value>
-  </data>
-  <data name="&gt;&gt;label48.Name" xml:space="preserve">
-    <value>label48</value>
-  </data>
-  <data name="&gt;&gt;label48.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label48.Parent" xml:space="preserve">
-    <value>groupBox2</value>
-  </data>
-  <data name="&gt;&gt;label48.ZOrder" xml:space="preserve">
-    <value>17</value>
-  </data>
-  <data name="nUDRS.Location" type="System.Drawing.Point, System.Drawing">
-    <value>103, 19</value>
-  </data>
-  <data name="nUDRS.RightToLeft" type="System.Windows.Forms.RightToLeft, System.Windows.Forms">
-    <value>No</value>
-  </data>
-  <data name="nUDRS.Size" type="System.Drawing.Size, System.Drawing">
-    <value>61, 20</value>
-  </data>
-  <data name="nUDRS.TabIndex" type="System.Int32, mscorlib">
-    <value>204</value>
-  </data>
-  <data name="&gt;&gt;nUDRS.Name" xml:space="preserve">
-    <value>nUDRS</value>
-  </data>
-  <data name="&gt;&gt;nUDRS.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDRS.Parent" xml:space="preserve">
-    <value>groupBox2</value>
-  </data>
-  <data name="&gt;&gt;nUDRS.ZOrder" xml:space="preserve">
-    <value>18</value>
-  </data>
-  <data name="label47.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label47.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label47.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 23</value>
-  </data>
-  <data name="label47.Size" type="System.Drawing.Size, System.Drawing">
-    <value>64, 13</value>
-  </data>
-  <data name="label47.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="label47.Text" xml:space="preserve">
-    <value>Dead Zone:</value>
-  </data>
-  <data name="&gt;&gt;label47.Name" xml:space="preserve">
-    <value>label47</value>
-  </data>
-  <data name="&gt;&gt;label47.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label47.Parent" xml:space="preserve">
-    <value>groupBox2</value>
-  </data>
-  <data name="&gt;&gt;label47.ZOrder" xml:space="preserve">
-    <value>19</value>
-  </data>
-  <data name="&gt;&gt;tBL2CustomOutputCurve.Name" xml:space="preserve">
-    <value>tBL2CustomOutputCurve</value>
-  </data>
-  <data name="&gt;&gt;tBL2CustomOutputCurve.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tBL2CustomOutputCurve.Parent" xml:space="preserve">
-    <value>groupBox3</value>
-  </data>
-  <data name="&gt;&gt;tBL2CustomOutputCurve.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;lbL2CurveEditorURL.Name" xml:space="preserve">
-    <value>lbL2CurveEditorURL</value>
-  </data>
-  <data name="&gt;&gt;lbL2CurveEditorURL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbL2CurveEditorURL.Parent" xml:space="preserve">
-    <value>groupBox3</value>
-  </data>
-  <data name="&gt;&gt;lbL2CurveEditorURL.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;nUDL2S.Name" xml:space="preserve">
-    <value>nUDL2S</value>
-  </data>
-  <data name="&gt;&gt;nUDL2S.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDL2S.Parent" xml:space="preserve">
-    <value>groupBox3</value>
-  </data>
-  <data name="&gt;&gt;nUDL2S.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;label71.Name" xml:space="preserve">
-    <value>label71</value>
-  </data>
-  <data name="&gt;&gt;label71.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label71.Parent" xml:space="preserve">
-    <value>groupBox3</value>
-  </data>
-  <data name="&gt;&gt;label71.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;cBL2OutputCurve.Name" xml:space="preserve">
-    <value>cBL2OutputCurve</value>
-  </data>
-  <data name="&gt;&gt;cBL2OutputCurve.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cBL2OutputCurve.Parent" xml:space="preserve">
-    <value>groupBox3</value>
-  </data>
-  <data name="&gt;&gt;cBL2OutputCurve.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;nUDL2AntiDead.Name" xml:space="preserve">
-    <value>nUDL2AntiDead</value>
-  </data>
-  <data name="&gt;&gt;nUDL2AntiDead.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDL2AntiDead.Parent" xml:space="preserve">
-    <value>groupBox3</value>
-  </data>
-  <data name="&gt;&gt;nUDL2AntiDead.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;nUDL2Maxzone.Name" xml:space="preserve">
-    <value>nUDL2Maxzone</value>
-  </data>
-  <data name="&gt;&gt;nUDL2Maxzone.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDL2Maxzone.Parent" xml:space="preserve">
-    <value>groupBox3</value>
-  </data>
-  <data name="&gt;&gt;nUDL2Maxzone.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;nUDL2.Name" xml:space="preserve">
-    <value>nUDL2</value>
-  </data>
-  <data name="&gt;&gt;nUDL2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDL2.Parent" xml:space="preserve">
-    <value>groupBox3</value>
-  </data>
-  <data name="&gt;&gt;nUDL2.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="&gt;&gt;label54.Name" xml:space="preserve">
-    <value>label54</value>
-  </data>
-  <data name="&gt;&gt;label54.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label54.Parent" xml:space="preserve">
-    <value>groupBox3</value>
-  </data>
-  <data name="&gt;&gt;label54.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;label55.Name" xml:space="preserve">
-    <value>label55</value>
-  </data>
-  <data name="&gt;&gt;label55.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label55.Parent" xml:space="preserve">
-    <value>groupBox3</value>
-  </data>
-  <data name="&gt;&gt;label55.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="&gt;&gt;label56.Name" xml:space="preserve">
-    <value>label56</value>
-  </data>
-  <data name="&gt;&gt;label56.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label56.Parent" xml:space="preserve">
-    <value>groupBox3</value>
-  </data>
-  <data name="&gt;&gt;label56.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="&gt;&gt;label57.Name" xml:space="preserve">
-    <value>label57</value>
-  </data>
-  <data name="&gt;&gt;label57.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label57.Parent" xml:space="preserve">
-    <value>groupBox3</value>
-  </data>
-  <data name="&gt;&gt;label57.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
-  <data name="groupBox3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 649</value>
-  </data>
-  <data name="groupBox3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>424, 217</value>
-  </data>
-  <data name="groupBox3.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="groupBox3.Text" xml:space="preserve">
-    <value>L2</value>
-  </data>
-  <data name="&gt;&gt;groupBox3.Name" xml:space="preserve">
-    <value>groupBox3</value>
-  </data>
-  <data name="&gt;&gt;groupBox3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;groupBox3.Parent" xml:space="preserve">
-    <value>flowLayoutPanel3</value>
-  </data>
-  <data name="&gt;&gt;groupBox3.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="tBL2CustomOutputCurve.Location" type="System.Drawing.Point, System.Drawing">
-    <value>117, 191</value>
-  </data>
-  <data name="tBL2CustomOutputCurve.Size" type="System.Drawing.Size, System.Drawing">
-    <value>149, 20</value>
-  </data>
-  <data name="tBL2CustomOutputCurve.TabIndex" type="System.Int32, mscorlib">
-    <value>233</value>
-  </data>
-  <data name="tBL2CustomOutputCurve.Text" xml:space="preserve">
-    <value>0.00, 0.00, 1.00, 1.00</value>
-  </data>
-  <data name="&gt;&gt;tBL2CustomOutputCurve.Name" xml:space="preserve">
-    <value>tBL2CustomOutputCurve</value>
-  </data>
-  <data name="&gt;&gt;tBL2CustomOutputCurve.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tBL2CustomOutputCurve.Parent" xml:space="preserve">
-    <value>groupBox3</value>
-  </data>
-  <data name="&gt;&gt;tBL2CustomOutputCurve.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="lbL2CurveEditorURL.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lbL2CurveEditorURL.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lbL2CurveEditorURL.Location" type="System.Drawing.Point, System.Drawing">
-    <value>289, 195</value>
-  </data>
-  <data name="lbL2CurveEditorURL.Size" type="System.Drawing.Size, System.Drawing">
-    <value>101, 13</value>
-  </data>
-  <data name="lbL2CurveEditorURL.TabIndex" type="System.Int32, mscorlib">
-    <value>232</value>
-  </data>
-  <data name="lbL2CurveEditorURL.Text" xml:space="preserve">
-    <value>Custom curve editor</value>
-  </data>
-  <data name="&gt;&gt;lbL2CurveEditorURL.Name" xml:space="preserve">
-    <value>lbL2CurveEditorURL</value>
-  </data>
-  <data name="&gt;&gt;lbL2CurveEditorURL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbL2CurveEditorURL.Parent" xml:space="preserve">
-    <value>groupBox3</value>
-  </data>
-  <data name="&gt;&gt;lbL2CurveEditorURL.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="nUDL2S.Location" type="System.Drawing.Point, System.Drawing">
-    <value>118, 110</value>
-  </data>
-  <data name="nUDL2S.RightToLeft" type="System.Windows.Forms.RightToLeft, System.Windows.Forms">
-    <value>No</value>
-  </data>
-  <data name="nUDL2S.Size" type="System.Drawing.Size, System.Drawing">
-    <value>64, 20</value>
-  </data>
-  <data name="nUDL2S.TabIndex" type="System.Int32, mscorlib">
-    <value>231</value>
-  </data>
-  <data name="&gt;&gt;nUDL2S.Name" xml:space="preserve">
-    <value>nUDL2S</value>
-  </data>
-  <data name="&gt;&gt;nUDL2S.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDL2S.Parent" xml:space="preserve">
-    <value>groupBox3</value>
-  </data>
-  <data name="&gt;&gt;nUDL2S.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="label71.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label71.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label71.Location" type="System.Drawing.Point, System.Drawing">
-    <value>15, 117</value>
-  </data>
-  <data name="label71.Size" type="System.Drawing.Size, System.Drawing">
-    <value>57, 13</value>
-  </data>
-  <data name="label71.TabIndex" type="System.Int32, mscorlib">
-    <value>230</value>
-  </data>
-  <data name="label71.Text" xml:space="preserve">
-    <value>Sensitivity:</value>
-  </data>
-  <data name="&gt;&gt;label71.Name" xml:space="preserve">
-    <value>label71</value>
-  </data>
-  <data name="&gt;&gt;label71.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label71.Parent" xml:space="preserve">
-    <value>groupBox3</value>
-  </data>
-  <data name="&gt;&gt;label71.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="cBL2OutputCurve.Items" xml:space="preserve">
-    <value>Linear</value>
-  </data>
-  <data name="cBL2OutputCurve.Items1" xml:space="preserve">
-    <value>Enhanced Precison</value>
-  </data>
-  <data name="cBL2OutputCurve.Items2" xml:space="preserve">
-    <value>Quadratic</value>
-  </data>
-  <data name="cBL2OutputCurve.Items3" xml:space="preserve">
-    <value>Cubic</value>
-  </data>
-  <data name="cBL2OutputCurve.Items4" xml:space="preserve">
-    <value>Easeout Quad</value>
-  </data>
-  <data name="cBL2OutputCurve.Items5" xml:space="preserve">
-    <value>Easeout Cubic</value>
-  </data>
-  <data name="cBL2OutputCurve.Items6" xml:space="preserve">
-    <value>Custom</value>
-  </data>
-  <data name="cBL2OutputCurve.Location" type="System.Drawing.Point, System.Drawing">
-    <value>117, 145</value>
-  </data>
-  <data name="cBL2OutputCurve.Size" type="System.Drawing.Size, System.Drawing">
-    <value>114, 21</value>
-  </data>
-  <data name="cBL2OutputCurve.TabIndex" type="System.Int32, mscorlib">
-    <value>220</value>
-  </data>
-  <data name="&gt;&gt;cBL2OutputCurve.Name" xml:space="preserve">
-    <value>cBL2OutputCurve</value>
-  </data>
-  <data name="&gt;&gt;cBL2OutputCurve.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cBL2OutputCurve.Parent" xml:space="preserve">
-    <value>groupBox3</value>
-  </data>
-  <data name="&gt;&gt;cBL2OutputCurve.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="nUDL2AntiDead.Location" type="System.Drawing.Point, System.Drawing">
-    <value>117, 77</value>
-  </data>
-  <data name="nUDL2AntiDead.Size" type="System.Drawing.Size, System.Drawing">
-    <value>65, 20</value>
-  </data>
-  <data name="nUDL2AntiDead.TabIndex" type="System.Int32, mscorlib">
-    <value>219</value>
-  </data>
-  <data name="&gt;&gt;nUDL2AntiDead.Name" xml:space="preserve">
-    <value>nUDL2AntiDead</value>
-  </data>
-  <data name="&gt;&gt;nUDL2AntiDead.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDL2AntiDead.Parent" xml:space="preserve">
-    <value>groupBox3</value>
-  </data>
-  <data name="&gt;&gt;nUDL2AntiDead.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="nUDL2Maxzone.Location" type="System.Drawing.Point, System.Drawing">
-    <value>118, 50</value>
-  </data>
-  <data name="nUDL2Maxzone.Size" type="System.Drawing.Size, System.Drawing">
-    <value>64, 20</value>
-  </data>
-  <data name="nUDL2Maxzone.TabIndex" type="System.Int32, mscorlib">
-    <value>218</value>
-  </data>
-  <data name="&gt;&gt;nUDL2Maxzone.Name" xml:space="preserve">
-    <value>nUDL2Maxzone</value>
-  </data>
-  <data name="&gt;&gt;nUDL2Maxzone.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDL2Maxzone.Parent" xml:space="preserve">
-    <value>groupBox3</value>
-  </data>
-  <data name="&gt;&gt;nUDL2Maxzone.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="nUDL2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>120, 21</value>
-  </data>
-  <data name="nUDL2.RightToLeft" type="System.Windows.Forms.RightToLeft, System.Windows.Forms">
-    <value>No</value>
-  </data>
-  <data name="nUDL2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>62, 20</value>
-  </data>
-  <data name="nUDL2.TabIndex" type="System.Int32, mscorlib">
-    <value>217</value>
-  </data>
-  <data name="&gt;&gt;nUDL2.Name" xml:space="preserve">
-    <value>nUDL2</value>
-  </data>
-  <data name="&gt;&gt;nUDL2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDL2.Parent" xml:space="preserve">
-    <value>groupBox3</value>
-  </data>
-  <data name="&gt;&gt;nUDL2.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="label54.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label54.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label54.Location" type="System.Drawing.Point, System.Drawing">
-    <value>14, 145</value>
-  </data>
-  <data name="label54.Size" type="System.Drawing.Size, System.Drawing">
-    <value>73, 13</value>
-  </data>
-  <data name="label54.TabIndex" type="System.Int32, mscorlib">
-    <value>215</value>
-  </data>
-  <data name="label54.Text" xml:space="preserve">
-    <value>Output Curve:</value>
-  </data>
-  <data name="&gt;&gt;label54.Name" xml:space="preserve">
-    <value>label54</value>
-  </data>
-  <data name="&gt;&gt;label54.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label54.Parent" xml:space="preserve">
-    <value>groupBox3</value>
-  </data>
-  <data name="&gt;&gt;label54.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="label55.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label55.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label55.Location" type="System.Drawing.Point, System.Drawing">
-    <value>15, 79</value>
-  </data>
-  <data name="label55.Size" type="System.Drawing.Size, System.Drawing">
-    <value>83, 13</value>
-  </data>
-  <data name="label55.TabIndex" type="System.Int32, mscorlib">
-    <value>214</value>
-  </data>
-  <data name="label55.Text" xml:space="preserve">
-    <value>Anti-dead Zone:</value>
-  </data>
-  <data name="&gt;&gt;label55.Name" xml:space="preserve">
-    <value>label55</value>
-  </data>
-  <data name="&gt;&gt;label55.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label55.Parent" xml:space="preserve">
-    <value>groupBox3</value>
-  </data>
-  <data name="&gt;&gt;label55.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="label56.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label56.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label56.Location" type="System.Drawing.Point, System.Drawing">
-    <value>15, 50</value>
-  </data>
-  <data name="label56.Size" type="System.Drawing.Size, System.Drawing">
-    <value>58, 13</value>
-  </data>
-  <data name="label56.TabIndex" type="System.Int32, mscorlib">
-    <value>213</value>
-  </data>
-  <data name="label56.Text" xml:space="preserve">
-    <value>Max Zone:</value>
-  </data>
-  <data name="&gt;&gt;label56.Name" xml:space="preserve">
-    <value>label56</value>
-  </data>
-  <data name="&gt;&gt;label56.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label56.Parent" xml:space="preserve">
-    <value>groupBox3</value>
-  </data>
-  <data name="&gt;&gt;label56.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="label57.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label57.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label57.Location" type="System.Drawing.Point, System.Drawing">
-    <value>15, 23</value>
-  </data>
-  <data name="label57.Size" type="System.Drawing.Size, System.Drawing">
-    <value>64, 13</value>
-  </data>
-  <data name="label57.TabIndex" type="System.Int32, mscorlib">
-    <value>212</value>
-  </data>
-  <data name="label57.Text" xml:space="preserve">
-    <value>Dead Zone:</value>
-  </data>
-  <data name="&gt;&gt;label57.Name" xml:space="preserve">
-    <value>label57</value>
-  </data>
-  <data name="&gt;&gt;label57.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label57.Parent" xml:space="preserve">
-    <value>groupBox3</value>
-  </data>
-  <data name="&gt;&gt;label57.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
-  <data name="&gt;&gt;tBR2CustomOutputCurve.Name" xml:space="preserve">
-    <value>tBR2CustomOutputCurve</value>
-  </data>
-  <data name="&gt;&gt;tBR2CustomOutputCurve.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tBR2CustomOutputCurve.Parent" xml:space="preserve">
-    <value>groupBox4</value>
-  </data>
-  <data name="&gt;&gt;tBR2CustomOutputCurve.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;lbR2CurveEditorURL.Name" xml:space="preserve">
-    <value>lbR2CurveEditorURL</value>
-  </data>
-  <data name="&gt;&gt;lbR2CurveEditorURL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbR2CurveEditorURL.Parent" xml:space="preserve">
-    <value>groupBox4</value>
-  </data>
-  <data name="&gt;&gt;lbR2CurveEditorURL.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;nUDR2S.Name" xml:space="preserve">
-    <value>nUDR2S</value>
-  </data>
-  <data name="&gt;&gt;nUDR2S.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDR2S.Parent" xml:space="preserve">
-    <value>groupBox4</value>
-  </data>
-  <data name="&gt;&gt;nUDR2S.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;label72.Name" xml:space="preserve">
-    <value>label72</value>
-  </data>
-  <data name="&gt;&gt;label72.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label72.Parent" xml:space="preserve">
-    <value>groupBox4</value>
-  </data>
-  <data name="&gt;&gt;label72.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;cBR2OutputCurve.Name" xml:space="preserve">
-    <value>cBR2OutputCurve</value>
-  </data>
-  <data name="&gt;&gt;cBR2OutputCurve.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cBR2OutputCurve.Parent" xml:space="preserve">
-    <value>groupBox4</value>
-  </data>
-  <data name="&gt;&gt;cBR2OutputCurve.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;nUDR2AntiDead.Name" xml:space="preserve">
-    <value>nUDR2AntiDead</value>
-  </data>
-  <data name="&gt;&gt;nUDR2AntiDead.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDR2AntiDead.Parent" xml:space="preserve">
-    <value>groupBox4</value>
-  </data>
-  <data name="&gt;&gt;nUDR2AntiDead.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;nUDR2Maxzone.Name" xml:space="preserve">
-    <value>nUDR2Maxzone</value>
-  </data>
-  <data name="&gt;&gt;nUDR2Maxzone.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDR2Maxzone.Parent" xml:space="preserve">
-    <value>groupBox4</value>
-  </data>
-  <data name="&gt;&gt;nUDR2Maxzone.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;nUDR2.Name" xml:space="preserve">
-    <value>nUDR2</value>
-  </data>
-  <data name="&gt;&gt;nUDR2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDR2.Parent" xml:space="preserve">
-    <value>groupBox4</value>
-  </data>
-  <data name="&gt;&gt;nUDR2.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="&gt;&gt;label53.Name" xml:space="preserve">
-    <value>label53</value>
-  </data>
-  <data name="&gt;&gt;label53.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label53.Parent" xml:space="preserve">
-    <value>groupBox4</value>
-  </data>
-  <data name="&gt;&gt;label53.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;label58.Name" xml:space="preserve">
-    <value>label58</value>
-  </data>
-  <data name="&gt;&gt;label58.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label58.Parent" xml:space="preserve">
-    <value>groupBox4</value>
-  </data>
-  <data name="&gt;&gt;label58.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="&gt;&gt;label59.Name" xml:space="preserve">
-    <value>label59</value>
-  </data>
-  <data name="&gt;&gt;label59.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label59.Parent" xml:space="preserve">
-    <value>groupBox4</value>
-  </data>
-  <data name="&gt;&gt;label59.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="&gt;&gt;label60.Name" xml:space="preserve">
-    <value>label60</value>
-  </data>
-  <data name="&gt;&gt;label60.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label60.Parent" xml:space="preserve">
-    <value>groupBox4</value>
-  </data>
-  <data name="&gt;&gt;label60.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
-  <data name="groupBox4.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 872</value>
-  </data>
-  <data name="groupBox4.Size" type="System.Drawing.Size, System.Drawing">
-    <value>424, 225</value>
-  </data>
-  <data name="groupBox4.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="groupBox4.Text" xml:space="preserve">
-    <value>R2</value>
-  </data>
-  <data name="&gt;&gt;groupBox4.Name" xml:space="preserve">
-    <value>groupBox4</value>
-  </data>
-  <data name="&gt;&gt;groupBox4.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;groupBox4.Parent" xml:space="preserve">
-    <value>flowLayoutPanel3</value>
-  </data>
-  <data name="&gt;&gt;groupBox4.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="tBR2CustomOutputCurve.Location" type="System.Drawing.Point, System.Drawing">
-    <value>114, 188</value>
-  </data>
-  <data name="tBR2CustomOutputCurve.Size" type="System.Drawing.Size, System.Drawing">
-    <value>149, 20</value>
-  </data>
-  <data name="tBR2CustomOutputCurve.TabIndex" type="System.Int32, mscorlib">
-    <value>234</value>
-  </data>
-  <data name="tBR2CustomOutputCurve.Text" xml:space="preserve">
-    <value>0.00, 0.00, 1.00, 1.00</value>
-  </data>
-  <data name="&gt;&gt;tBR2CustomOutputCurve.Name" xml:space="preserve">
-    <value>tBR2CustomOutputCurve</value>
-  </data>
-  <data name="&gt;&gt;tBR2CustomOutputCurve.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tBR2CustomOutputCurve.Parent" xml:space="preserve">
-    <value>groupBox4</value>
-  </data>
-  <data name="&gt;&gt;tBR2CustomOutputCurve.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="lbR2CurveEditorURL.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lbR2CurveEditorURL.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lbR2CurveEditorURL.Location" type="System.Drawing.Point, System.Drawing">
-    <value>286, 192</value>
-  </data>
-  <data name="lbR2CurveEditorURL.Size" type="System.Drawing.Size, System.Drawing">
-    <value>101, 13</value>
-  </data>
-  <data name="lbR2CurveEditorURL.TabIndex" type="System.Int32, mscorlib">
-    <value>233</value>
-  </data>
-  <data name="lbR2CurveEditorURL.Text" xml:space="preserve">
-    <value>Custom curve editor</value>
-  </data>
-  <data name="&gt;&gt;lbR2CurveEditorURL.Name" xml:space="preserve">
-    <value>lbR2CurveEditorURL</value>
-  </data>
-  <data name="&gt;&gt;lbR2CurveEditorURL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbR2CurveEditorURL.Parent" xml:space="preserve">
-    <value>groupBox4</value>
-  </data>
-  <data name="&gt;&gt;lbR2CurveEditorURL.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="nUDR2S.Location" type="System.Drawing.Point, System.Drawing">
-    <value>117, 109</value>
-  </data>
-  <data name="nUDR2S.Size" type="System.Drawing.Size, System.Drawing">
-    <value>65, 20</value>
-  </data>
-  <data name="nUDR2S.TabIndex" type="System.Int32, mscorlib">
-    <value>232</value>
-  </data>
-  <data name="&gt;&gt;nUDR2S.Name" xml:space="preserve">
-    <value>nUDR2S</value>
-  </data>
-  <data name="&gt;&gt;nUDR2S.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDR2S.Parent" xml:space="preserve">
-    <value>groupBox4</value>
-  </data>
-  <data name="&gt;&gt;nUDR2S.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="label72.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label72.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label72.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 116</value>
-  </data>
-  <data name="label72.Size" type="System.Drawing.Size, System.Drawing">
-    <value>57, 13</value>
-  </data>
-  <data name="label72.TabIndex" type="System.Int32, mscorlib">
-    <value>231</value>
-  </data>
-  <data name="label72.Text" xml:space="preserve">
-    <value>Sensitivity:</value>
-  </data>
-  <data name="&gt;&gt;label72.Name" xml:space="preserve">
-    <value>label72</value>
-  </data>
-  <data name="&gt;&gt;label72.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label72.Parent" xml:space="preserve">
-    <value>groupBox4</value>
-  </data>
-  <data name="&gt;&gt;label72.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="cBR2OutputCurve.Items" xml:space="preserve">
-    <value>Linear</value>
-  </data>
-  <data name="cBR2OutputCurve.Items1" xml:space="preserve">
-    <value>Enhanced Precison</value>
-  </data>
-  <data name="cBR2OutputCurve.Items2" xml:space="preserve">
-    <value>Quadratic</value>
-  </data>
-  <data name="cBR2OutputCurve.Items3" xml:space="preserve">
-    <value>Cubic</value>
-  </data>
-  <data name="cBR2OutputCurve.Items4" xml:space="preserve">
-    <value>Easeout Quad</value>
-  </data>
-  <data name="cBR2OutputCurve.Items5" xml:space="preserve">
-    <value>Easeout Cubic</value>
-  </data>
-  <data name="cBR2OutputCurve.Items6" xml:space="preserve">
-    <value>Custom</value>
-  </data>
-  <data name="cBR2OutputCurve.Location" type="System.Drawing.Point, System.Drawing">
-    <value>117, 147</value>
-  </data>
-  <data name="cBR2OutputCurve.Size" type="System.Drawing.Size, System.Drawing">
-    <value>125, 21</value>
-  </data>
-  <data name="cBR2OutputCurve.TabIndex" type="System.Int32, mscorlib">
-    <value>223</value>
-  </data>
-  <data name="&gt;&gt;cBR2OutputCurve.Name" xml:space="preserve">
-    <value>cBR2OutputCurve</value>
-  </data>
-  <data name="&gt;&gt;cBR2OutputCurve.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cBR2OutputCurve.Parent" xml:space="preserve">
-    <value>groupBox4</value>
-  </data>
-  <data name="&gt;&gt;cBR2OutputCurve.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="nUDR2AntiDead.Location" type="System.Drawing.Point, System.Drawing">
-    <value>117, 79</value>
-  </data>
-  <data name="nUDR2AntiDead.Size" type="System.Drawing.Size, System.Drawing">
-    <value>65, 20</value>
-  </data>
-  <data name="nUDR2AntiDead.TabIndex" type="System.Int32, mscorlib">
-    <value>222</value>
-  </data>
-  <data name="&gt;&gt;nUDR2AntiDead.Name" xml:space="preserve">
-    <value>nUDR2AntiDead</value>
-  </data>
-  <data name="&gt;&gt;nUDR2AntiDead.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDR2AntiDead.Parent" xml:space="preserve">
-    <value>groupBox4</value>
-  </data>
-  <data name="&gt;&gt;nUDR2AntiDead.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="nUDR2Maxzone.Location" type="System.Drawing.Point, System.Drawing">
-    <value>117, 49</value>
-  </data>
-  <data name="nUDR2Maxzone.Size" type="System.Drawing.Size, System.Drawing">
-    <value>65, 20</value>
-  </data>
-  <data name="nUDR2Maxzone.TabIndex" type="System.Int32, mscorlib">
-    <value>221</value>
-  </data>
-  <data name="&gt;&gt;nUDR2Maxzone.Name" xml:space="preserve">
-    <value>nUDR2Maxzone</value>
-  </data>
-  <data name="&gt;&gt;nUDR2Maxzone.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDR2Maxzone.Parent" xml:space="preserve">
-    <value>groupBox4</value>
-  </data>
-  <data name="&gt;&gt;nUDR2Maxzone.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="nUDR2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>117, 23</value>
-  </data>
-  <data name="nUDR2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>65, 20</value>
-  </data>
-  <data name="nUDR2.TabIndex" type="System.Int32, mscorlib">
-    <value>220</value>
-  </data>
-  <data name="&gt;&gt;nUDR2.Name" xml:space="preserve">
-    <value>nUDR2</value>
-  </data>
-  <data name="&gt;&gt;nUDR2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDR2.Parent" xml:space="preserve">
-    <value>groupBox4</value>
-  </data>
-  <data name="&gt;&gt;nUDR2.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="label53.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label53.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label53.Location" type="System.Drawing.Point, System.Drawing">
-    <value>17, 147</value>
-  </data>
-  <data name="label53.Size" type="System.Drawing.Size, System.Drawing">
-    <value>73, 13</value>
-  </data>
-  <data name="label53.TabIndex" type="System.Int32, mscorlib">
-    <value>219</value>
-  </data>
-  <data name="label53.Text" xml:space="preserve">
-    <value>Output Curve:</value>
-  </data>
-  <data name="&gt;&gt;label53.Name" xml:space="preserve">
-    <value>label53</value>
-  </data>
-  <data name="&gt;&gt;label53.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label53.Parent" xml:space="preserve">
-    <value>groupBox4</value>
-  </data>
-  <data name="&gt;&gt;label53.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="label58.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label58.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label58.Location" type="System.Drawing.Point, System.Drawing">
-    <value>14, 79</value>
-  </data>
-  <data name="label58.Size" type="System.Drawing.Size, System.Drawing">
-    <value>83, 13</value>
-  </data>
-  <data name="label58.TabIndex" type="System.Int32, mscorlib">
-    <value>218</value>
-  </data>
-  <data name="label58.Text" xml:space="preserve">
-    <value>Anti-dead Zone:</value>
-  </data>
-  <data name="&gt;&gt;label58.Name" xml:space="preserve">
-    <value>label58</value>
-  </data>
-  <data name="&gt;&gt;label58.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label58.Parent" xml:space="preserve">
-    <value>groupBox4</value>
-  </data>
-  <data name="&gt;&gt;label58.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="label59.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label59.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label59.Location" type="System.Drawing.Point, System.Drawing">
-    <value>14, 50</value>
-  </data>
-  <data name="label59.Size" type="System.Drawing.Size, System.Drawing">
-    <value>58, 13</value>
-  </data>
-  <data name="label59.TabIndex" type="System.Int32, mscorlib">
-    <value>217</value>
-  </data>
-  <data name="label59.Text" xml:space="preserve">
-    <value>Max Zone:</value>
-  </data>
-  <data name="&gt;&gt;label59.Name" xml:space="preserve">
-    <value>label59</value>
-  </data>
-  <data name="&gt;&gt;label59.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label59.Parent" xml:space="preserve">
-    <value>groupBox4</value>
-  </data>
-  <data name="&gt;&gt;label59.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="label60.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label60.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label60.Location" type="System.Drawing.Point, System.Drawing">
-    <value>14, 23</value>
-  </data>
-  <data name="label60.Size" type="System.Drawing.Size, System.Drawing">
-    <value>64, 13</value>
-  </data>
-  <data name="label60.TabIndex" type="System.Int32, mscorlib">
-    <value>216</value>
-  </data>
-  <data name="label60.Text" xml:space="preserve">
-    <value>Dead Zone:</value>
-  </data>
-  <data name="&gt;&gt;label60.Name" xml:space="preserve">
-    <value>label60</value>
-  </data>
-  <data name="&gt;&gt;label60.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label60.Parent" xml:space="preserve">
-    <value>groupBox4</value>
-  </data>
-  <data name="&gt;&gt;label60.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
-  <data name="&gt;&gt;tBSixZCustomOutputCurve.Name" xml:space="preserve">
-    <value>tBSixZCustomOutputCurve</value>
-  </data>
-  <data name="&gt;&gt;tBSixZCustomOutputCurve.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tBSixZCustomOutputCurve.Parent" xml:space="preserve">
-    <value>groupBox5</value>
-  </data>
-  <data name="&gt;&gt;tBSixZCustomOutputCurve.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;lbSixZCurveEditorURL.Name" xml:space="preserve">
-    <value>lbSixZCurveEditorURL</value>
-  </data>
-  <data name="&gt;&gt;lbSixZCurveEditorURL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbSixZCurveEditorURL.Parent" xml:space="preserve">
-    <value>groupBox5</value>
-  </data>
-  <data name="&gt;&gt;lbSixZCurveEditorURL.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;tBSixXCustomOutputCurve.Name" xml:space="preserve">
-    <value>tBSixXCustomOutputCurve</value>
-  </data>
-  <data name="&gt;&gt;tBSixXCustomOutputCurve.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tBSixXCustomOutputCurve.Parent" xml:space="preserve">
-    <value>groupBox5</value>
-  </data>
-  <data name="&gt;&gt;tBSixXCustomOutputCurve.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;lbSixXCurveEditorURL.Name" xml:space="preserve">
-    <value>lbSixXCurveEditorURL</value>
-  </data>
-  <data name="&gt;&gt;lbSixXCurveEditorURL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbSixXCurveEditorURL.Parent" xml:space="preserve">
-    <value>groupBox5</value>
-  </data>
-  <data name="&gt;&gt;lbSixXCurveEditorURL.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;nUDSZS.Name" xml:space="preserve">
-    <value>nUDSZS</value>
-  </data>
-  <data name="&gt;&gt;nUDSZS.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDSZS.Parent" xml:space="preserve">
-    <value>groupBox5</value>
-  </data>
-  <data name="&gt;&gt;nUDSZS.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;nUDSXS.Name" xml:space="preserve">
-    <value>nUDSXS</value>
-  </data>
-  <data name="&gt;&gt;nUDSXS.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDSXS.Parent" xml:space="preserve">
-    <value>groupBox5</value>
-  </data>
-  <data name="&gt;&gt;nUDSXS.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;label74.Name" xml:space="preserve">
-    <value>label74</value>
-  </data>
-  <data name="&gt;&gt;label74.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label74.Parent" xml:space="preserve">
-    <value>groupBox5</value>
-  </data>
-  <data name="&gt;&gt;label74.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;label73.Name" xml:space="preserve">
-    <value>label73</value>
-  </data>
-  <data name="&gt;&gt;label73.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label73.Parent" xml:space="preserve">
-    <value>groupBox5</value>
-  </data>
-  <data name="&gt;&gt;label73.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="&gt;&gt;cBSixaxisZOutputCurve.Name" xml:space="preserve">
-    <value>cBSixaxisZOutputCurve</value>
-  </data>
-  <data name="&gt;&gt;cBSixaxisZOutputCurve.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cBSixaxisZOutputCurve.Parent" xml:space="preserve">
-    <value>groupBox5</value>
-  </data>
-  <data name="&gt;&gt;cBSixaxisZOutputCurve.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;label68.Name" xml:space="preserve">
-    <value>label68</value>
-  </data>
-  <data name="&gt;&gt;label68.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label68.Parent" xml:space="preserve">
-    <value>groupBox5</value>
-  </data>
-  <data name="&gt;&gt;label68.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="&gt;&gt;cBSixaxisXOutputCurve.Name" xml:space="preserve">
-    <value>cBSixaxisXOutputCurve</value>
-  </data>
-  <data name="&gt;&gt;cBSixaxisXOutputCurve.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cBSixaxisXOutputCurve.Parent" xml:space="preserve">
-    <value>groupBox5</value>
-  </data>
-  <data name="&gt;&gt;cBSixaxisXOutputCurve.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="&gt;&gt;label67.Name" xml:space="preserve">
-    <value>label67</value>
-  </data>
-  <data name="&gt;&gt;label67.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label67.Parent" xml:space="preserve">
-    <value>groupBox5</value>
-  </data>
-  <data name="&gt;&gt;label67.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
-  <data name="&gt;&gt;nUDSixaxisZAntiDead.Name" xml:space="preserve">
-    <value>nUDSixaxisZAntiDead</value>
-  </data>
-  <data name="&gt;&gt;nUDSixaxisZAntiDead.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDSixaxisZAntiDead.Parent" xml:space="preserve">
-    <value>groupBox5</value>
-  </data>
-  <data name="&gt;&gt;nUDSixaxisZAntiDead.ZOrder" xml:space="preserve">
-    <value>12</value>
-  </data>
-  <data name="&gt;&gt;label66.Name" xml:space="preserve">
-    <value>label66</value>
-  </data>
-  <data name="&gt;&gt;label66.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label66.Parent" xml:space="preserve">
-    <value>groupBox5</value>
-  </data>
-  <data name="&gt;&gt;label66.ZOrder" xml:space="preserve">
-    <value>13</value>
-  </data>
-  <data name="&gt;&gt;nUDSixaxisXAntiDead.Name" xml:space="preserve">
-    <value>nUDSixaxisXAntiDead</value>
-  </data>
-  <data name="&gt;&gt;nUDSixaxisXAntiDead.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDSixaxisXAntiDead.Parent" xml:space="preserve">
-    <value>groupBox5</value>
-  </data>
-  <data name="&gt;&gt;nUDSixaxisXAntiDead.ZOrder" xml:space="preserve">
-    <value>14</value>
-  </data>
-  <data name="&gt;&gt;label65.Name" xml:space="preserve">
-    <value>label65</value>
-  </data>
-  <data name="&gt;&gt;label65.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label65.Parent" xml:space="preserve">
-    <value>groupBox5</value>
-  </data>
-  <data name="&gt;&gt;label65.ZOrder" xml:space="preserve">
-    <value>15</value>
-  </data>
-  <data name="&gt;&gt;nUDSixAxisZMaxZone.Name" xml:space="preserve">
-    <value>nUDSixAxisZMaxZone</value>
-  </data>
-  <data name="&gt;&gt;nUDSixAxisZMaxZone.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDSixAxisZMaxZone.Parent" xml:space="preserve">
-    <value>groupBox5</value>
-  </data>
-  <data name="&gt;&gt;nUDSixAxisZMaxZone.ZOrder" xml:space="preserve">
-    <value>16</value>
-  </data>
-  <data name="&gt;&gt;label64.Name" xml:space="preserve">
-    <value>label64</value>
-  </data>
-  <data name="&gt;&gt;label64.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label64.Parent" xml:space="preserve">
-    <value>groupBox5</value>
-  </data>
-  <data name="&gt;&gt;label64.ZOrder" xml:space="preserve">
-    <value>17</value>
-  </data>
-  <data name="&gt;&gt;nUDSixAxisXMaxZone.Name" xml:space="preserve">
-    <value>nUDSixAxisXMaxZone</value>
-  </data>
-  <data name="&gt;&gt;nUDSixAxisXMaxZone.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDSixAxisXMaxZone.Parent" xml:space="preserve">
-    <value>groupBox5</value>
-  </data>
-  <data name="&gt;&gt;nUDSixAxisXMaxZone.ZOrder" xml:space="preserve">
-    <value>18</value>
-  </data>
-  <data name="&gt;&gt;label63.Name" xml:space="preserve">
-    <value>label63</value>
-  </data>
-  <data name="&gt;&gt;label63.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label63.Parent" xml:space="preserve">
-    <value>groupBox5</value>
-  </data>
-  <data name="&gt;&gt;label63.ZOrder" xml:space="preserve">
-    <value>19</value>
-  </data>
-  <data name="&gt;&gt;nUDSZ.Name" xml:space="preserve">
-    <value>nUDSZ</value>
-  </data>
-  <data name="&gt;&gt;nUDSZ.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDSZ.Parent" xml:space="preserve">
-    <value>groupBox5</value>
-  </data>
-  <data name="&gt;&gt;nUDSZ.ZOrder" xml:space="preserve">
-    <value>20</value>
-  </data>
-  <data name="&gt;&gt;label62.Name" xml:space="preserve">
-    <value>label62</value>
-  </data>
-  <data name="&gt;&gt;label62.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label62.Parent" xml:space="preserve">
-    <value>groupBox5</value>
-  </data>
-  <data name="&gt;&gt;label62.ZOrder" xml:space="preserve">
-    <value>21</value>
-  </data>
-  <data name="&gt;&gt;nUDSX.Name" xml:space="preserve">
-    <value>nUDSX</value>
-  </data>
-  <data name="&gt;&gt;nUDSX.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDSX.Parent" xml:space="preserve">
-    <value>groupBox5</value>
-  </data>
-  <data name="&gt;&gt;nUDSX.ZOrder" xml:space="preserve">
-    <value>22</value>
-  </data>
-  <data name="&gt;&gt;label61.Name" xml:space="preserve">
-    <value>label61</value>
-  </data>
-  <data name="&gt;&gt;label61.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label61.Parent" xml:space="preserve">
-    <value>groupBox5</value>
-  </data>
-  <data name="&gt;&gt;label61.ZOrder" xml:space="preserve">
-    <value>23</value>
-  </data>
-  <data name="groupBox5.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 1103</value>
-  </data>
-  <data name="groupBox5.Size" type="System.Drawing.Size, System.Drawing">
-    <value>424, 429</value>
-  </data>
-  <data name="groupBox5.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="groupBox5.Text" xml:space="preserve">
-    <value>SixAxis</value>
-  </data>
-  <data name="&gt;&gt;groupBox5.Name" xml:space="preserve">
-    <value>groupBox5</value>
-  </data>
-  <data name="&gt;&gt;groupBox5.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;groupBox5.Parent" xml:space="preserve">
-    <value>flowLayoutPanel3</value>
-  </data>
-  <data name="&gt;&gt;groupBox5.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="tBSixZCustomOutputCurve.Location" type="System.Drawing.Point, System.Drawing">
-    <value>121, 391</value>
-  </data>
-  <data name="tBSixZCustomOutputCurve.Size" type="System.Drawing.Size, System.Drawing">
-    <value>149, 20</value>
-  </data>
-  <data name="tBSixZCustomOutputCurve.TabIndex" type="System.Int32, mscorlib">
-    <value>240</value>
-  </data>
-  <data name="tBSixZCustomOutputCurve.Text" xml:space="preserve">
-    <value>0.00, 0.00, 1.00, 1.00</value>
-  </data>
-  <data name="&gt;&gt;tBSixZCustomOutputCurve.Name" xml:space="preserve">
-    <value>tBSixZCustomOutputCurve</value>
-  </data>
-  <data name="&gt;&gt;tBSixZCustomOutputCurve.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tBSixZCustomOutputCurve.Parent" xml:space="preserve">
-    <value>groupBox5</value>
-  </data>
-  <data name="&gt;&gt;tBSixZCustomOutputCurve.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="lbSixZCurveEditorURL.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lbSixZCurveEditorURL.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lbSixZCurveEditorURL.Location" type="System.Drawing.Point, System.Drawing">
-    <value>293, 395</value>
-  </data>
-  <data name="lbSixZCurveEditorURL.Size" type="System.Drawing.Size, System.Drawing">
-    <value>101, 13</value>
-  </data>
-  <data name="lbSixZCurveEditorURL.TabIndex" type="System.Int32, mscorlib">
-    <value>239</value>
-  </data>
-  <data name="lbSixZCurveEditorURL.Text" xml:space="preserve">
-    <value>Custom curve editor</value>
-  </data>
-  <data name="&gt;&gt;lbSixZCurveEditorURL.Name" xml:space="preserve">
-    <value>lbSixZCurveEditorURL</value>
-  </data>
-  <data name="&gt;&gt;lbSixZCurveEditorURL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbSixZCurveEditorURL.Parent" xml:space="preserve">
-    <value>groupBox5</value>
-  </data>
-  <data name="&gt;&gt;lbSixZCurveEditorURL.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="tBSixXCustomOutputCurve.Location" type="System.Drawing.Point, System.Drawing">
-    <value>121, 319</value>
-  </data>
-  <data name="tBSixXCustomOutputCurve.Size" type="System.Drawing.Size, System.Drawing">
-    <value>149, 20</value>
-  </data>
-  <data name="tBSixXCustomOutputCurve.TabIndex" type="System.Int32, mscorlib">
-    <value>238</value>
-  </data>
-  <data name="tBSixXCustomOutputCurve.Text" xml:space="preserve">
-    <value>0.00, 0.00, 1.00, 1.00</value>
-  </data>
-  <data name="&gt;&gt;tBSixXCustomOutputCurve.Name" xml:space="preserve">
-    <value>tBSixXCustomOutputCurve</value>
-  </data>
-  <data name="&gt;&gt;tBSixXCustomOutputCurve.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tBSixXCustomOutputCurve.Parent" xml:space="preserve">
-    <value>groupBox5</value>
-  </data>
-  <data name="&gt;&gt;tBSixXCustomOutputCurve.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="lbSixXCurveEditorURL.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lbSixXCurveEditorURL.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lbSixXCurveEditorURL.Location" type="System.Drawing.Point, System.Drawing">
-    <value>293, 323</value>
-  </data>
-  <data name="lbSixXCurveEditorURL.Size" type="System.Drawing.Size, System.Drawing">
-    <value>101, 13</value>
-  </data>
-  <data name="lbSixXCurveEditorURL.TabIndex" type="System.Int32, mscorlib">
-    <value>237</value>
-  </data>
-  <data name="lbSixXCurveEditorURL.Text" xml:space="preserve">
-    <value>Custom curve editor</value>
-  </data>
-  <data name="&gt;&gt;lbSixXCurveEditorURL.Name" xml:space="preserve">
-    <value>lbSixXCurveEditorURL</value>
-  </data>
-  <data name="&gt;&gt;lbSixXCurveEditorURL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbSixXCurveEditorURL.Parent" xml:space="preserve">
-    <value>groupBox5</value>
-  </data>
-  <data name="&gt;&gt;lbSixXCurveEditorURL.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="nUDSZS.Location" type="System.Drawing.Point, System.Drawing">
-    <value>128, 239</value>
-  </data>
-  <data name="nUDSZS.RightToLeft" type="System.Windows.Forms.RightToLeft, System.Windows.Forms">
-    <value>No</value>
-  </data>
-  <data name="nUDSZS.Size" type="System.Drawing.Size, System.Drawing">
-    <value>70, 20</value>
-  </data>
-  <data name="nUDSZS.TabIndex" type="System.Int32, mscorlib">
-    <value>236</value>
-  </data>
-  <data name="&gt;&gt;nUDSZS.Name" xml:space="preserve">
-    <value>nUDSZS</value>
-  </data>
-  <data name="&gt;&gt;nUDSZS.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDSZS.Parent" xml:space="preserve">
-    <value>groupBox5</value>
-  </data>
-  <data name="&gt;&gt;nUDSZS.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="nUDSXS.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 239</value>
-  </data>
-  <data name="nUDSXS.Size" type="System.Drawing.Size, System.Drawing">
-    <value>68, 20</value>
-  </data>
-  <data name="nUDSXS.TabIndex" type="System.Int32, mscorlib">
-    <value>235</value>
-  </data>
-  <data name="&gt;&gt;nUDSXS.Name" xml:space="preserve">
-    <value>nUDSXS</value>
-  </data>
-  <data name="&gt;&gt;nUDSXS.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDSXS.Parent" xml:space="preserve">
-    <value>groupBox5</value>
-  </data>
-  <data name="&gt;&gt;nUDSXS.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="label74.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label74.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label74.Location" type="System.Drawing.Point, System.Drawing">
-    <value>125, 221</value>
-  </data>
-  <data name="label74.Size" type="System.Drawing.Size, System.Drawing">
-    <value>67, 13</value>
-  </data>
-  <data name="label74.TabIndex" type="System.Int32, mscorlib">
-    <value>234</value>
-  </data>
-  <data name="label74.Text" xml:space="preserve">
-    <value>Sensitivity Z:</value>
-  </data>
-  <data name="&gt;&gt;label74.Name" xml:space="preserve">
-    <value>label74</value>
-  </data>
-  <data name="&gt;&gt;label74.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label74.Parent" xml:space="preserve">
-    <value>groupBox5</value>
-  </data>
-  <data name="&gt;&gt;label74.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="label73.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label73.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label73.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 221</value>
-  </data>
-  <data name="label73.Size" type="System.Drawing.Size, System.Drawing">
-    <value>67, 13</value>
-  </data>
-  <data name="label73.TabIndex" type="System.Int32, mscorlib">
-    <value>233</value>
-  </data>
-  <data name="label73.Text" xml:space="preserve">
-    <value>Sensitivity X:</value>
-  </data>
-  <data name="&gt;&gt;label73.Name" xml:space="preserve">
-    <value>label73</value>
-  </data>
-  <data name="&gt;&gt;label73.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label73.Parent" xml:space="preserve">
-    <value>groupBox5</value>
-  </data>
-  <data name="&gt;&gt;label73.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="cBSixaxisZOutputCurve.Items" xml:space="preserve">
-    <value>Linear</value>
-  </data>
-  <data name="cBSixaxisZOutputCurve.Items1" xml:space="preserve">
-    <value>Enhanced Precison</value>
-  </data>
-  <data name="cBSixaxisZOutputCurve.Items2" xml:space="preserve">
-    <value>Quadratic</value>
-  </data>
-  <data name="cBSixaxisZOutputCurve.Items3" xml:space="preserve">
-    <value>Cubic</value>
-  </data>
-  <data name="cBSixaxisZOutputCurve.Items4" xml:space="preserve">
-    <value>Easeout Quad</value>
-  </data>
-  <data name="cBSixaxisZOutputCurve.Items5" xml:space="preserve">
-    <value>Easeout Cubic</value>
-  </data>
-  <data name="cBSixaxisZOutputCurve.Items6" xml:space="preserve">
-    <value>Custom</value>
-  </data>
-  <data name="cBSixaxisZOutputCurve.Location" type="System.Drawing.Point, System.Drawing">
-    <value>121, 356</value>
-  </data>
-  <data name="cBSixaxisZOutputCurve.Size" type="System.Drawing.Size, System.Drawing">
-    <value>109, 21</value>
-  </data>
-  <data name="cBSixaxisZOutputCurve.TabIndex" type="System.Int32, mscorlib">
-    <value>232</value>
-  </data>
-  <data name="&gt;&gt;cBSixaxisZOutputCurve.Name" xml:space="preserve">
-    <value>cBSixaxisZOutputCurve</value>
-  </data>
-  <data name="&gt;&gt;cBSixaxisZOutputCurve.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cBSixaxisZOutputCurve.Parent" xml:space="preserve">
-    <value>groupBox5</value>
-  </data>
-  <data name="&gt;&gt;cBSixaxisZOutputCurve.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="label68.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label68.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label68.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 359</value>
-  </data>
-  <data name="label68.Size" type="System.Drawing.Size, System.Drawing">
-    <value>83, 13</value>
-  </data>
-  <data name="label68.TabIndex" type="System.Int32, mscorlib">
-    <value>231</value>
-  </data>
-  <data name="label68.Text" xml:space="preserve">
-    <value>Output Curve Z:</value>
-  </data>
-  <data name="&gt;&gt;label68.Name" xml:space="preserve">
-    <value>label68</value>
-  </data>
-  <data name="&gt;&gt;label68.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label68.Parent" xml:space="preserve">
-    <value>groupBox5</value>
-  </data>
-  <data name="&gt;&gt;label68.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="cBSixaxisXOutputCurve.Items" xml:space="preserve">
-    <value>Linear</value>
-  </data>
-  <data name="cBSixaxisXOutputCurve.Items1" xml:space="preserve">
-    <value>Enhanced Precison</value>
-  </data>
-  <data name="cBSixaxisXOutputCurve.Items2" xml:space="preserve">
-    <value>Quadratic</value>
-  </data>
-  <data name="cBSixaxisXOutputCurve.Items3" xml:space="preserve">
-    <value>Cubic</value>
-  </data>
-  <data name="cBSixaxisXOutputCurve.Items4" xml:space="preserve">
-    <value>Easeout Quad</value>
-  </data>
-  <data name="cBSixaxisXOutputCurve.Items5" xml:space="preserve">
-    <value>Easeout Cubic</value>
-  </data>
-  <data name="cBSixaxisXOutputCurve.Items6" xml:space="preserve">
-    <value>Custom</value>
-  </data>
-  <data name="cBSixaxisXOutputCurve.Location" type="System.Drawing.Point, System.Drawing">
-    <value>123, 281</value>
-  </data>
-  <data name="cBSixaxisXOutputCurve.Size" type="System.Drawing.Size, System.Drawing">
-    <value>108, 21</value>
-  </data>
-  <data name="cBSixaxisXOutputCurve.TabIndex" type="System.Int32, mscorlib">
-    <value>230</value>
-  </data>
-  <data name="&gt;&gt;cBSixaxisXOutputCurve.Name" xml:space="preserve">
-    <value>cBSixaxisXOutputCurve</value>
-  </data>
-  <data name="&gt;&gt;cBSixaxisXOutputCurve.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cBSixaxisXOutputCurve.Parent" xml:space="preserve">
-    <value>groupBox5</value>
-  </data>
-  <data name="&gt;&gt;cBSixaxisXOutputCurve.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="label67.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label67.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label67.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 281</value>
-  </data>
-  <data name="label67.Size" type="System.Drawing.Size, System.Drawing">
-    <value>83, 13</value>
-  </data>
-  <data name="label67.TabIndex" type="System.Int32, mscorlib">
-    <value>229</value>
-  </data>
-  <data name="label67.Text" xml:space="preserve">
-    <value>Output Curve X:</value>
-  </data>
-  <data name="&gt;&gt;label67.Name" xml:space="preserve">
-    <value>label67</value>
-  </data>
-  <data name="&gt;&gt;label67.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label67.Parent" xml:space="preserve">
-    <value>groupBox5</value>
-  </data>
-  <data name="&gt;&gt;label67.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
-  <data name="nUDSixaxisZAntiDead.Location" type="System.Drawing.Point, System.Drawing">
-    <value>127, 181</value>
-  </data>
-  <data name="nUDSixaxisZAntiDead.Size" type="System.Drawing.Size, System.Drawing">
-    <value>68, 20</value>
-  </data>
-  <data name="nUDSixaxisZAntiDead.TabIndex" type="System.Int32, mscorlib">
-    <value>228</value>
-  </data>
-  <data name="&gt;&gt;nUDSixaxisZAntiDead.Name" xml:space="preserve">
-    <value>nUDSixaxisZAntiDead</value>
-  </data>
-  <data name="&gt;&gt;nUDSixaxisZAntiDead.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDSixaxisZAntiDead.Parent" xml:space="preserve">
-    <value>groupBox5</value>
-  </data>
-  <data name="&gt;&gt;nUDSixaxisZAntiDead.ZOrder" xml:space="preserve">
-    <value>12</value>
-  </data>
-  <data name="label66.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label66.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label66.Location" type="System.Drawing.Point, System.Drawing">
-    <value>124, 156</value>
-  </data>
-  <data name="label66.Size" type="System.Drawing.Size, System.Drawing">
-    <value>93, 13</value>
-  </data>
-  <data name="label66.TabIndex" type="System.Int32, mscorlib">
-    <value>227</value>
-  </data>
-  <data name="label66.Text" xml:space="preserve">
-    <value>Anti-dead Zone Z:</value>
-  </data>
-  <data name="&gt;&gt;label66.Name" xml:space="preserve">
-    <value>label66</value>
-  </data>
-  <data name="&gt;&gt;label66.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label66.Parent" xml:space="preserve">
-    <value>groupBox5</value>
-  </data>
-  <data name="&gt;&gt;label66.ZOrder" xml:space="preserve">
-    <value>13</value>
-  </data>
-  <data name="nUDSixaxisXAntiDead.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 181</value>
-  </data>
-  <data name="nUDSixaxisXAntiDead.Size" type="System.Drawing.Size, System.Drawing">
-    <value>68, 20</value>
-  </data>
-  <data name="nUDSixaxisXAntiDead.TabIndex" type="System.Int32, mscorlib">
-    <value>226</value>
-  </data>
-  <data name="&gt;&gt;nUDSixaxisXAntiDead.Name" xml:space="preserve">
-    <value>nUDSixaxisXAntiDead</value>
-  </data>
-  <data name="&gt;&gt;nUDSixaxisXAntiDead.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDSixaxisXAntiDead.Parent" xml:space="preserve">
-    <value>groupBox5</value>
-  </data>
-  <data name="&gt;&gt;nUDSixaxisXAntiDead.ZOrder" xml:space="preserve">
-    <value>14</value>
-  </data>
-  <data name="label65.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label65.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label65.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 155</value>
-  </data>
-  <data name="label65.Size" type="System.Drawing.Size, System.Drawing">
-    <value>93, 13</value>
-  </data>
-  <data name="label65.TabIndex" type="System.Int32, mscorlib">
-    <value>225</value>
-  </data>
-  <data name="label65.Text" xml:space="preserve">
-    <value>Anti-dead Zone X:</value>
-  </data>
-  <data name="&gt;&gt;label65.Name" xml:space="preserve">
-    <value>label65</value>
-  </data>
-  <data name="&gt;&gt;label65.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label65.Parent" xml:space="preserve">
-    <value>groupBox5</value>
-  </data>
-  <data name="&gt;&gt;label65.ZOrder" xml:space="preserve">
-    <value>15</value>
-  </data>
-  <data name="nUDSixAxisZMaxZone.Location" type="System.Drawing.Point, System.Drawing">
-    <value>128, 116</value>
-  </data>
-  <data name="nUDSixAxisZMaxZone.Size" type="System.Drawing.Size, System.Drawing">
-    <value>68, 20</value>
-  </data>
-  <data name="nUDSixAxisZMaxZone.TabIndex" type="System.Int32, mscorlib">
-    <value>224</value>
-  </data>
-  <data name="&gt;&gt;nUDSixAxisZMaxZone.Name" xml:space="preserve">
-    <value>nUDSixAxisZMaxZone</value>
-  </data>
-  <data name="&gt;&gt;nUDSixAxisZMaxZone.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDSixAxisZMaxZone.Parent" xml:space="preserve">
-    <value>groupBox5</value>
-  </data>
-  <data name="&gt;&gt;nUDSixAxisZMaxZone.ZOrder" xml:space="preserve">
-    <value>16</value>
-  </data>
-  <data name="label64.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label64.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label64.Location" type="System.Drawing.Point, System.Drawing">
-    <value>125, 88</value>
-  </data>
-  <data name="label64.Size" type="System.Drawing.Size, System.Drawing">
-    <value>68, 13</value>
-  </data>
-  <data name="label64.TabIndex" type="System.Int32, mscorlib">
-    <value>223</value>
-  </data>
-  <data name="label64.Text" xml:space="preserve">
-    <value>Max Zone Z:</value>
-  </data>
-  <data name="&gt;&gt;label64.Name" xml:space="preserve">
-    <value>label64</value>
-  </data>
-  <data name="&gt;&gt;label64.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label64.Parent" xml:space="preserve">
-    <value>groupBox5</value>
-  </data>
-  <data name="&gt;&gt;label64.ZOrder" xml:space="preserve">
-    <value>17</value>
-  </data>
-  <data name="nUDSixAxisXMaxZone.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 118</value>
-  </data>
-  <data name="nUDSixAxisXMaxZone.Size" type="System.Drawing.Size, System.Drawing">
-    <value>68, 20</value>
-  </data>
-  <data name="nUDSixAxisXMaxZone.TabIndex" type="System.Int32, mscorlib">
-    <value>222</value>
-  </data>
-  <data name="&gt;&gt;nUDSixAxisXMaxZone.Name" xml:space="preserve">
-    <value>nUDSixAxisXMaxZone</value>
-  </data>
-  <data name="&gt;&gt;nUDSixAxisXMaxZone.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDSixAxisXMaxZone.Parent" xml:space="preserve">
-    <value>groupBox5</value>
-  </data>
-  <data name="&gt;&gt;nUDSixAxisXMaxZone.ZOrder" xml:space="preserve">
-    <value>18</value>
-  </data>
-  <data name="label63.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label63.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label63.Location" type="System.Drawing.Point, System.Drawing">
-    <value>14, 87</value>
-  </data>
-  <data name="label63.Size" type="System.Drawing.Size, System.Drawing">
-    <value>68, 13</value>
-  </data>
-  <data name="label63.TabIndex" type="System.Int32, mscorlib">
-    <value>221</value>
-  </data>
-  <data name="label63.Text" xml:space="preserve">
-    <value>Max Zone X:</value>
-  </data>
-  <data name="&gt;&gt;label63.Name" xml:space="preserve">
-    <value>label63</value>
-  </data>
-  <data name="&gt;&gt;label63.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label63.Parent" xml:space="preserve">
-    <value>groupBox5</value>
-  </data>
-  <data name="&gt;&gt;label63.ZOrder" xml:space="preserve">
-    <value>19</value>
-  </data>
-  <data name="nUDSZ.Location" type="System.Drawing.Point, System.Drawing">
-    <value>128, 50</value>
-  </data>
-  <data name="nUDSZ.RightToLeft" type="System.Windows.Forms.RightToLeft, System.Windows.Forms">
-    <value>No</value>
-  </data>
-  <data name="nUDSZ.Size" type="System.Drawing.Size, System.Drawing">
-    <value>68, 20</value>
-  </data>
-  <data name="nUDSZ.TabIndex" type="System.Int32, mscorlib">
-    <value>220</value>
-  </data>
-  <data name="&gt;&gt;nUDSZ.Name" xml:space="preserve">
-    <value>nUDSZ</value>
-  </data>
-  <data name="&gt;&gt;nUDSZ.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDSZ.Parent" xml:space="preserve">
-    <value>groupBox5</value>
-  </data>
-  <data name="&gt;&gt;nUDSZ.ZOrder" xml:space="preserve">
-    <value>20</value>
-  </data>
-  <data name="label62.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label62.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label62.Location" type="System.Drawing.Point, System.Drawing">
-    <value>125, 24</value>
-  </data>
-  <data name="label62.Size" type="System.Drawing.Size, System.Drawing">
-    <value>74, 13</value>
-  </data>
-  <data name="label62.TabIndex" type="System.Int32, mscorlib">
-    <value>219</value>
-  </data>
-  <data name="label62.Text" xml:space="preserve">
-    <value>Dead Zone Z:</value>
-  </data>
-  <data name="&gt;&gt;label62.Name" xml:space="preserve">
-    <value>label62</value>
-  </data>
-  <data name="&gt;&gt;label62.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label62.Parent" xml:space="preserve">
-    <value>groupBox5</value>
-  </data>
-  <data name="&gt;&gt;label62.ZOrder" xml:space="preserve">
-    <value>21</value>
-  </data>
-  <data name="nUDSX.Location" type="System.Drawing.Point, System.Drawing">
-    <value>17, 48</value>
-  </data>
-  <data name="nUDSX.Size" type="System.Drawing.Size, System.Drawing">
-    <value>68, 20</value>
-  </data>
-  <data name="nUDSX.TabIndex" type="System.Int32, mscorlib">
-    <value>218</value>
-  </data>
-  <data name="&gt;&gt;nUDSX.Name" xml:space="preserve">
-    <value>nUDSX</value>
-  </data>
-  <data name="&gt;&gt;nUDSX.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDSX.Parent" xml:space="preserve">
-    <value>groupBox5</value>
-  </data>
-  <data name="&gt;&gt;nUDSX.ZOrder" xml:space="preserve">
-    <value>22</value>
-  </data>
-  <data name="label61.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label61.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label61.Location" type="System.Drawing.Point, System.Drawing">
-    <value>14, 24</value>
-  </data>
-  <data name="label61.Size" type="System.Drawing.Size, System.Drawing">
-    <value>74, 13</value>
-  </data>
-  <data name="label61.TabIndex" type="System.Int32, mscorlib">
-    <value>217</value>
-  </data>
-  <data name="label61.Text" xml:space="preserve">
-    <value>Dead Zone X:</value>
-  </data>
-  <data name="&gt;&gt;label61.Name" xml:space="preserve">
-    <value>label61</value>
-  </data>
-  <data name="&gt;&gt;label61.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label61.Parent" xml:space="preserve">
-    <value>groupBox5</value>
-  </data>
-  <data name="&gt;&gt;label61.ZOrder" xml:space="preserve">
-    <value>23</value>
-  </data>
   <data name="flowLayoutPanel2.AutoScroll" type="System.Boolean, mscorlib">
     <value>True</value>
-  </data>
-  <data name="&gt;&gt;panel6.Name" xml:space="preserve">
-    <value>panel6</value>
-  </data>
-  <data name="&gt;&gt;panel6.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;panel6.Parent" xml:space="preserve">
-    <value>flowLayoutPanel2</value>
-  </data>
-  <data name="&gt;&gt;panel6.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;gyroMouseJoyFLP.Name" xml:space="preserve">
-    <value>gyroMouseJoyFLP</value>
-  </data>
-  <data name="&gt;&gt;gyroMouseJoyFLP.Type" xml:space="preserve">
-    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;gyroMouseJoyFLP.Parent" xml:space="preserve">
-    <value>flowLayoutPanel2</value>
-  </data>
-  <data name="&gt;&gt;gyroMouseJoyFLP.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;fLPTiltControls.Name" xml:space="preserve">
-    <value>fLPTiltControls</value>
-  </data>
-  <data name="&gt;&gt;fLPTiltControls.Type" xml:space="preserve">
-    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;fLPTiltControls.Parent" xml:space="preserve">
-    <value>flowLayoutPanel2</value>
-  </data>
-  <data name="&gt;&gt;fLPTiltControls.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;pnlSAMouse.Name" xml:space="preserve">
-    <value>pnlSAMouse</value>
-  </data>
-  <data name="&gt;&gt;pnlSAMouse.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;pnlSAMouse.Parent" xml:space="preserve">
-    <value>flowLayoutPanel2</value>
-  </data>
-  <data name="&gt;&gt;pnlSAMouse.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="flowLayoutPanel2.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="flowLayoutPanel2.FlowDirection" type="System.Windows.Forms.FlowDirection, System.Windows.Forms">
-    <value>TopDown</value>
-  </data>
-  <data name="flowLayoutPanel2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="flowLayoutPanel2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>557, 485</value>
-  </data>
-  <data name="flowLayoutPanel2.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="flowLayoutPanel2.WrapContents" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanel2.Name" xml:space="preserve">
-    <value>flowLayoutPanel2</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanel2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanel2.Parent" xml:space="preserve">
-    <value>tabGyro</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanel2.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;label34.Name" xml:space="preserve">
-    <value>label34</value>
-  </data>
-  <data name="&gt;&gt;label34.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label34.Parent" xml:space="preserve">
-    <value>panel6</value>
-  </data>
-  <data name="&gt;&gt;label34.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;gyroOutputMode.Name" xml:space="preserve">
-    <value>gyroOutputMode</value>
-  </data>
-  <data name="&gt;&gt;gyroOutputMode.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;gyroOutputMode.Parent" xml:space="preserve">
-    <value>panel6</value>
-  </data>
-  <data name="&gt;&gt;gyroOutputMode.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="panel6.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 3</value>
-  </data>
-  <data name="panel6.Size" type="System.Drawing.Size, System.Drawing">
-    <value>307, 33</value>
-  </data>
-  <data name="panel6.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;panel6.Name" xml:space="preserve">
-    <value>panel6</value>
-  </data>
-  <data name="&gt;&gt;panel6.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;panel6.Parent" xml:space="preserve">
-    <value>flowLayoutPanel2</value>
-  </data>
-  <data name="&gt;&gt;panel6.ZOrder" xml:space="preserve">
-    <value>0</value>
   </data>
   <data name="label34.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -10956,314 +7596,26 @@
   <data name="&gt;&gt;gyroOutputMode.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="&gt;&gt;label36.Name" xml:space="preserve">
-    <value>label36</value>
+  <data name="panel6.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 3</value>
   </data>
-  <data name="&gt;&gt;label36.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="panel6.Size" type="System.Drawing.Size, System.Drawing">
+    <value>307, 33</value>
   </data>
-  <data name="&gt;&gt;label36.Parent" xml:space="preserve">
-    <value>gyroMouseJoyFLP</value>
-  </data>
-  <data name="&gt;&gt;label36.ZOrder" xml:space="preserve">
+  <data name="panel6.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <data name="&gt;&gt;btnGyroMStickTrig.Name" xml:space="preserve">
-    <value>btnGyroMStickTrig</value>
+  <data name="&gt;&gt;panel6.Name" xml:space="preserve">
+    <value>panel6</value>
   </data>
-  <data name="&gt;&gt;btnGyroMStickTrig.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;panel6.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;btnGyroMStickTrig.Parent" xml:space="preserve">
-    <value>gyroMouseJoyFLP</value>
-  </data>
-  <data name="&gt;&gt;btnGyroMStickTrig.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;gyroMStickTrigBehaveCk.Name" xml:space="preserve">
-    <value>gyroMStickTrigBehaveCk</value>
-  </data>
-  <data name="&gt;&gt;gyroMStickTrigBehaveCk.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;gyroMStickTrigBehaveCk.Parent" xml:space="preserve">
-    <value>gyroMouseJoyFLP</value>
-  </data>
-  <data name="&gt;&gt;gyroMStickTrigBehaveCk.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;gyroMStickToggleCk.Name" xml:space="preserve">
-    <value>gyroMStickToggleCk</value>
-  </data>
-  <data name="&gt;&gt;gyroMStickToggleCk.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;gyroMStickToggleCk.Parent" xml:space="preserve">
-    <value>gyroMouseJoyFLP</value>
-  </data>
-  <data name="&gt;&gt;gyroMStickToggleCk.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;label29.Name" xml:space="preserve">
-    <value>label29</value>
-  </data>
-  <data name="&gt;&gt;label29.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label29.Parent" xml:space="preserve">
-    <value>gyroMouseJoyFLP</value>
-  </data>
-  <data name="&gt;&gt;label29.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;gyroMouseStickDZ.Name" xml:space="preserve">
-    <value>gyroMouseStickDZ</value>
-  </data>
-  <data name="&gt;&gt;gyroMouseStickDZ.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;gyroMouseStickDZ.Parent" xml:space="preserve">
-    <value>gyroMouseJoyFLP</value>
-  </data>
-  <data name="&gt;&gt;gyroMouseStickDZ.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;label30.Name" xml:space="preserve">
-    <value>label30</value>
-  </data>
-  <data name="&gt;&gt;label30.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label30.Parent" xml:space="preserve">
-    <value>gyroMouseJoyFLP</value>
-  </data>
-  <data name="&gt;&gt;label30.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;gyroMouseStickMaxZ.Name" xml:space="preserve">
-    <value>gyroMouseStickMaxZ</value>
-  </data>
-  <data name="&gt;&gt;gyroMouseStickMaxZ.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;gyroMouseStickMaxZ.Parent" xml:space="preserve">
-    <value>gyroMouseJoyFLP</value>
-  </data>
-  <data name="&gt;&gt;gyroMouseStickMaxZ.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="&gt;&gt;label31.Name" xml:space="preserve">
-    <value>label31</value>
-  </data>
-  <data name="&gt;&gt;label31.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label31.Parent" xml:space="preserve">
-    <value>gyroMouseJoyFLP</value>
-  </data>
-  <data name="&gt;&gt;label31.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;gyroMouseStickAntiDeadX.Name" xml:space="preserve">
-    <value>gyroMouseStickAntiDeadX</value>
-  </data>
-  <data name="&gt;&gt;gyroMouseStickAntiDeadX.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;gyroMouseStickAntiDeadX.Parent" xml:space="preserve">
-    <value>gyroMouseJoyFLP</value>
-  </data>
-  <data name="&gt;&gt;gyroMouseStickAntiDeadX.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="&gt;&gt;label32.Name" xml:space="preserve">
-    <value>label32</value>
-  </data>
-  <data name="&gt;&gt;label32.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label32.Parent" xml:space="preserve">
-    <value>gyroMouseJoyFLP</value>
-  </data>
-  <data name="&gt;&gt;label32.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="&gt;&gt;gyroMouseStickAntiDeadY.Name" xml:space="preserve">
-    <value>gyroMouseStickAntiDeadY</value>
-  </data>
-  <data name="&gt;&gt;gyroMouseStickAntiDeadY.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;gyroMouseStickAntiDeadY.Parent" xml:space="preserve">
-    <value>gyroMouseJoyFLP</value>
-  </data>
-  <data name="&gt;&gt;gyroMouseStickAntiDeadY.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
-  <data name="&gt;&gt;label37.Name" xml:space="preserve">
-    <value>label37</value>
-  </data>
-  <data name="&gt;&gt;label37.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label37.Parent" xml:space="preserve">
-    <value>gyroMouseJoyFLP</value>
-  </data>
-  <data name="&gt;&gt;label37.ZOrder" xml:space="preserve">
-    <value>12</value>
-  </data>
-  <data name="&gt;&gt;gyroMStickVertScaleNUD.Name" xml:space="preserve">
-    <value>gyroMStickVertScaleNUD</value>
-  </data>
-  <data name="&gt;&gt;gyroMStickVertScaleNUD.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;gyroMStickVertScaleNUD.Parent" xml:space="preserve">
-    <value>gyroMouseJoyFLP</value>
-  </data>
-  <data name="&gt;&gt;gyroMStickVertScaleNUD.ZOrder" xml:space="preserve">
-    <value>13</value>
-  </data>
-  <data name="&gt;&gt;label38.Name" xml:space="preserve">
-    <value>label38</value>
-  </data>
-  <data name="&gt;&gt;label38.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label38.Parent" xml:space="preserve">
-    <value>gyroMouseJoyFLP</value>
-  </data>
-  <data name="&gt;&gt;label38.ZOrder" xml:space="preserve">
-    <value>14</value>
-  </data>
-  <data name="&gt;&gt;label35.Name" xml:space="preserve">
-    <value>label35</value>
-  </data>
-  <data name="&gt;&gt;label35.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label35.Parent" xml:space="preserve">
-    <value>gyroMouseJoyFLP</value>
-  </data>
-  <data name="&gt;&gt;label35.ZOrder" xml:space="preserve">
-    <value>15</value>
-  </data>
-  <data name="&gt;&gt;gyroMouseStickEvalCombo.Name" xml:space="preserve">
-    <value>gyroMouseStickEvalCombo</value>
-  </data>
-  <data name="&gt;&gt;gyroMouseStickEvalCombo.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;gyroMouseStickEvalCombo.Parent" xml:space="preserve">
-    <value>gyroMouseJoyFLP</value>
-  </data>
-  <data name="&gt;&gt;gyroMouseStickEvalCombo.ZOrder" xml:space="preserve">
-    <value>16</value>
-  </data>
-  <data name="&gt;&gt;label33.Name" xml:space="preserve">
-    <value>label33</value>
-  </data>
-  <data name="&gt;&gt;label33.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label33.Parent" xml:space="preserve">
-    <value>gyroMouseJoyFLP</value>
-  </data>
-  <data name="&gt;&gt;label33.ZOrder" xml:space="preserve">
-    <value>17</value>
-  </data>
-  <data name="&gt;&gt;gyroMousestickXAxisCom.Name" xml:space="preserve">
-    <value>gyroMousestickXAxisCom</value>
-  </data>
-  <data name="&gt;&gt;gyroMousestickXAxisCom.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;gyroMousestickXAxisCom.Parent" xml:space="preserve">
-    <value>gyroMouseJoyFLP</value>
-  </data>
-  <data name="&gt;&gt;gyroMousestickXAxisCom.ZOrder" xml:space="preserve">
-    <value>18</value>
-  </data>
-  <data name="&gt;&gt;gyroMouseStickInvertXCk.Name" xml:space="preserve">
-    <value>gyroMouseStickInvertXCk</value>
-  </data>
-  <data name="&gt;&gt;gyroMouseStickInvertXCk.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;gyroMouseStickInvertXCk.Parent" xml:space="preserve">
-    <value>gyroMouseJoyFLP</value>
-  </data>
-  <data name="&gt;&gt;gyroMouseStickInvertXCk.ZOrder" xml:space="preserve">
-    <value>19</value>
-  </data>
-  <data name="&gt;&gt;gyroMouseStickInvertYCk.Name" xml:space="preserve">
-    <value>gyroMouseStickInvertYCk</value>
-  </data>
-  <data name="&gt;&gt;gyroMouseStickInvertYCk.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;gyroMouseStickInvertYCk.Parent" xml:space="preserve">
-    <value>gyroMouseJoyFLP</value>
-  </data>
-  <data name="&gt;&gt;gyroMouseStickInvertYCk.ZOrder" xml:space="preserve">
-    <value>20</value>
-  </data>
-  <data name="&gt;&gt;gyroMStickUseSmoothCk.Name" xml:space="preserve">
-    <value>gyroMStickUseSmoothCk</value>
-  </data>
-  <data name="&gt;&gt;gyroMStickUseSmoothCk.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;gyroMStickUseSmoothCk.Parent" xml:space="preserve">
-    <value>gyroMouseJoyFLP</value>
-  </data>
-  <data name="&gt;&gt;gyroMStickUseSmoothCk.ZOrder" xml:space="preserve">
-    <value>21</value>
-  </data>
-  <data name="&gt;&gt;label39.Name" xml:space="preserve">
-    <value>label39</value>
-  </data>
-  <data name="&gt;&gt;label39.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label39.Parent" xml:space="preserve">
-    <value>gyroMouseJoyFLP</value>
-  </data>
-  <data name="&gt;&gt;label39.ZOrder" xml:space="preserve">
-    <value>22</value>
-  </data>
-  <data name="&gt;&gt;gyroMStickSmoothWeightNUD.Name" xml:space="preserve">
-    <value>gyroMStickSmoothWeightNUD</value>
-  </data>
-  <data name="&gt;&gt;gyroMStickSmoothWeightNUD.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;gyroMStickSmoothWeightNUD.Parent" xml:space="preserve">
-    <value>gyroMouseJoyFLP</value>
-  </data>
-  <data name="&gt;&gt;gyroMStickSmoothWeightNUD.ZOrder" xml:space="preserve">
-    <value>23</value>
-  </data>
-  <data name="gyroMouseJoyFLP.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 42</value>
-  </data>
-  <data name="gyroMouseJoyFLP.Size" type="System.Drawing.Size, System.Drawing">
-    <value>252, 210</value>
-  </data>
-  <data name="gyroMouseJoyFLP.TabIndex" type="System.Int32, mscorlib">
-    <value>261</value>
-  </data>
-  <data name="&gt;&gt;gyroMouseJoyFLP.Name" xml:space="preserve">
-    <value>gyroMouseJoyFLP</value>
-  </data>
-  <data name="&gt;&gt;gyroMouseJoyFLP.Type" xml:space="preserve">
-    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;gyroMouseJoyFLP.Parent" xml:space="preserve">
+  <data name="&gt;&gt;panel6.Parent" xml:space="preserve">
     <value>flowLayoutPanel2</value>
   </data>
-  <data name="&gt;&gt;gyroMouseJoyFLP.ZOrder" xml:space="preserve">
-    <value>1</value>
+  <data name="&gt;&gt;panel6.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="label36.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -11931,182 +8283,26 @@
   <data name="&gt;&gt;gyroMStickSmoothWeightNUD.ZOrder" xml:space="preserve">
     <value>23</value>
   </data>
-  <data name="&gt;&gt;bnGyroZN.Name" xml:space="preserve">
-    <value>bnGyroZN</value>
+  <data name="gyroMouseJoyFLP.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 42</value>
   </data>
-  <data name="&gt;&gt;bnGyroZN.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="gyroMouseJoyFLP.Size" type="System.Drawing.Size, System.Drawing">
+    <value>252, 210</value>
   </data>
-  <data name="&gt;&gt;bnGyroZN.Parent" xml:space="preserve">
-    <value>fLPTiltControls</value>
+  <data name="gyroMouseJoyFLP.TabIndex" type="System.Int32, mscorlib">
+    <value>261</value>
   </data>
-  <data name="&gt;&gt;bnGyroZN.ZOrder" xml:space="preserve">
-    <value>0</value>
+  <data name="&gt;&gt;gyroMouseJoyFLP.Name" xml:space="preserve">
+    <value>gyroMouseJoyFLP</value>
   </data>
-  <data name="&gt;&gt;lbGyroZN.Name" xml:space="preserve">
-    <value>lbGyroZN</value>
-  </data>
-  <data name="&gt;&gt;lbGyroZN.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbGyroZN.Parent" xml:space="preserve">
-    <value>fLPTiltControls</value>
-  </data>
-  <data name="&gt;&gt;lbGyroZN.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;bnGyroZP.Name" xml:space="preserve">
-    <value>bnGyroZP</value>
-  </data>
-  <data name="&gt;&gt;bnGyroZP.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;bnGyroZP.Parent" xml:space="preserve">
-    <value>fLPTiltControls</value>
-  </data>
-  <data name="&gt;&gt;bnGyroZP.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;lbGyroZP.Name" xml:space="preserve">
-    <value>lbGyroZP</value>
-  </data>
-  <data name="&gt;&gt;lbGyroZP.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbGyroZP.Parent" xml:space="preserve">
-    <value>fLPTiltControls</value>
-  </data>
-  <data name="&gt;&gt;lbGyroZP.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;bnGyroXP.Name" xml:space="preserve">
-    <value>bnGyroXP</value>
-  </data>
-  <data name="&gt;&gt;bnGyroXP.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;bnGyroXP.Parent" xml:space="preserve">
-    <value>fLPTiltControls</value>
-  </data>
-  <data name="&gt;&gt;bnGyroXP.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;lbGyroXP.Name" xml:space="preserve">
-    <value>lbGyroXP</value>
-  </data>
-  <data name="&gt;&gt;lbGyroXP.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbGyroXP.Parent" xml:space="preserve">
-    <value>fLPTiltControls</value>
-  </data>
-  <data name="&gt;&gt;lbGyroXP.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;bnGyroXN.Name" xml:space="preserve">
-    <value>bnGyroXN</value>
-  </data>
-  <data name="&gt;&gt;bnGyroXN.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;bnGyroXN.Parent" xml:space="preserve">
-    <value>fLPTiltControls</value>
-  </data>
-  <data name="&gt;&gt;bnGyroXN.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;lbGyroXN.Name" xml:space="preserve">
-    <value>lbGyroXN</value>
-  </data>
-  <data name="&gt;&gt;lbGyroXN.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbGyroXN.Parent" xml:space="preserve">
-    <value>fLPTiltControls</value>
-  </data>
-  <data name="&gt;&gt;lbGyroXN.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="&gt;&gt;lblSteeringWheelEmulationAxis.Name" xml:space="preserve">
-    <value>lblSteeringWheelEmulationAxis</value>
-  </data>
-  <data name="&gt;&gt;lblSteeringWheelEmulationAxis.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblSteeringWheelEmulationAxis.Parent" xml:space="preserve">
-    <value>fLPTiltControls</value>
-  </data>
-  <data name="&gt;&gt;lblSteeringWheelEmulationAxis.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;cBSteeringWheelEmulationAxis.Name" xml:space="preserve">
-    <value>cBSteeringWheelEmulationAxis</value>
-  </data>
-  <data name="&gt;&gt;cBSteeringWheelEmulationAxis.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cBSteeringWheelEmulationAxis.Parent" xml:space="preserve">
-    <value>fLPTiltControls</value>
-  </data>
-  <data name="&gt;&gt;cBSteeringWheelEmulationAxis.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="&gt;&gt;lblSteeringWheelEmulationRange.Name" xml:space="preserve">
-    <value>lblSteeringWheelEmulationRange</value>
-  </data>
-  <data name="&gt;&gt;lblSteeringWheelEmulationRange.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblSteeringWheelEmulationRange.Parent" xml:space="preserve">
-    <value>fLPTiltControls</value>
-  </data>
-  <data name="&gt;&gt;lblSteeringWheelEmulationRange.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="&gt;&gt;cBSteeringWheelEmulationRange.Name" xml:space="preserve">
-    <value>cBSteeringWheelEmulationRange</value>
-  </data>
-  <data name="&gt;&gt;cBSteeringWheelEmulationRange.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cBSteeringWheelEmulationRange.Parent" xml:space="preserve">
-    <value>fLPTiltControls</value>
-  </data>
-  <data name="&gt;&gt;cBSteeringWheelEmulationRange.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
-  <data name="&gt;&gt;btnSteeringWheelEmulationCalibrate.Name" xml:space="preserve">
-    <value>btnSteeringWheelEmulationCalibrate</value>
-  </data>
-  <data name="&gt;&gt;btnSteeringWheelEmulationCalibrate.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnSteeringWheelEmulationCalibrate.Parent" xml:space="preserve">
-    <value>fLPTiltControls</value>
-  </data>
-  <data name="&gt;&gt;btnSteeringWheelEmulationCalibrate.ZOrder" xml:space="preserve">
-    <value>12</value>
-  </data>
-  <data name="fLPTiltControls.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 258</value>
-  </data>
-  <data name="fLPTiltControls.Size" type="System.Drawing.Size, System.Drawing">
-    <value>271, 199</value>
-  </data>
-  <data name="fLPTiltControls.TabIndex" type="System.Int32, mscorlib">
-    <value>262</value>
-  </data>
-  <data name="&gt;&gt;fLPTiltControls.Name" xml:space="preserve">
-    <value>fLPTiltControls</value>
-  </data>
-  <data name="&gt;&gt;fLPTiltControls.Type" xml:space="preserve">
+  <data name="&gt;&gt;gyroMouseJoyFLP.Type" xml:space="preserve">
     <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;fLPTiltControls.Parent" xml:space="preserve">
+  <data name="&gt;&gt;gyroMouseJoyFLP.Parent" xml:space="preserve">
     <value>flowLayoutPanel2</value>
   </data>
-  <data name="&gt;&gt;fLPTiltControls.ZOrder" xml:space="preserve">
-    <value>2</value>
+  <data name="&gt;&gt;gyroMouseJoyFLP.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
   <data name="bnGyroZN.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -12522,293 +8718,26 @@
   <data name="&gt;&gt;btnSteeringWheelEmulationCalibrate.ZOrder" xml:space="preserve">
     <value>12</value>
   </data>
-  <data name="&gt;&gt;toggleGyroMCb.Name" xml:space="preserve">
-    <value>toggleGyroMCb</value>
+  <data name="fLPTiltControls.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 258</value>
   </data>
-  <data name="&gt;&gt;toggleGyroMCb.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="fLPTiltControls.Size" type="System.Drawing.Size, System.Drawing">
+    <value>271, 199</value>
   </data>
-  <data name="&gt;&gt;toggleGyroMCb.Parent" xml:space="preserve">
-    <value>pnlSAMouse</value>
+  <data name="fLPTiltControls.TabIndex" type="System.Int32, mscorlib">
+    <value>262</value>
   </data>
-  <data name="&gt;&gt;toggleGyroMCb.ZOrder" xml:space="preserve">
-    <value>0</value>
+  <data name="&gt;&gt;fLPTiltControls.Name" xml:space="preserve">
+    <value>fLPTiltControls</value>
   </data>
-  <data name="&gt;&gt;label27.Name" xml:space="preserve">
-    <value>label27</value>
+  <data name="&gt;&gt;fLPTiltControls.Type" xml:space="preserve">
+    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;label27.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label27.Parent" xml:space="preserve">
-    <value>pnlSAMouse</value>
-  </data>
-  <data name="&gt;&gt;label27.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;gyroMouseDzNUD.Name" xml:space="preserve">
-    <value>gyroMouseDzNUD</value>
-  </data>
-  <data name="&gt;&gt;gyroMouseDzNUD.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;gyroMouseDzNUD.Parent" xml:space="preserve">
-    <value>pnlSAMouse</value>
-  </data>
-  <data name="&gt;&gt;gyroMouseDzNUD.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;label26.Name" xml:space="preserve">
-    <value>label26</value>
-  </data>
-  <data name="&gt;&gt;label26.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label26.Parent" xml:space="preserve">
-    <value>pnlSAMouse</value>
-  </data>
-  <data name="&gt;&gt;label26.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;triggerCondAndCombo.Name" xml:space="preserve">
-    <value>triggerCondAndCombo</value>
-  </data>
-  <data name="&gt;&gt;triggerCondAndCombo.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;triggerCondAndCombo.Parent" xml:space="preserve">
-    <value>pnlSAMouse</value>
-  </data>
-  <data name="&gt;&gt;triggerCondAndCombo.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;cBGyroMouseXAxis.Name" xml:space="preserve">
-    <value>cBGyroMouseXAxis</value>
-  </data>
-  <data name="&gt;&gt;cBGyroMouseXAxis.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cBGyroMouseXAxis.Parent" xml:space="preserve">
-    <value>pnlSAMouse</value>
-  </data>
-  <data name="&gt;&gt;cBGyroMouseXAxis.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;label16.Name" xml:space="preserve">
-    <value>label16</value>
-  </data>
-  <data name="&gt;&gt;label16.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label16.Parent" xml:space="preserve">
-    <value>pnlSAMouse</value>
-  </data>
-  <data name="&gt;&gt;label16.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;lbGyroSmooth.Name" xml:space="preserve">
-    <value>lbGyroSmooth</value>
-  </data>
-  <data name="&gt;&gt;lbGyroSmooth.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbGyroSmooth.Parent" xml:space="preserve">
-    <value>pnlSAMouse</value>
-  </data>
-  <data name="&gt;&gt;lbGyroSmooth.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="&gt;&gt;cBGyroSmooth.Name" xml:space="preserve">
-    <value>cBGyroSmooth</value>
-  </data>
-  <data name="&gt;&gt;cBGyroSmooth.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cBGyroSmooth.Parent" xml:space="preserve">
-    <value>pnlSAMouse</value>
-  </data>
-  <data name="&gt;&gt;cBGyroSmooth.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;lbSmoothWeight.Name" xml:space="preserve">
-    <value>lbSmoothWeight</value>
-  </data>
-  <data name="&gt;&gt;lbSmoothWeight.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbSmoothWeight.Parent" xml:space="preserve">
-    <value>pnlSAMouse</value>
-  </data>
-  <data name="&gt;&gt;lbSmoothWeight.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="&gt;&gt;nUDGyroSmoothWeight.Name" xml:space="preserve">
-    <value>nUDGyroSmoothWeight</value>
-  </data>
-  <data name="&gt;&gt;nUDGyroSmoothWeight.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDGyroSmoothWeight.Parent" xml:space="preserve">
-    <value>pnlSAMouse</value>
-  </data>
-  <data name="&gt;&gt;nUDGyroSmoothWeight.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="&gt;&gt;label12.Name" xml:space="preserve">
-    <value>label12</value>
-  </data>
-  <data name="&gt;&gt;label12.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label12.Parent" xml:space="preserve">
-    <value>pnlSAMouse</value>
-  </data>
-  <data name="&gt;&gt;label12.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
-  <data name="&gt;&gt;nUDGyroMouseVertScale.Name" xml:space="preserve">
-    <value>nUDGyroMouseVertScale</value>
-  </data>
-  <data name="&gt;&gt;nUDGyroMouseVertScale.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDGyroMouseVertScale.Parent" xml:space="preserve">
-    <value>pnlSAMouse</value>
-  </data>
-  <data name="&gt;&gt;nUDGyroMouseVertScale.ZOrder" xml:space="preserve">
-    <value>12</value>
-  </data>
-  <data name="&gt;&gt;label11.Name" xml:space="preserve">
-    <value>label11</value>
-  </data>
-  <data name="&gt;&gt;label11.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label11.Parent" xml:space="preserve">
-    <value>pnlSAMouse</value>
-  </data>
-  <data name="&gt;&gt;label11.ZOrder" xml:space="preserve">
-    <value>13</value>
-  </data>
-  <data name="&gt;&gt;gyroTriggerBehavior.Name" xml:space="preserve">
-    <value>gyroTriggerBehavior</value>
-  </data>
-  <data name="&gt;&gt;gyroTriggerBehavior.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;gyroTriggerBehavior.Parent" xml:space="preserve">
-    <value>pnlSAMouse</value>
-  </data>
-  <data name="&gt;&gt;gyroTriggerBehavior.ZOrder" xml:space="preserve">
-    <value>14</value>
-  </data>
-  <data name="&gt;&gt;cBGyroInvertY.Name" xml:space="preserve">
-    <value>cBGyroInvertY</value>
-  </data>
-  <data name="&gt;&gt;cBGyroInvertY.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cBGyroInvertY.Parent" xml:space="preserve">
-    <value>pnlSAMouse</value>
-  </data>
-  <data name="&gt;&gt;cBGyroInvertY.ZOrder" xml:space="preserve">
-    <value>15</value>
-  </data>
-  <data name="&gt;&gt;cBGyroInvertX.Name" xml:space="preserve">
-    <value>cBGyroInvertX</value>
-  </data>
-  <data name="&gt;&gt;cBGyroInvertX.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cBGyroInvertX.Parent" xml:space="preserve">
-    <value>pnlSAMouse</value>
-  </data>
-  <data name="&gt;&gt;cBGyroInvertX.ZOrder" xml:space="preserve">
-    <value>16</value>
-  </data>
-  <data name="&gt;&gt;lbGyroInvert.Name" xml:space="preserve">
-    <value>lbGyroInvert</value>
-  </data>
-  <data name="&gt;&gt;lbGyroInvert.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbGyroInvert.Parent" xml:space="preserve">
-    <value>pnlSAMouse</value>
-  </data>
-  <data name="&gt;&gt;lbGyroInvert.ZOrder" xml:space="preserve">
-    <value>17</value>
-  </data>
-  <data name="&gt;&gt;lbGyroTriggers.Name" xml:space="preserve">
-    <value>lbGyroTriggers</value>
-  </data>
-  <data name="&gt;&gt;lbGyroTriggers.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbGyroTriggers.Parent" xml:space="preserve">
-    <value>pnlSAMouse</value>
-  </data>
-  <data name="&gt;&gt;lbGyroTriggers.ZOrder" xml:space="preserve">
-    <value>18</value>
-  </data>
-  <data name="&gt;&gt;btnGyroTriggers.Name" xml:space="preserve">
-    <value>btnGyroTriggers</value>
-  </data>
-  <data name="&gt;&gt;btnGyroTriggers.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnGyroTriggers.Parent" xml:space="preserve">
-    <value>pnlSAMouse</value>
-  </data>
-  <data name="&gt;&gt;btnGyroTriggers.ZOrder" xml:space="preserve">
-    <value>19</value>
-  </data>
-  <data name="&gt;&gt;nUDGyroSensitivity.Name" xml:space="preserve">
-    <value>nUDGyroSensitivity</value>
-  </data>
-  <data name="&gt;&gt;nUDGyroSensitivity.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDGyroSensitivity.Parent" xml:space="preserve">
-    <value>pnlSAMouse</value>
-  </data>
-  <data name="&gt;&gt;nUDGyroSensitivity.ZOrder" xml:space="preserve">
-    <value>20</value>
-  </data>
-  <data name="&gt;&gt;lbGyroSens.Name" xml:space="preserve">
-    <value>lbGyroSens</value>
-  </data>
-  <data name="&gt;&gt;lbGyroSens.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbGyroSens.Parent" xml:space="preserve">
-    <value>pnlSAMouse</value>
-  </data>
-  <data name="&gt;&gt;lbGyroSens.ZOrder" xml:space="preserve">
-    <value>21</value>
-  </data>
-  <data name="pnlSAMouse.Location" type="System.Drawing.Point, System.Drawing">
-    <value>2, 462</value>
-  </data>
-  <data name="pnlSAMouse.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>2, 2, 2, 2</value>
-  </data>
-  <data name="pnlSAMouse.Size" type="System.Drawing.Size, System.Drawing">
-    <value>263, 222</value>
-  </data>
-  <data name="pnlSAMouse.TabIndex" type="System.Int32, mscorlib">
-    <value>263</value>
-  </data>
-  <data name="&gt;&gt;pnlSAMouse.Name" xml:space="preserve">
-    <value>pnlSAMouse</value>
-  </data>
-  <data name="&gt;&gt;pnlSAMouse.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;pnlSAMouse.Parent" xml:space="preserve">
+  <data name="&gt;&gt;fLPTiltControls.Parent" xml:space="preserve">
     <value>flowLayoutPanel2</value>
   </data>
-  <data name="&gt;&gt;pnlSAMouse.ZOrder" xml:space="preserve">
-    <value>3</value>
+  <data name="&gt;&gt;fLPTiltControls.ZOrder" xml:space="preserve">
+    <value>2</value>
   </data>
   <data name="toggleGyroMCb.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -13452,242 +9381,86 @@
   <data name="&gt;&gt;lbGyroSens.ZOrder" xml:space="preserve">
     <value>21</value>
   </data>
-  <data name="flowLayoutPanel4.AutoScroll" type="System.Boolean, mscorlib">
-    <value>True</value>
+  <data name="pnlSAMouse.Location" type="System.Drawing.Point, System.Drawing">
+    <value>2, 462</value>
   </data>
-  <data name="&gt;&gt;gBRumble.Name" xml:space="preserve">
-    <value>gBRumble</value>
+  <data name="pnlSAMouse.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 2, 2, 2</value>
   </data>
-  <data name="&gt;&gt;gBRumble.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="pnlSAMouse.Size" type="System.Drawing.Size, System.Drawing">
+    <value>263, 222</value>
   </data>
-  <data name="&gt;&gt;gBRumble.Parent" xml:space="preserve">
-    <value>flowLayoutPanel4</value>
+  <data name="pnlSAMouse.TabIndex" type="System.Int32, mscorlib">
+    <value>263</value>
   </data>
-  <data name="&gt;&gt;gBRumble.ZOrder" xml:space="preserve">
-    <value>0</value>
+  <data name="&gt;&gt;pnlSAMouse.Name" xml:space="preserve">
+    <value>pnlSAMouse</value>
   </data>
-  <data name="&gt;&gt;panel7.Name" xml:space="preserve">
-    <value>panel7</value>
-  </data>
-  <data name="&gt;&gt;panel7.Type" xml:space="preserve">
+  <data name="&gt;&gt;pnlSAMouse.Type" xml:space="preserve">
     <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;panel7.Parent" xml:space="preserve">
-    <value>flowLayoutPanel4</value>
+  <data name="&gt;&gt;pnlSAMouse.Parent" xml:space="preserve">
+    <value>flowLayoutPanel2</value>
   </data>
-  <data name="&gt;&gt;panel7.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;panel8.Name" xml:space="preserve">
-    <value>panel8</value>
-  </data>
-  <data name="&gt;&gt;panel8.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;panel8.Parent" xml:space="preserve">
-    <value>flowLayoutPanel4</value>
-  </data>
-  <data name="&gt;&gt;panel8.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;cBMouseAccel.Name" xml:space="preserve">
-    <value>cBMouseAccel</value>
-  </data>
-  <data name="&gt;&gt;cBMouseAccel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cBMouseAccel.Parent" xml:space="preserve">
-    <value>flowLayoutPanel4</value>
-  </data>
-  <data name="&gt;&gt;cBMouseAccel.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;pnlSAMouse.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
-  <data name="&gt;&gt;enableTouchToggleCheckbox.Name" xml:space="preserve">
-    <value>enableTouchToggleCheckbox</value>
-  </data>
-  <data name="&gt;&gt;enableTouchToggleCheckbox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;enableTouchToggleCheckbox.Parent" xml:space="preserve">
-    <value>flowLayoutPanel4</value>
-  </data>
-  <data name="&gt;&gt;enableTouchToggleCheckbox.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;panel9.Name" xml:space="preserve">
-    <value>panel9</value>
-  </data>
-  <data name="&gt;&gt;panel9.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;panel9.Parent" xml:space="preserve">
-    <value>flowLayoutPanel4</value>
-  </data>
-  <data name="&gt;&gt;panel9.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;cBDinput.Name" xml:space="preserve">
-    <value>cBDinput</value>
-  </data>
-  <data name="&gt;&gt;cBDinput.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cBDinput.Parent" xml:space="preserve">
-    <value>flowLayoutPanel4</value>
-  </data>
-  <data name="&gt;&gt;cBDinput.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;cBFlushHIDQueue.Name" xml:space="preserve">
-    <value>cBFlushHIDQueue</value>
-  </data>
-  <data name="&gt;&gt;cBFlushHIDQueue.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cBFlushHIDQueue.Parent" xml:space="preserve">
-    <value>flowLayoutPanel4</value>
-  </data>
-  <data name="&gt;&gt;cBFlushHIDQueue.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="&gt;&gt;panel10.Name" xml:space="preserve">
-    <value>panel10</value>
-  </data>
-  <data name="&gt;&gt;panel10.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;panel10.Parent" xml:space="preserve">
-    <value>flowLayoutPanel4</value>
-  </data>
-  <data name="&gt;&gt;panel10.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;panel11.Name" xml:space="preserve">
-    <value>panel11</value>
-  </data>
-  <data name="&gt;&gt;panel11.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;panel11.Parent" xml:space="preserve">
-    <value>flowLayoutPanel4</value>
-  </data>
-  <data name="&gt;&gt;panel11.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="&gt;&gt;panel12.Name" xml:space="preserve">
-    <value>panel12</value>
-  </data>
-  <data name="&gt;&gt;panel12.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;panel12.Parent" xml:space="preserve">
-    <value>flowLayoutPanel4</value>
-  </data>
-  <data name="&gt;&gt;panel12.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="flowLayoutPanel4.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+  <data name="flowLayoutPanel2.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
-  <data name="flowLayoutPanel4.FlowDirection" type="System.Windows.Forms.FlowDirection, System.Windows.Forms">
+  <data name="flowLayoutPanel2.FlowDirection" type="System.Windows.Forms.FlowDirection, System.Windows.Forms">
     <value>TopDown</value>
   </data>
-  <data name="flowLayoutPanel4.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 3</value>
+  <data name="flowLayoutPanel2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
   </data>
-  <data name="flowLayoutPanel4.Size" type="System.Drawing.Size, System.Drawing">
-    <value>551, 479</value>
+  <data name="flowLayoutPanel2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>557, 485</value>
   </data>
-  <data name="flowLayoutPanel4.TabIndex" type="System.Int32, mscorlib">
+  <data name="flowLayoutPanel2.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <data name="flowLayoutPanel4.WrapContents" type="System.Boolean, mscorlib">
+  <data name="flowLayoutPanel2.WrapContents" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
-  <data name="&gt;&gt;flowLayoutPanel4.Name" xml:space="preserve">
-    <value>flowLayoutPanel4</value>
+  <data name="&gt;&gt;flowLayoutPanel2.Name" xml:space="preserve">
+    <value>flowLayoutPanel2</value>
   </data>
-  <data name="&gt;&gt;flowLayoutPanel4.Type" xml:space="preserve">
+  <data name="&gt;&gt;flowLayoutPanel2.Type" xml:space="preserve">
     <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;flowLayoutPanel4.Parent" xml:space="preserve">
-    <value>tabOther</value>
+  <data name="&gt;&gt;flowLayoutPanel2.Parent" xml:space="preserve">
+    <value>tabGyro</value>
   </data>
-  <data name="&gt;&gt;flowLayoutPanel4.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;flowLayoutPanel2.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="&gt;&gt;lbPercentRumble.Name" xml:space="preserve">
-    <value>lbPercentRumble</value>
+  <data name="tabGyro.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
   </data>
-  <data name="&gt;&gt;lbPercentRumble.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="tabGyro.Size" type="System.Drawing.Size, System.Drawing">
+    <value>557, 485</value>
   </data>
-  <data name="&gt;&gt;lbPercentRumble.Parent" xml:space="preserve">
-    <value>gBRumble</value>
-  </data>
-  <data name="&gt;&gt;lbPercentRumble.ZOrder" xml:space="preserve">
+  <data name="tabGyro.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <data name="&gt;&gt;btnRumbleLightTest.Name" xml:space="preserve">
-    <value>btnRumbleLightTest</value>
+  <data name="tabGyro.Text" xml:space="preserve">
+    <value>Gyro</value>
   </data>
-  <data name="&gt;&gt;btnRumbleLightTest.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;tabGyro.Name" xml:space="preserve">
+    <value>tabGyro</value>
   </data>
-  <data name="&gt;&gt;btnRumbleLightTest.Parent" xml:space="preserve">
-    <value>gBRumble</value>
+  <data name="&gt;&gt;tabGyro.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;btnRumbleLightTest.ZOrder" xml:space="preserve">
-    <value>1</value>
+  <data name="&gt;&gt;tabGyro.Parent" xml:space="preserve">
+    <value>tabControl1</value>
   </data>
-  <data name="&gt;&gt;btnRumbleHeavyTest.Name" xml:space="preserve">
-    <value>btnRumbleHeavyTest</value>
-  </data>
-  <data name="&gt;&gt;btnRumbleHeavyTest.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnRumbleHeavyTest.Parent" xml:space="preserve">
-    <value>gBRumble</value>
-  </data>
-  <data name="&gt;&gt;btnRumbleHeavyTest.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;tabGyro.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
-  <data name="&gt;&gt;nUDRumbleBoost.Name" xml:space="preserve">
-    <value>nUDRumbleBoost</value>
-  </data>
-  <data name="&gt;&gt;nUDRumbleBoost.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDRumbleBoost.Parent" xml:space="preserve">
-    <value>gBRumble</value>
-  </data>
-  <data name="&gt;&gt;nUDRumbleBoost.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="gBRumble.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 3</value>
-  </data>
-  <data name="gBRumble.Size" type="System.Drawing.Size, System.Drawing">
-    <value>272, 46</value>
-  </data>
-  <data name="gBRumble.TabIndex" type="System.Int32, mscorlib">
-    <value>248</value>
-  </data>
-  <data name="gBRumble.Text" xml:space="preserve">
-    <value>Rumble</value>
-  </data>
-  <data name="&gt;&gt;gBRumble.Name" xml:space="preserve">
-    <value>gBRumble</value>
-  </data>
-  <data name="&gt;&gt;gBRumble.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;gBRumble.Parent" xml:space="preserve">
-    <value>flowLayoutPanel4</value>
-  </data>
-  <data name="&gt;&gt;gBRumble.ZOrder" xml:space="preserve">
-    <value>0</value>
+  <data name="flowLayoutPanel4.AutoScroll" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
   <data name="lbPercentRumble.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -13794,62 +9567,29 @@
   <data name="&gt;&gt;nUDRumbleBoost.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
-  <data name="&gt;&gt;lbUseController.Name" xml:space="preserve">
-    <value>lbUseController</value>
+  <data name="gBRumble.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 3</value>
   </data>
-  <data name="&gt;&gt;lbUseController.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="gBRumble.Size" type="System.Drawing.Size, System.Drawing">
+    <value>272, 46</value>
   </data>
-  <data name="&gt;&gt;lbUseController.Parent" xml:space="preserve">
-    <value>panel7</value>
+  <data name="gBRumble.TabIndex" type="System.Int32, mscorlib">
+    <value>248</value>
   </data>
-  <data name="&gt;&gt;lbUseController.ZOrder" xml:space="preserve">
-    <value>0</value>
+  <data name="gBRumble.Text" xml:space="preserve">
+    <value>Rumble</value>
   </data>
-  <data name="&gt;&gt;nUDSixaxis.Name" xml:space="preserve">
-    <value>nUDSixaxis</value>
+  <data name="&gt;&gt;gBRumble.Name" xml:space="preserve">
+    <value>gBRumble</value>
   </data>
-  <data name="&gt;&gt;nUDSixaxis.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;gBRumble.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;nUDSixaxis.Parent" xml:space="preserve">
-    <value>panel7</value>
-  </data>
-  <data name="&gt;&gt;nUDSixaxis.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;cBControllerInput.Name" xml:space="preserve">
-    <value>cBControllerInput</value>
-  </data>
-  <data name="&gt;&gt;cBControllerInput.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cBControllerInput.Parent" xml:space="preserve">
-    <value>panel7</value>
-  </data>
-  <data name="&gt;&gt;cBControllerInput.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="panel7.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 55</value>
-  </data>
-  <data name="panel7.Size" type="System.Drawing.Size, System.Drawing">
-    <value>302, 29</value>
-  </data>
-  <data name="panel7.TabIndex" type="System.Int32, mscorlib">
-    <value>249</value>
-  </data>
-  <data name="&gt;&gt;panel7.Name" xml:space="preserve">
-    <value>panel7</value>
-  </data>
-  <data name="&gt;&gt;panel7.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;panel7.Parent" xml:space="preserve">
+  <data name="&gt;&gt;gBRumble.Parent" xml:space="preserve">
     <value>flowLayoutPanel4</value>
   </data>
-  <data name="&gt;&gt;panel7.ZOrder" xml:space="preserve">
-    <value>1</value>
+  <data name="&gt;&gt;gBRumble.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="lbUseController.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -13935,50 +9675,26 @@
   <data name="&gt;&gt;cBControllerInput.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
-  <data name="&gt;&gt;lbButtonMouseSens.Name" xml:space="preserve">
-    <value>lbButtonMouseSens</value>
+  <data name="panel7.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 55</value>
   </data>
-  <data name="&gt;&gt;lbButtonMouseSens.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="panel7.Size" type="System.Drawing.Size, System.Drawing">
+    <value>302, 29</value>
   </data>
-  <data name="&gt;&gt;lbButtonMouseSens.Parent" xml:space="preserve">
-    <value>panel8</value>
+  <data name="panel7.TabIndex" type="System.Int32, mscorlib">
+    <value>249</value>
   </data>
-  <data name="&gt;&gt;lbButtonMouseSens.ZOrder" xml:space="preserve">
-    <value>0</value>
+  <data name="&gt;&gt;panel7.Name" xml:space="preserve">
+    <value>panel7</value>
   </data>
-  <data name="&gt;&gt;numUDMouseSens.Name" xml:space="preserve">
-    <value>numUDMouseSens</value>
-  </data>
-  <data name="&gt;&gt;numUDMouseSens.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;numUDMouseSens.Parent" xml:space="preserve">
-    <value>panel8</value>
-  </data>
-  <data name="&gt;&gt;numUDMouseSens.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="panel8.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 90</value>
-  </data>
-  <data name="panel8.Size" type="System.Drawing.Size, System.Drawing">
-    <value>200, 32</value>
-  </data>
-  <data name="panel8.TabIndex" type="System.Int32, mscorlib">
-    <value>250</value>
-  </data>
-  <data name="&gt;&gt;panel8.Name" xml:space="preserve">
-    <value>panel8</value>
-  </data>
-  <data name="&gt;&gt;panel8.Type" xml:space="preserve">
+  <data name="&gt;&gt;panel7.Type" xml:space="preserve">
     <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;panel8.Parent" xml:space="preserve">
+  <data name="&gt;&gt;panel7.Parent" xml:space="preserve">
     <value>flowLayoutPanel4</value>
   </data>
-  <data name="&gt;&gt;panel8.ZOrder" xml:space="preserve">
-    <value>2</value>
+  <data name="&gt;&gt;panel7.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
   <data name="lbButtonMouseSens.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -14030,6 +9746,27 @@
   </data>
   <data name="&gt;&gt;numUDMouseSens.ZOrder" xml:space="preserve">
     <value>1</value>
+  </data>
+  <data name="panel8.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 90</value>
+  </data>
+  <data name="panel8.Size" type="System.Drawing.Size, System.Drawing">
+    <value>200, 32</value>
+  </data>
+  <data name="panel8.TabIndex" type="System.Int32, mscorlib">
+    <value>250</value>
+  </data>
+  <data name="&gt;&gt;panel8.Name" xml:space="preserve">
+    <value>panel8</value>
+  </data>
+  <data name="&gt;&gt;panel8.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;panel8.Parent" xml:space="preserve">
+    <value>flowLayoutPanel4</value>
+  </data>
+  <data name="&gt;&gt;panel8.ZOrder" xml:space="preserve">
+    <value>2</value>
   </data>
   <data name="cBMouseAccel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -14102,63 +9839,6 @@
   </data>
   <data name="&gt;&gt;enableTouchToggleCheckbox.ZOrder" xml:space="preserve">
     <value>4</value>
-  </data>
-  <data name="&gt;&gt;pBProgram.Name" xml:space="preserve">
-    <value>pBProgram</value>
-  </data>
-  <data name="&gt;&gt;pBProgram.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;pBProgram.Parent" xml:space="preserve">
-    <value>panel9</value>
-  </data>
-  <data name="&gt;&gt;pBProgram.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;cBLaunchProgram.Name" xml:space="preserve">
-    <value>cBLaunchProgram</value>
-  </data>
-  <data name="&gt;&gt;cBLaunchProgram.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cBLaunchProgram.Parent" xml:space="preserve">
-    <value>panel9</value>
-  </data>
-  <data name="&gt;&gt;cBLaunchProgram.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;btnBrowse.Name" xml:space="preserve">
-    <value>btnBrowse</value>
-  </data>
-  <data name="&gt;&gt;btnBrowse.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnBrowse.Parent" xml:space="preserve">
-    <value>panel9</value>
-  </data>
-  <data name="&gt;&gt;btnBrowse.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="panel9.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 174</value>
-  </data>
-  <data name="panel9.Size" type="System.Drawing.Size, System.Drawing">
-    <value>335, 34</value>
-  </data>
-  <data name="panel9.TabIndex" type="System.Int32, mscorlib">
-    <value>259</value>
-  </data>
-  <data name="&gt;&gt;panel9.Name" xml:space="preserve">
-    <value>panel9</value>
-  </data>
-  <data name="&gt;&gt;panel9.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;panel9.Parent" xml:space="preserve">
-    <value>flowLayoutPanel4</value>
-  </data>
-  <data name="&gt;&gt;panel9.ZOrder" xml:space="preserve">
-    <value>5</value>
   </data>
   <data name="pBProgram.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -14256,6 +9936,27 @@
   <data name="&gt;&gt;btnBrowse.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
+  <data name="panel9.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 174</value>
+  </data>
+  <data name="panel9.Size" type="System.Drawing.Size, System.Drawing">
+    <value>335, 34</value>
+  </data>
+  <data name="panel9.TabIndex" type="System.Int32, mscorlib">
+    <value>259</value>
+  </data>
+  <data name="&gt;&gt;panel9.Name" xml:space="preserve">
+    <value>panel9</value>
+  </data>
+  <data name="&gt;&gt;panel9.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;panel9.Parent" xml:space="preserve">
+    <value>flowLayoutPanel4</value>
+  </data>
+  <data name="&gt;&gt;panel9.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
   <data name="cBDinput.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -14330,63 +10031,6 @@
   </data>
   <data name="&gt;&gt;cBFlushHIDQueue.ZOrder" xml:space="preserve">
     <value>7</value>
-  </data>
-  <data name="&gt;&gt;nUDIdleDisconnect.Name" xml:space="preserve">
-    <value>nUDIdleDisconnect</value>
-  </data>
-  <data name="&gt;&gt;nUDIdleDisconnect.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nUDIdleDisconnect.Parent" xml:space="preserve">
-    <value>panel10</value>
-  </data>
-  <data name="&gt;&gt;nUDIdleDisconnect.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;cBIdleDisconnect.Name" xml:space="preserve">
-    <value>cBIdleDisconnect</value>
-  </data>
-  <data name="&gt;&gt;cBIdleDisconnect.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cBIdleDisconnect.Parent" xml:space="preserve">
-    <value>panel10</value>
-  </data>
-  <data name="&gt;&gt;cBIdleDisconnect.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;lbIdleMinutes.Name" xml:space="preserve">
-    <value>lbIdleMinutes</value>
-  </data>
-  <data name="&gt;&gt;lbIdleMinutes.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbIdleMinutes.Parent" xml:space="preserve">
-    <value>panel10</value>
-  </data>
-  <data name="&gt;&gt;lbIdleMinutes.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="panel10.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 260</value>
-  </data>
-  <data name="panel10.Size" type="System.Drawing.Size, System.Drawing">
-    <value>335, 32</value>
-  </data>
-  <data name="panel10.TabIndex" type="System.Int32, mscorlib">
-    <value>262</value>
-  </data>
-  <data name="&gt;&gt;panel10.Name" xml:space="preserve">
-    <value>panel10</value>
-  </data>
-  <data name="&gt;&gt;panel10.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;panel10.Parent" xml:space="preserve">
-    <value>flowLayoutPanel4</value>
-  </data>
-  <data name="&gt;&gt;panel10.ZOrder" xml:space="preserve">
-    <value>8</value>
   </data>
   <data name="nUDIdleDisconnect.Location" type="System.Drawing.Point, System.Drawing">
     <value>119, 2</value>
@@ -14475,50 +10119,26 @@
   <data name="&gt;&gt;lbIdleMinutes.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
-  <data name="&gt;&gt;btPollRateLabel.Name" xml:space="preserve">
-    <value>btPollRateLabel</value>
+  <data name="panel10.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 260</value>
   </data>
-  <data name="&gt;&gt;btPollRateLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="panel10.Size" type="System.Drawing.Size, System.Drawing">
+    <value>335, 32</value>
   </data>
-  <data name="&gt;&gt;btPollRateLabel.Parent" xml:space="preserve">
-    <value>panel11</value>
+  <data name="panel10.TabIndex" type="System.Int32, mscorlib">
+    <value>262</value>
   </data>
-  <data name="&gt;&gt;btPollRateLabel.ZOrder" xml:space="preserve">
-    <value>0</value>
+  <data name="&gt;&gt;panel10.Name" xml:space="preserve">
+    <value>panel10</value>
   </data>
-  <data name="&gt;&gt;btPollRateComboBox.Name" xml:space="preserve">
-    <value>btPollRateComboBox</value>
-  </data>
-  <data name="&gt;&gt;btPollRateComboBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btPollRateComboBox.Parent" xml:space="preserve">
-    <value>panel11</value>
-  </data>
-  <data name="&gt;&gt;btPollRateComboBox.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="panel11.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 298</value>
-  </data>
-  <data name="panel11.Size" type="System.Drawing.Size, System.Drawing">
-    <value>335, 38</value>
-  </data>
-  <data name="panel11.TabIndex" type="System.Int32, mscorlib">
-    <value>263</value>
-  </data>
-  <data name="&gt;&gt;panel11.Name" xml:space="preserve">
-    <value>panel11</value>
-  </data>
-  <data name="&gt;&gt;panel11.Type" xml:space="preserve">
+  <data name="&gt;&gt;panel10.Type" xml:space="preserve">
     <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;panel11.Parent" xml:space="preserve">
+  <data name="&gt;&gt;panel10.Parent" xml:space="preserve">
     <value>flowLayoutPanel4</value>
   </data>
-  <data name="&gt;&gt;panel11.ZOrder" xml:space="preserve">
-    <value>9</value>
+  <data name="&gt;&gt;panel10.ZOrder" xml:space="preserve">
+    <value>8</value>
   </data>
   <data name="btPollRateLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -14622,50 +10242,26 @@
   <data name="&gt;&gt;btPollRateComboBox.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="&gt;&gt;OutContTypeCb.Name" xml:space="preserve">
-    <value>OutContTypeCb</value>
+  <data name="panel11.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 298</value>
   </data>
-  <data name="&gt;&gt;OutContTypeCb.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;OutContTypeCb.Parent" xml:space="preserve">
-    <value>panel12</value>
-  </data>
-  <data name="&gt;&gt;OutContTypeCb.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;outcontLb.Name" xml:space="preserve">
-    <value>outcontLb</value>
-  </data>
-  <data name="&gt;&gt;outcontLb.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;outcontLb.Parent" xml:space="preserve">
-    <value>panel12</value>
-  </data>
-  <data name="&gt;&gt;outcontLb.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="panel12.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 342</value>
-  </data>
-  <data name="panel12.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="panel11.Size" type="System.Drawing.Size, System.Drawing">
     <value>335, 38</value>
   </data>
-  <data name="panel12.TabIndex" type="System.Int32, mscorlib">
-    <value>264</value>
+  <data name="panel11.TabIndex" type="System.Int32, mscorlib">
+    <value>263</value>
   </data>
-  <data name="&gt;&gt;panel12.Name" xml:space="preserve">
-    <value>panel12</value>
+  <data name="&gt;&gt;panel11.Name" xml:space="preserve">
+    <value>panel11</value>
   </data>
-  <data name="&gt;&gt;panel12.Type" xml:space="preserve">
+  <data name="&gt;&gt;panel11.Type" xml:space="preserve">
     <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;panel12.Parent" xml:space="preserve">
+  <data name="&gt;&gt;panel11.Parent" xml:space="preserve">
     <value>flowLayoutPanel4</value>
   </data>
-  <data name="&gt;&gt;panel12.ZOrder" xml:space="preserve">
-    <value>10</value>
+  <data name="&gt;&gt;panel11.ZOrder" xml:space="preserve">
+    <value>9</value>
   </data>
   <data name="OutContTypeCb.Items" xml:space="preserve">
     <value>Xbox 360</value>
@@ -14724,11 +10320,113 @@
   <data name="&gt;&gt;outcontLb.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
+  <data name="panel12.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 342</value>
+  </data>
+  <data name="panel12.Size" type="System.Drawing.Size, System.Drawing">
+    <value>335, 38</value>
+  </data>
+  <data name="panel12.TabIndex" type="System.Int32, mscorlib">
+    <value>264</value>
+  </data>
+  <data name="&gt;&gt;panel12.Name" xml:space="preserve">
+    <value>panel12</value>
+  </data>
+  <data name="&gt;&gt;panel12.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;panel12.Parent" xml:space="preserve">
+    <value>flowLayoutPanel4</value>
+  </data>
+  <data name="&gt;&gt;panel12.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="flowLayoutPanel4.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="flowLayoutPanel4.FlowDirection" type="System.Windows.Forms.FlowDirection, System.Windows.Forms">
+    <value>TopDown</value>
+  </data>
+  <data name="flowLayoutPanel4.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 3</value>
+  </data>
+  <data name="flowLayoutPanel4.Size" type="System.Drawing.Size, System.Drawing">
+    <value>551, 479</value>
+  </data>
+  <data name="flowLayoutPanel4.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="flowLayoutPanel4.WrapContents" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;flowLayoutPanel4.Name" xml:space="preserve">
+    <value>flowLayoutPanel4</value>
+  </data>
+  <data name="&gt;&gt;flowLayoutPanel4.Type" xml:space="preserve">
+    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;flowLayoutPanel4.Parent" xml:space="preserve">
+    <value>tabOther</value>
+  </data>
+  <data name="&gt;&gt;flowLayoutPanel4.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="tabOther.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tabOther.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tabOther.Size" type="System.Drawing.Size, System.Drawing">
+    <value>557, 485</value>
+  </data>
+  <data name="tabOther.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="tabOther.Text" xml:space="preserve">
+    <value>Other</value>
+  </data>
+  <data name="&gt;&gt;tabOther.Name" xml:space="preserve">
+    <value>tabOther</value>
+  </data>
+  <data name="&gt;&gt;tabOther.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tabOther.Parent" xml:space="preserve">
+    <value>tabControl1</value>
+  </data>
+  <data name="&gt;&gt;tabOther.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="tabControl1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="tabControl1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>446, 0</value>
+  </data>
+  <data name="tabControl1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>565, 511</value>
+  </data>
+  <data name="tabControl1.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;tabControl1.Name" xml:space="preserve">
+    <value>tabControl1</value>
+  </data>
+  <data name="&gt;&gt;tabControl1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tabControl1.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;tabControl1.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>25</value>
+    <value>59</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
     <value>96, 96</value>

--- a/DS4Windows/Properties/Resources.Designer.cs
+++ b/DS4Windows/Properties/Resources.Designer.cs
@@ -1883,6 +1883,15 @@ namespace DS4Windows.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Roundness of Square Stick corners.
+        /// </summary>
+        public static string SquareStickRoundness {
+            get {
+                return ResourceManager.GetString("SquareStickRoundness", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
         public static System.Drawing.Bitmap START {

--- a/DS4Windows/Properties/Resources.fi.resx
+++ b/DS4Windows/Properties/Resources.fi.resx
@@ -630,4 +630,7 @@
   <data name="MacroKeepKeyStateTip" xml:space="preserve">
     <value>Säilytä napin tilatieto kun makron suoritus on päättynyt (jos makro jättää napin Painettu-tilaan, niin makron suoritus ei automaattisesti palauta napin tilatietoa takaisin oletustilaan)</value>
   </data>
+  <data name="SquareStickRoundness" xml:space="preserve">
+    <value>Neliötikun kulmien pyöristys</value>
+  </data>
 </root>

--- a/DS4Windows/Properties/Resources.resx
+++ b/DS4Windows/Properties/Resources.resx
@@ -847,4 +847,7 @@
   <data name="MacroKeepKeyStateTip" xml:space="preserve">
     <value>Keep the last key state when macro execution is completed (ie. if a key is left in down state then it is not automatically reset back to default state)</value>
   </data>
+  <data name="SquareStickRoundness" xml:space="preserve">
+    <value>Roundness of Square Stick corners</value>
+  </data>
 </root>


### PR DESCRIPTION
Modified axis configuration screen layout to utilize better the screen space and to make it easier to compare axis values of LS-vs-RS and L2-vs-R2 and SX-vs-SZ.

I think this layout is a bit more logical and eye friendly than the "original new" layout. There is less up/down scrolling to do and less repeated label objects (with the same text).

Also fixed a new bug relating setting custom output curve config values which was introduced with the "original new" layout. All new custom curve options accidentally set a value to lsCustomCurve variable.
