### PR TITLE
Wrapped filesystem actions within try/catch

### DIFF
--- a/DS4Windows/DS4Forms/DS4Form.cs
+++ b/DS4Windows/DS4Forms/DS4Form.cs
@@ -346,9 +346,18 @@ namespace DS4Windows.Forms
 
                 if (onlylnkpath != Process.GetCurrentProcess().MainModule.FileName)
                 {
-                    File.Delete(Environment.GetFolderPath(Environment.SpecialFolder.Startup) + "\\DS4Windows.lnk");
-                    appShortcutToStartup();
-                    changeStartupRoutine();
+                    try
+                    {
+                        File.Delete(Environment.GetFolderPath(Environment.SpecialFolder.Startup) + "\\DS4Windows.lnk");
+                        appShortcutToStartup();
+                        changeStartupRoutine();
+                    }
+                    catch
+                    {
+                        MessageBox.Show("No access to Autorun/DS4Windows.lnk\nPlease check file permissions", "DS4Windows");
+                        StartWindowsCheckBox.Checked = false;
+                        runStartupPanel.Visible = false;
+                    }
                 }
             }
 


### PR DESCRIPTION
...to avoid unexpected launch crashes.

I have made my custom .bat launcher and replaced original DS4Windows.lnk with 'read-only' access to that .bat file. This resulted in crashes, I only managed the reason when compiled the program myself, since crashes were silent without any log messages.

I recommend to accept this PR, though not so many people would make such weird things like me, it's still safer to operate with filesystem within **try/catch**

Best Regards, almod90