### PR TITLE
Nacon Revolution Infinite support. Sometimes known also as Nacon Revolution Unlimited Pro v2?

### DIFF
--- a/DS4Windows/DS4Library/DS4Device.cs
+++ b/DS4Windows/DS4Library/DS4Device.cs
@@ -427,8 +427,9 @@ namespace DS4Windows
                         audio = new DS4Audio();
                         micAudio = new DS4Audio(DS4Library.CoreAudio.DataFlow.Capture);
                     }
-                    else if (tempAttr.VendorId == 0x146B)
+                    else if (tempAttr.VendorId == 0x146B && (tempAttr.ProductId == 0x0D01 || tempAttr.ProductId == 0x0D02))
                     {
+                        // The old logic didn't run gyro calibration for any of the Nacon gamepads. Nowadays there are Nacon gamepads with full PS4 compatible gyro, so skip the calibration only for old Nacon devices (is that skip even necessary?)
                         runCalib = false;
                     }
                     else if (tempAttr.VendorId == DS4Devices.RAZER_VID &&

--- a/DS4Windows/DS4Library/DS4Devices.cs
+++ b/DS4Windows/DS4Library/DS4Devices.cs
@@ -57,6 +57,7 @@ namespace DS4Windows
             new VidPidInfo(0x0C12, 0x57AB, "Warrior Joypad JS083"), // Warrior Joypad JS083 (wired). Custom lightbar color doesn't work, but everything else works OK (except touchpad and gyro because the gamepad doesnt have those).
             new VidPidInfo(0x0C12, 0x0E16, "Steel Play MetalTech"), // Steel Play Metaltech P4 (wired)
             new VidPidInfo(NACON_VID, 0x0D08, "Nacon Revol U Pro"), // Nacon Revolution Unlimited Pro
+            new VidPidInfo(NACON_VID, 0x0D10, "Nacon Revol Infinite"), // Nacon Revolution Infinite (sometimes known as Revol Unlimited Pro v2?). Touchpad, gyro, rumble, "led indicator" lightbar.
             new VidPidInfo(HORI_VID, 0x0084, "Hori Fighting Cmd"), // Hori Fighting Commander (special kind of gamepad without touchpad or sticks. There is a hardware switch to alter d-pad type between dpad and LS/RS)
             new VidPidInfo(NACON_VID, 0x0D13, "Nacon Revol Pro v.3"),
         };


### PR DESCRIPTION
Support for Nacon Revolution Infinite gamepad (maybe sometimes known as Nacon Revol Unlimited v2?). Anyway, libSDL in Linux seems to refer to 0x0D10 Nacon device as as Nacon Revolution Infinite model name. Touchpad, rumble and gyro works. Lightbar is just a "led indicator light" and it works also.

Device debug log provided by "GroundMeat" (https://github.com/Ryochan7/DS4Windows/issues/856#issuecomment-565822765)

