### PR TITLE
Workaround to inverted YAW gyro axis issue in some DS4 v1 gamepads.

### DIFF
--- a/DS4Windows/BezierCurveEditor/BezierCurve.cs
+++ b/DS4Windows/BezierCurveEditor/BezierCurve.cs
@@ -66,7 +66,7 @@ namespace DS4Windows
 
         // Custom definition set by DS4Windows options screens. This string is not validated (ie. the value is as user entered it and could be an invalid curve definition). This value is saved in a profile XML file.
         public string CustomDefinition { get; set; }
-        public string ToString() { return this.CustomDefinition; }
+        public override string ToString() { return this.CustomDefinition; }
 
         public AxisType axisType;               // Axis type of curve object (LS/RS/R2/L2/SA)
         private double axisMaxDouble;           // Max range of axis (range of positive values)

--- a/DS4Windows/DS4Library/DS4Device.cs
+++ b/DS4Windows/DS4Library/DS4Device.cs
@@ -528,6 +528,9 @@ namespace DS4Windows
                 }
 
                 sixAxis.setCalibrationData(ref calibration, conType == ConnectionType.USB);
+
+                if ((hDevice.Attributes.ProductId == 0x5C4 && hDevice.Attributes.VendorId == 0x054C) && sixAxis.fixupInvertedGyroAxis())
+                    AppLogger.LogToGui($"Automatically fixed inverted YAW gyro axis in DS4 v.1 BT gamepad ({Mac.ToString()})", false);
             }
             else
             {

--- a/DS4Windows/DS4Library/DS4Sixaxis.cs
+++ b/DS4Windows/DS4Library/DS4Sixaxis.cs
@@ -255,5 +255,18 @@ namespace DS4Windows
                 }
             }
         }
+
+        public bool fixupInvertedGyroAxis()
+        {
+            // Some, not all, DS4 rev1 gamepads have an inverted YAW gyro axis calibration value (sensNumber>0 but at the same time sensDenom value is <0 while other two axies have both attributes >0).
+            // If this gamepad has YAW calibration with weird mixed values then fix it automatically to workaround inverted YAW axis problem.
+            if ((calibrationData[1].sensNumer > 0 && calibrationData[1].sensDenom < 0) && calibrationData[0].sensDenom > 0 && calibrationData[2].sensDenom > 0)
+            {
+                calibrationData[1].sensDenom *= -1;
+                return true; // Fixed inverted axis
+            }
+            return false; // No need to fix anything
+        }
+
     }
 }


### PR DESCRIPTION
Workaround to inverted YAW gyro axis issue in some DS4 v1 BT gamepads. YAW calibration values are sometimes inverted. The same gamepad works just fine in USB, so this is just BT issue in some old rev1 gamepads. Issues 929 and 767 talks more about the problem.

Also fixed compile time warning about bezierCurve.ToString hiding a base method (override keyword missing).