### PR TITLE
User configurable (profile) max time in seconds for a rumble effect

### DIFF
--- a/DS4Windows/DS4Forms/ProfileEditor.xaml
+++ b/DS4Windows/DS4Forms/ProfileEditor.xaml
@@ -910,9 +910,11 @@
                 <StackPanel>
                     <GroupBox Header="{lex:Loc Rumble}" MinHeight="50" Margin="4,4,4,0" Padding="0,4,0,4">
                         <UniformGrid Rows="1" Columns="3">
-                            <UniformGrid Columns="2">
-                                <xctk:IntegerUpDown x:Name="RumbleBoostIUD" d:IsHidden="True" MinWidth="60" Value="{Binding RumbleBoost}" Minimum="0" Maximum="200" Increment="10" />
+                            <UniformGrid Columns="4" HorizontalAlignment="Left">
+                                <xctk:IntegerUpDown x:Name="RumbleBoostIUD" d:IsHidden="True" Value="{Binding RumbleBoost}" Minimum="0" Maximum="200" Increment="10" />
                                 <Label Content="%" />
+                                <xctk:IntegerUpDown x:Name="RumbleAutostopTimeIUD" d:IsHidden="True" Value="{Binding RumbleAutostopTime}" Minimum="0" Maximum="3600" Increment="1" ToolTip="{lex:Loc RumbleMaxSecsTip}"/>
+                                <Label Content="{lex:Loc RumbleMaxSecs}" />
                             </UniformGrid>
 
                             <Button x:Name="heavyRumbleTestBtn" Content="Test Heavy" Margin="10,0,0,0" Click="HeavyRumbleTestBtn_Click" />

--- a/DS4Windows/DS4Forms/ViewModels/ProfileSettingsViewModel.cs
+++ b/DS4Windows/DS4Forms/ViewModels/ProfileSettingsViewModel.cs
@@ -342,6 +342,13 @@ namespace DS4WinWPF.DS4Forms.ViewModels
             set => Global.RumbleBoost[device] = (byte)value;
         }
 
+        public int RumbleAutostopTime
+        {
+            // RumbleAutostopTime value is in milliseconds in XML config file, but GUI uses just seconds
+            get => Global.getRumbleAutostopTime(device) / 1000;
+            set => Global.setRumbleAutostopTime(device, value * 1000);
+        }
+
         private bool heavyRumbleActive;
         public bool HeavyRumbleActive
         {

--- a/DS4Windows/Translations/Strings.Designer.cs
+++ b/DS4Windows/Translations/Strings.Designer.cs
@@ -187,8 +187,7 @@ namespace DS4WinWPF.Translations {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Clear
-        ///.
+        ///   Looks up a localized string similar to Clear.
         /// </summary>
         public static string Clear {
             get {
@@ -503,6 +502,24 @@ namespace DS4WinWPF.Translations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to sec.
+        /// </summary>
+        public static string RumbleMaxSecs {
+            get {
+                return ResourceManager.GetString("RumbleMaxSecs", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Auto stop rumble in secs (0=auto stop disabled).
+        /// </summary>
+        public static string RumbleMaxSecsTip {
+            get {
+                return ResourceManager.GetString("RumbleMaxSecsTip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Run At Startup.
         /// </summary>
         public static string RunAtStartup {
@@ -584,8 +601,7 @@ namespace DS4WinWPF.Translations {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Scroll
-        ///.
+        ///   Looks up a localized string similar to Scroll.
         /// </summary>
         public static string TouchScroll {
             get {

--- a/DS4Windows/Translations/Strings.resx
+++ b/DS4Windows/Translations/Strings.resx
@@ -306,4 +306,10 @@
   <data name="WarningsOnly" xml:space="preserve">
     <value>Warnings only</value>
   </data>
+  <data name="RumbleMaxSecs" xml:space="preserve">
+    <value>sec</value>
+  </data>
+  <data name="RumbleMaxSecsTip" xml:space="preserve">
+    <value>Auto stop rumble in secs (0=auto stop disabled)</value>
+  </data>
 </root>


### PR DESCRIPTION
User configurable (profile) max time in seconds for a rumble effect. The rumble watchdog timer used to be fixed 2 secs and there was no way to disable it. This PR makes it possible to disable the rumble watchdog timer (0 secs value) or set the timer value anything between 1...3600 seconds.

#995 issue has more info.

![DS4Win_RumbleAutoStopTime](https://user-images.githubusercontent.com/35538525/71785598-27936a00-300a-11ea-963e-d18204241eb9.png)
