### PR TITLE
MoveUp and MoveDown context menu (right mouse button) in AutoProfiler list to re-order autoprofiler rules via GUI

### DIFF
--- a/DS4Windows/DS4Forms/AutoProfiles.xaml
+++ b/DS4Windows/DS4Forms/AutoProfiles.xaml
@@ -116,8 +116,8 @@
                 </Grid>
                 <CheckBox Content="Turn Off DS4Window Temporarily" Margin="{StaticResource spaceMargin}"
                           IsChecked="{Binding Turnoff}" />
-                <TextBox Text="{Binding Path}" Margin="{StaticResource spaceMargin}" />
-                <TextBox Text="{Binding Title, UpdateSourceTrigger=LostFocus}" Margin="{StaticResource spaceMargin}" />
+                <TextBox Text="{Binding Path}" Margin="{StaticResource spaceMargin}" ToolTip="{lex:Loc AutoProfPathTip}"/>
+                <TextBox Text="{Binding Title, UpdateSourceTrigger=LostFocus}" Margin="{StaticResource spaceMargin}" ToolTip="{lex:Loc AutoProfTitleTip}"/>
                 <Border Height="4" Background="#FFDADADA" Margin="0,10,0,0" />
             </StackPanel>
             <CheckBox x:Name="revertDefaultProfileOnUnknownCk" Content="Revert to default profile on unknown" Margin="0,10,0,0" IsChecked="{Binding RevertDefaultProfileOnUnknown}" />

--- a/DS4Windows/DS4Forms/AutoProfiles.xaml
+++ b/DS4Windows/DS4Forms/AutoProfiles.xaml
@@ -152,10 +152,16 @@
                             </GridViewColumn.CellTemplate>
                         </GridViewColumn>
                         <GridViewColumn Header="{lex:Loc Path}" Width="600" DisplayMemberBinding="{Binding Path}"/>
-                        <GridViewColumn Header="Window Title" Width="Auto" DisplayMemberBinding="{Binding Title}"/>
+                        <GridViewColumn Header="{lex:Loc WindowTitle}" Width="Auto" DisplayMemberBinding="{Binding Title}"/>
                     </GridView>
                 </ListView.View>
-           </ListView>
+                <ListView.ContextMenu>
+                    <ContextMenu>
+                        <MenuItem Header="{lex:Loc MoveUp}" Name="MoveUp" Click="MoveUpDownAutoBtn_Click"/>
+                        <MenuItem Header="{lex:Loc MoveDown}" Name="MoveDown" Click="MoveUpDownAutoBtn_Click"/>
+                    </ContextMenu>
+                </ListView.ContextMenu>
+            </ListView>
         </DockPanel>
     </DockPanel>
 </UserControl>

--- a/DS4Windows/DS4Forms/AutoProfiles.xaml.cs
+++ b/DS4Windows/DS4Forms/AutoProfiles.xaml.cs
@@ -66,7 +66,7 @@ namespace DS4WinWPF.DS4Forms
             autoProfVM = new AutoProfilesViewModel(autoProfileHolder, profileList);
             programListLV.DataContext = autoProfVM;
             programListLV.ItemsSource = autoProfVM.ProgramColl;
-
+            
             revertDefaultProfileOnUnknownCk.DataContext = autoProfVM;
 
             autoProfVM.SearchFinished += AutoProfVM_SearchFinished;
@@ -275,6 +275,15 @@ namespace DS4WinWPF.DS4Forms
             else
             {
                 this.IsEnabled = true;
+            }
+        }
+
+        private void MoveUpDownAutoBtn_Click(object sender, RoutedEventArgs e)
+        {
+            if (autoProfVM.SelectedItem != null && sender != null)
+            {
+                if(autoProfVM.MoveItemUpDown(autoProfVM.SelectedItem, ((sender as MenuItem).Name == "MoveUp") ? -1 : 1))
+                    autoProfVM.AutoProfileHolder.Save(DS4Windows.Global.appdatapath + @"\Auto Profiles.xml");
             }
         }
     }

--- a/DS4Windows/DS4Forms/ViewModels/AutoProfilesViewModel.cs
+++ b/DS4Windows/DS4Forms/ViewModels/AutoProfilesViewModel.cs
@@ -326,6 +326,28 @@ namespace DS4WinWPF.DS4Forms.ViewModels
 
             return result;
         }
+
+        public bool MoveItemUpDown(ProgramItem item, int moveDirection)
+        {
+            // Move autoprofile item up (-1) or down (1) both in listView (programColl) and in autoProfileHolder data structure (will be written into AutoProfiles.xml file)
+            bool itemMoved = true;
+            int oldIdx = programColl.IndexOf(item);
+
+            if (moveDirection == -1 && oldIdx > 0 && oldIdx < autoProfileHolder.AutoProfileColl.Count)
+            {
+                programColl.Move(oldIdx, oldIdx - 1);
+                autoProfileHolder.AutoProfileColl.Move(oldIdx, oldIdx - 1);
+            }
+            else if (moveDirection == 1 && oldIdx >= 0 && oldIdx < programColl.Count - 1 && oldIdx < autoProfileHolder.AutoProfileColl.Count - 1)
+            {    
+                programColl.Move(oldIdx, oldIdx + 1);
+                autoProfileHolder.AutoProfileColl.Move(oldIdx, oldIdx + 1);
+            }
+            else
+                itemMoved = false;
+
+            return itemMoved;
+        }
     }
 
     public class ProgramItem

--- a/DS4Windows/Translations/Strings.Designer.cs
+++ b/DS4Windows/Translations/Strings.Designer.cs
@@ -376,6 +376,24 @@ namespace DS4WinWPF.Translations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Move Down.
+        /// </summary>
+        public static string MoveDown {
+            get {
+                return ResourceManager.GetString("MoveDown", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Move Up.
+        /// </summary>
+        public static string MoveUp {
+            get {
+                return ResourceManager.GetString("MoveUp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Name.
         /// </summary>
         public static string Name {
@@ -642,6 +660,15 @@ namespace DS4WinWPF.Translations {
         public static string WarningsOnly {
             get {
                 return ResourceManager.GetString("WarningsOnly", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Window Title.
+        /// </summary>
+        public static string WindowTitle {
+            get {
+                return ResourceManager.GetString("WindowTitle", resourceCulture);
             }
         }
     }

--- a/DS4Windows/Translations/Strings.Designer.cs
+++ b/DS4Windows/Translations/Strings.Designer.cs
@@ -133,6 +133,24 @@ namespace DS4WinWPF.Translations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Process path. ^ABC = Match at the beginning of string (^) | ABC$ = Match at the end of string ($) | *ABC =Contains a string (*).
+        /// </summary>
+        public static string AutoProfPathTip {
+            get {
+                return ResourceManager.GetString("AutoProfPathTip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Window title. ^ABC = Match at the beginning of string (^) | ABC$ = Match at the end of string ($) | *ABC =Contains a string (*).
+        /// </summary>
+        public static string AutoProfTitleTip {
+            get {
+                return ResourceManager.GetString("AutoProfTitleTip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Battery.
         /// </summary>
         public static string Battery {

--- a/DS4Windows/Translations/Strings.resx
+++ b/DS4Windows/Translations/Strings.resx
@@ -312,4 +312,13 @@
   <data name="RumbleMaxSecsTip" xml:space="preserve">
     <value>Auto stop rumble in secs (0=auto stop disabled)</value>
   </data>
+  <data name="WindowTitle" xml:space="preserve">
+    <value>Window Title</value>
+  </data>
+  <data name="MoveUp" xml:space="preserve">
+    <value>Move Up</value>
+  </data>
+  <data name="MoveDown" xml:space="preserve">
+    <value>Move Down</value>
+  </data>
 </root>

--- a/DS4Windows/Translations/Strings.resx
+++ b/DS4Windows/Translations/Strings.resx
@@ -321,4 +321,10 @@
   <data name="MoveDown" xml:space="preserve">
     <value>Move Down</value>
   </data>
+  <data name="AutoProfPathTip" xml:space="preserve">
+    <value>Process path. ^ABC = Match at the beginning of string (^) | ABC$ = Match at the end of string ($) | *ABC =Contains a string (*)</value>
+  </data>
+  <data name="AutoProfTitleTip" xml:space="preserve">
+    <value>Window title. ^ABC = Match at the beginning of string (^) | ABC$ = Match at the end of string ($) | *ABC =Contains a string (*)</value>
+  </data>
 </root>


### PR DESCRIPTION
MoveUp and MoveDown context menu (right mouse button) in AutoProfiler list view to move items up or down. If there are wildchars in path or wndTitle search keywords then the order of auto-profile rules is significant. Now it is possible to modify the order of rules through the GUI and not just by editing AutoProfiles.xml file via text editor.