### PR TITLE
Fixed "Flash at high latency XX ms" value binding error in WPF GUI

### DIFF
--- a/DS4Windows/DS4Forms/MainWindow.xaml
+++ b/DS4Windows/DS4Forms/MainWindow.xaml
@@ -249,7 +249,7 @@
                             <StackPanel Orientation="Horizontal" Margin="8,0,0,0"
                                     IsEnabled="{Binding FlashHighLatency,FallbackValue='False'}">
                                 <!--<TextBox Text="20" VerticalContentAlignment="Center" />-->
-                                <xctk:IntegerUpDown d:IsHidden="True" Value="20" MinWidth="30" ButtonSpinnerLocation="Right" Increment="1" Maximum="100" Minimum="10" />
+                                <xctk:IntegerUpDown d:IsHidden="True" Value="{Binding FlashHighLatencyAt}" MinWidth="30" ButtonSpinnerLocation="Right" Increment="1" Maximum="100" Minimum="10" />
                                 <Label Content="ms" />
                             </StackPanel>
                         </StackPanel>


### PR DESCRIPTION
Flash at high latency value was missing GUI WPF binding entry. The settings screen showed always "20 ms" high latency value instead of the configured value. #1053 issue ticket.