### PR TITLE
Add Hori FPS Plus Support

### DIFF
--- a/DS4Windows/DS4Library/DS4Devices.cs
+++ b/DS4Windows/DS4Library/DS4Devices.cs
@@ -82,6 +82,7 @@ namespace DS4Windows
             new VidPidInfo(NACON_VID, 0x0D10, "Nacon Revol Infinite"), // Nacon Revolution Infinite (sometimes known as Revol Unlimited Pro v2?). Touchpad, gyro, rumble, "led indicator" lightbar.
             new VidPidInfo(HORI_VID, 0x0084, "Hori Fighting Cmd"), // Hori Fighting Commander (special kind of gamepad without touchpad or sticks. There is a hardware switch to alter d-pad type between dpad and LS/RS)
             new VidPidInfo(NACON_VID, 0x0D13, "Nacon Revol Pro v.3"),
+            new VidPidInfo(HORI_VID, 0x0066, "Horipad FPS Plus"), // Horipad FPS Plus (wired only. No light bar, rumble and Gyro/Accel sensor. Cannot Hide "HID-compliant vendor-defined device" in USB Composite Device. Other feature works fine.) 
         };
 
         private static string devicePathToInstanceId(string devicePath)


### PR DESCRIPTION
* Redoing PR #1166

Add Horipad Fps Plus Support.
(In Steam Controller List, It is named "Horipad 4 FPS Plus", but Its product name is "Horipad Fps Plus" in Japan.)
Tested with MGS5, DOA5, Undertale, Skyrim SE.

Cannot Hide "HID-compliant vendor-defined device" in USB Composite Device(I don't know why).
It lacks light bar, rumble and Gyro/Accel sensor by design.
Other feature works fine.

Steam Controller List has another VID/PID "0x0738/0x8384" as another "Horipad 4 FPS Plus",
Maybe Madcatz or Hori sells same devices in different branding, but i can't confirm.
so I just added VID/PID "0x0f0d/0x0066".