### PR TITLE
Wait a bit longer before switching over to PC-friendly mode in BT

### DIFF
--- a/DS4Windows/DS4Library/DS4Device.cs
+++ b/DS4Windows/DS4Library/DS4Device.cs
@@ -882,7 +882,7 @@ namespace DS4Windows
                                 cState.PacketCounter = pState.PacketCounter + 1; //still increase so we know there were lost packets
 
                                 // If the incoming data packet doesn't have the native DS4 type (0x11) in BT mode then the gamepad sends PC-friendly 0x01 data packets even in BT mode. Switch over to accept 0x01 data packets in BT mode.
-                                if (this.inputReportErrorCount >= 5)
+                                if (this.inputReportErrorCount >= 10)
                                 {
                                     if (btInputReport[0] == 0x01)
                                     {


### PR DESCRIPTION
Wait a bit longer before switching over to PC-friendly mode in BT (after Nth failed crc32 check of input report packets)