### PR TITLE
Fixed a bug where a shiftKey macro accidentally saved HoldMacro and M…

### DIFF
--- a/DS4Windows/DS4Forms/ViewModels/BindingWindowViewModel.cs
+++ b/DS4Windows/DS4Forms/ViewModels/BindingWindowViewModel.cs
@@ -645,11 +645,11 @@ namespace DS4WinWPF.DS4Forms.ViewModels
 
                     if (macroType.HasFlag(DS4KeyType.HoldMacro))
                     {
-                        settings.keyType |= DS4KeyType.HoldMacro;
+                        settings.shiftKeyType |= DS4KeyType.HoldMacro;
                     }
                     else
                     {
-                        settings.keyType |= DS4KeyType.Macro;
+                        settings.shiftKeyType |= DS4KeyType.Macro;
                     }
 
                     if (hasScanCode)

--- a/DS4Windows/DS4WinWPF.csproj
+++ b/DS4Windows/DS4WinWPF.csproj
@@ -71,6 +71,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>true</Prefer32Bit>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
     <OutputPath>bin\x86\Release\</OutputPath>


### PR DESCRIPTION
Fixed a bug where a shiftKey macro accidentally saved HoldMacro and Macro status values to a regular keyType attribute instead to shiftKeyType attribute. Also, enabled debug config option to compile by adding "allow unsafe code" option.

Related to #1246 ticket (the second issue in the ticket about loosing status of RepeatWhileHold option).
