### PR TITLE
Update DS4Devices.cs

### DIFF
--- a/DS4Windows/DS4Library/DS4Devices.cs
+++ b/DS4Windows/DS4Library/DS4Devices.cs
@@ -104,6 +104,7 @@ namespace DS4Windows
             new VidPidInfo(NACON_VID, 0x0D01, "Nacon Revol Pro v.1", VidPidFeatureSet.NoGyroCalib), // Nacon Revolution Pro v1 and v2 doesn't support DS4 gyro calibration routines
             new VidPidInfo(NACON_VID, 0x0D02, "Nacon Revol Pro v.2", VidPidFeatureSet.NoGyroCalib),
             new VidPidInfo(HORI_VID, 0x00EE, "Hori PS4 Mini", VidPidFeatureSet.NoOutputData | VidPidFeatureSet.NoBatteryReading | VidPidFeatureSet.NoGyroCalib),  // Hori PS4 Mini Wired Gamepad
+            new VidPidInfo(HORI_VID, 0x0123, "Hori Wireless Controller Light", VidPidFeatureSet.NoOutputData | VidPidFeatureSet.NoBatteryReading | VidPidFeatureSet.NoGyroCalib), // Hori Wireless Controller Light
             new VidPidInfo(0x7545, 0x0104, "Armor 3 LU Cobra"), // Armor 3 Level Up Cobra
             new VidPidInfo(0x2E95, 0x7725, "Scuf Vantage"), // Scuf Vantage gamepad
             new VidPidInfo(0x11C0, 0x4001, "PS4 Fun"), // PS4 Fun Controller


### PR DESCRIPTION
Add support for HORI Wireless Controller Light 0F0D:0123, a wireless version of Hori PS4 Mini, ostensibly the same feature set. At present, error upon connecting at SendOutputReport -> writeOutput and RefreshCalibration -> readFeatureData