### PR TITLE
Encapsulate Left and Right Stick state into its own Stick class

### DIFF
--- a/DS4Windows/DS4Control/ControlService.cs
+++ b/DS4Windows/DS4Control/ControlService.cs
@@ -1772,21 +1772,21 @@ namespace DS4Windows
                     result = DS4Controls.Options;
                 else if (Mapping.getBoolButtonMapping(cState.PS))
                     result = DS4Controls.PS;
-                else if (Mapping.getBoolAxisDirMapping(cState.LX, true))
+                else if (Mapping.getBoolAxisDirMapping(cState.L.X, true))
                     result = DS4Controls.LXPos;
-                else if (Mapping.getBoolAxisDirMapping(cState.LX, false))
+                else if (Mapping.getBoolAxisDirMapping(cState.L.X, false))
                     result = DS4Controls.LXNeg;
-                else if (Mapping.getBoolAxisDirMapping(cState.LY, true))
+                else if (Mapping.getBoolAxisDirMapping(cState.L.Y, true))
                     result = DS4Controls.LYPos;
-                else if (Mapping.getBoolAxisDirMapping(cState.LY, false))
+                else if (Mapping.getBoolAxisDirMapping(cState.L.Y, false))
                     result = DS4Controls.LYNeg;
-                else if (Mapping.getBoolAxisDirMapping(cState.RX, true))
+                else if (Mapping.getBoolAxisDirMapping(cState.R.X, true))
                     result = DS4Controls.RXPos;
-                else if (Mapping.getBoolAxisDirMapping(cState.RX, false))
+                else if (Mapping.getBoolAxisDirMapping(cState.R.X, false))
                     result = DS4Controls.RXNeg;
-                else if (Mapping.getBoolAxisDirMapping(cState.RY, true))
+                else if (Mapping.getBoolAxisDirMapping(cState.R.Y, true))
                     result = DS4Controls.RYPos;
-                else if (Mapping.getBoolAxisDirMapping(cState.RY, false))
+                else if (Mapping.getBoolAxisDirMapping(cState.R.Y, false))
                     result = DS4Controls.RYNeg;
                 else if (Mapping.getBoolTouchMapping(tp.leftDown))
                     result = DS4Controls.TouchLeft;

--- a/DS4Windows/DS4Control/DS4OutDevice.cs
+++ b/DS4Windows/DS4Control/DS4OutDevice.cs
@@ -79,37 +79,37 @@ namespace DS4Windows
             switch (steeringWheelMappedAxis)
             {
                 case SASteeringWheelEmulationAxisType.None:
-                    cont.LeftThumbX = state.LX;
-                    cont.LeftThumbY = state.LY;
-                    cont.RightThumbX = state.RX;
-                    cont.RightThumbY = state.RY;
+                    cont.LeftThumbX = state.L.X;
+                    cont.LeftThumbY = state.L.Y;
+                    cont.RightThumbX = state.R.X;
+                    cont.RightThumbY = state.R.Y;
                     break;
 
                 case SASteeringWheelEmulationAxisType.LX:
                     cont.LeftThumbX = (byte)state.SASteeringWheelEmulationUnit;
-                    cont.LeftThumbY = state.LY;
-                    cont.RightThumbX = state.RX;
-                    cont.RightThumbY = state.RY;
+                    cont.LeftThumbY = state.L.Y;
+                    cont.RightThumbX = state.R.X;
+                    cont.RightThumbY = state.R.Y;
                     break;
 
                 case SASteeringWheelEmulationAxisType.LY:
-                    cont.LeftThumbX = state.LX;
+                    cont.LeftThumbX = state.L.X;
                     cont.LeftThumbY = (byte)state.SASteeringWheelEmulationUnit;
-                    cont.RightThumbX = state.RX;
-                    cont.RightThumbY = state.RY;
+                    cont.RightThumbX = state.R.X;
+                    cont.RightThumbY = state.R.Y;
                     break;
 
                 case SASteeringWheelEmulationAxisType.RX:
-                    cont.LeftThumbX = state.LX;
-                    cont.LeftThumbY = state.LY;
+                    cont.LeftThumbX = state.L.X;
+                    cont.LeftThumbY = state.L.Y;
                     cont.RightThumbX = (byte)state.SASteeringWheelEmulationUnit;
-                    cont.RightThumbY = state.RY;
+                    cont.RightThumbY = state.R.Y;
                     break;
 
                 case SASteeringWheelEmulationAxisType.RY:
-                    cont.LeftThumbX = state.LX;
-                    cont.LeftThumbY = state.LY;
-                    cont.RightThumbX = state.RX;
+                    cont.LeftThumbX = state.L.X;
+                    cont.LeftThumbY = state.L.Y;
+                    cont.RightThumbX = state.R.X;
                     cont.RightThumbY = (byte)state.SASteeringWheelEmulationUnit;
                     break;
 

--- a/DS4Windows/DS4Control/DS4StateFieldMapping.cs
+++ b/DS4Windows/DS4Control/DS4StateFieldMapping.cs
@@ -66,15 +66,15 @@ namespace DS4Windows
         {
             unchecked
             {
-                axisdirs[(int)DS4Controls.LXNeg] = cState.LX;
-                axisdirs[(int)DS4Controls.LXPos] = cState.LX;
-                axisdirs[(int)DS4Controls.LYNeg] = cState.LY;
-                axisdirs[(int)DS4Controls.LYPos] = cState.LY;
+                axisdirs[(int)DS4Controls.LXNeg] = cState.L.X;
+                axisdirs[(int)DS4Controls.LXPos] = cState.L.X;
+                axisdirs[(int)DS4Controls.LYNeg] = cState.L.Y;
+                axisdirs[(int)DS4Controls.LYPos] = cState.L.Y;
 
-                axisdirs[(int)DS4Controls.RXNeg] = cState.RX;
-                axisdirs[(int)DS4Controls.RXPos] = cState.RX;
-                axisdirs[(int)DS4Controls.RYNeg] = cState.RY;
-                axisdirs[(int)DS4Controls.RYPos] = cState.RY;
+                axisdirs[(int)DS4Controls.RXNeg] = cState.R.X;
+                axisdirs[(int)DS4Controls.RXPos] = cState.R.X;
+                axisdirs[(int)DS4Controls.RYNeg] = cState.R.Y;
+                axisdirs[(int)DS4Controls.RYPos] = cState.R.Y;
 
                 triggers[(int)DS4Controls.L2] = cState.L2;
                 triggers[(int)DS4Controls.R2] = cState.R2;
@@ -127,15 +127,15 @@ namespace DS4Windows
         {
             unchecked
             {
-                state.LX = axisdirs[(int)DS4Controls.LXNeg];
-                state.LX = axisdirs[(int)DS4Controls.LXPos];
-                state.LY = axisdirs[(int)DS4Controls.LYNeg];
-                state.LY = axisdirs[(int)DS4Controls.LYPos];
+                state.L.X = axisdirs[(int)DS4Controls.LXNeg];
+                state.L.X = axisdirs[(int)DS4Controls.LXPos];
+                state.L.Y = axisdirs[(int)DS4Controls.LYNeg];
+                state.L.Y = axisdirs[(int)DS4Controls.LYPos];
 
-                state.RX = axisdirs[(int)DS4Controls.RXNeg];
-                state.RX = axisdirs[(int)DS4Controls.RXPos];
-                state.RY = axisdirs[(int)DS4Controls.RYNeg];
-                state.RY = axisdirs[(int)DS4Controls.RYPos];
+                state.R.X = axisdirs[(int)DS4Controls.RXNeg];
+                state.R.X = axisdirs[(int)DS4Controls.RXPos];
+                state.R.Y = axisdirs[(int)DS4Controls.RYNeg];
+                state.R.Y = axisdirs[(int)DS4Controls.RYPos];
 
                 state.L2 = triggers[(int)DS4Controls.L2];
                 state.R2 = triggers[(int)DS4Controls.R2];

--- a/DS4Windows/DS4Control/Mapping.cs
+++ b/DS4Windows/DS4Control/Mapping.cs
@@ -579,8 +579,8 @@ namespace DS4Windows
             int lsCurve = getLSCurve(device);
             if (lsCurve > 0)
             {
-                x = cState.LX;
-                y = cState.LY;
+                x = cState.L.X;
+                y = cState.L.Y;
                 float max = x + y;
                 double curvex;
                 double curvey;
@@ -606,16 +606,16 @@ namespace DS4Windows
                     }
                 }
 
-                dState.LX = (byte)Math.Round(curvex, 0);
-                dState.LY = (byte)Math.Round(curvey, 0);
+                dState.L.X = (byte)Math.Round(curvex, 0);
+                dState.L.Y = (byte)Math.Round(curvey, 0);
             }
 
             /* TODO: Look into curve options and make sure maximum axes values are being respected */
             int rsCurve = getRSCurve(device);
             if (rsCurve > 0)
             {
-                x = cState.RX;
-                y = cState.RY;
+                x = cState.R.X;
+                y = cState.R.Y;
                 float max = x + y;
                 double curvex;
                 double curvey;
@@ -641,8 +641,8 @@ namespace DS4Windows
                     }
                 }
 
-                dState.RX = (byte)Math.Round(curvex, 0);
-                dState.RY = (byte)Math.Round(curvey, 0);
+                dState.R.X = (byte)Math.Round(curvex, 0);
+                dState.R.Y = (byte)Math.Round(curvey, 0);
             }
 
             /*int lsDeadzone = getLSDeadzone(device);
@@ -657,18 +657,18 @@ namespace DS4Windows
 
             if (lsDeadzone > 0 || lsAntiDead > 0 || lsMaxZone != 100 || lsMaxOutput != 100.0)
             {
-                double lsSquared = Math.Pow(cState.LX - 128f, 2) + Math.Pow(cState.LY - 128f, 2);
+                double lsSquared = Math.Pow(cState.L.X - 128f, 2) + Math.Pow(cState.L.Y - 128f, 2);
                 double lsDeadzoneSquared = Math.Pow(lsDeadzone, 2);
                 if (lsDeadzone > 0 && lsSquared <= lsDeadzoneSquared)
                 {
-                    dState.LX = 128;
-                    dState.LY = 128;
+                    dState.L.X = 128;
+                    dState.L.Y = 128;
                 }
                 else if ((lsDeadzone > 0 && lsSquared > lsDeadzoneSquared) || lsAntiDead > 0 || lsMaxZone != 100 || lsMaxOutput != 100.0)
                 {
-                    double r = Math.Atan2(-(dState.LY - 128.0), (dState.LX - 128.0));
-                    double maxXValue = dState.LX >= 128.0 ? 127.0 : -128;
-                    double maxYValue = dState.LY >= 128.0 ? 127.0 : -128;
+                    double r = Math.Atan2(-(dState.L.Y - 128.0), (dState.L.X - 128.0));
+                    double maxXValue = dState.L.X >= 128.0 ? 127.0 : -128;
+                    double maxYValue = dState.L.Y >= 128.0 ? 127.0 : -128;
                     double ratio = lsMaxZone / 100.0;
                     double maxOutRatio = lsMaxOutput / 100.0;
 
@@ -676,8 +676,8 @@ namespace DS4Windows
                     double maxZoneXPosValue = (ratio * 127) + 128;
                     double maxZoneYNegValue = maxZoneXNegValue;
                     double maxZoneYPosValue = maxZoneXPosValue;
-                    double maxZoneX = dState.LX >= 128.0 ? (maxZoneXPosValue - 128.0) : (maxZoneXNegValue - 128.0);
-                    double maxZoneY = dState.LY >= 128.0 ? (maxZoneYPosValue - 128.0) : (maxZoneYNegValue - 128.0);
+                    double maxZoneX = dState.L.X >= 128.0 ? (maxZoneXPosValue - 128.0) : (maxZoneXNegValue - 128.0);
+                    double maxZoneY = dState.L.Y >= 128.0 ? (maxZoneYPosValue - 128.0) : (maxZoneYNegValue - 128.0);
 
                     double tempLsXDead = 0.0, tempLsYDead = 0.0;
                     double tempOutputX = 0.0, tempOutputY = 0.0;
@@ -688,16 +688,16 @@ namespace DS4Windows
 
                         if (lsSquared > lsDeadzoneSquared)
                         {
-                            double currentX = Global.Clamp(maxZoneXNegValue, dState.LX, maxZoneXPosValue);
-                            double currentY = Global.Clamp(maxZoneYNegValue, dState.LY, maxZoneYPosValue);
+                            double currentX = Global.Clamp(maxZoneXNegValue, dState.L.X, maxZoneXPosValue);
+                            double currentY = Global.Clamp(maxZoneYNegValue, dState.L.Y, maxZoneYPosValue);
                             tempOutputX = ((currentX - 128.0 - tempLsXDead) / (maxZoneX - tempLsXDead));
                             tempOutputY = ((currentY - 128.0 - tempLsYDead) / (maxZoneY - tempLsYDead));
                         }
                     }
                     else
                     {
-                        double currentX = Global.Clamp(maxZoneXNegValue, dState.LX, maxZoneXPosValue);
-                        double currentY = Global.Clamp(maxZoneYNegValue, dState.LY, maxZoneYPosValue);
+                        double currentX = Global.Clamp(maxZoneXNegValue, dState.L.X, maxZoneXPosValue);
+                        double currentY = Global.Clamp(maxZoneYNegValue, dState.L.Y, maxZoneYPosValue);
                         tempOutputX = (currentX - 128.0) / maxZoneX;
                         tempOutputY = (currentY - 128.0) / maxZoneY;
                     }
@@ -719,20 +719,20 @@ namespace DS4Windows
 
                     if (tempOutputX > 0.0)
                     {
-                        dState.LX = (byte)((((1.0 - tempLsXAntiDeadPercent) * tempOutputX + tempLsXAntiDeadPercent)) * maxXValue + 128.0);
+                        dState.L.X = (byte)((((1.0 - tempLsXAntiDeadPercent) * tempOutputX + tempLsXAntiDeadPercent)) * maxXValue + 128.0);
                     }
                     else
                     {
-                        dState.LX = 128;
+                        dState.L.X = 128;
                     }
 
                     if (tempOutputY > 0.0)
                     {
-                        dState.LY = (byte)((((1.0 - tempLsYAntiDeadPercent) * tempOutputY + tempLsYAntiDeadPercent)) * maxYValue + 128.0);
+                        dState.L.Y = (byte)((((1.0 - tempLsYAntiDeadPercent) * tempOutputY + tempLsYAntiDeadPercent)) * maxYValue + 128.0);
                     }
                     else
                     {
-                        dState.LY = 128;
+                        dState.L.Y = 128;
                     }
                 }
             }
@@ -749,18 +749,18 @@ namespace DS4Windows
 
             if (rsDeadzone > 0 || rsAntiDead > 0 || rsMaxZone != 100 || rsMaxOutput != 100.0)
             {
-                double rsSquared = Math.Pow(cState.RX - 128.0, 2) + Math.Pow(cState.RY - 128.0, 2);
+                double rsSquared = Math.Pow(cState.R.X - 128.0, 2) + Math.Pow(cState.R.Y - 128.0, 2);
                 double rsDeadzoneSquared = Math.Pow(rsDeadzone, 2);
                 if (rsDeadzone > 0 && rsSquared <= rsDeadzoneSquared)
                 {
-                    dState.RX = 128;
-                    dState.RY = 128;
+                    dState.R.X = 128;
+                    dState.R.Y = 128;
                 }
                 else if ((rsDeadzone > 0 && rsSquared > rsDeadzoneSquared) || rsAntiDead > 0 || rsMaxZone != 100 || rsMaxOutput != 100.0)
                 {
-                    double r = Math.Atan2(-(dState.RY - 128.0), (dState.RX - 128.0));
-                    double maxXValue = dState.RX >= 128.0 ? 127 : -128;
-                    double maxYValue = dState.RY >= 128.0 ? 127 : -128;
+                    double r = Math.Atan2(-(dState.R.Y - 128.0), (dState.R.X - 128.0));
+                    double maxXValue = dState.R.X >= 128.0 ? 127 : -128;
+                    double maxYValue = dState.R.Y >= 128.0 ? 127 : -128;
                     double ratio = rsMaxZone / 100.0;
                     double maxOutRatio = rsMaxOutput / 100.0;
 
@@ -768,8 +768,8 @@ namespace DS4Windows
                     double maxZoneXPosValue = (ratio * 127.0) + 128.0;
                     double maxZoneYNegValue = maxZoneXNegValue;
                     double maxZoneYPosValue = maxZoneXPosValue;
-                    double maxZoneX = dState.RX >= 128.0 ? (maxZoneXPosValue - 128.0) : (maxZoneXNegValue - 128.0);
-                    double maxZoneY = dState.RY >= 128.0 ? (maxZoneYPosValue - 128.0) : (maxZoneYNegValue - 128.0);
+                    double maxZoneX = dState.R.X >= 128.0 ? (maxZoneXPosValue - 128.0) : (maxZoneXNegValue - 128.0);
+                    double maxZoneY = dState.R.Y >= 128.0 ? (maxZoneYPosValue - 128.0) : (maxZoneYNegValue - 128.0);
 
                     double tempRsXDead = 0.0, tempRsYDead = 0.0;
                     double tempOutputX = 0.0, tempOutputY = 0.0;
@@ -780,8 +780,8 @@ namespace DS4Windows
 
                         if (rsSquared > rsDeadzoneSquared)
                         {
-                            double currentX = Global.Clamp(maxZoneXNegValue, dState.RX, maxZoneXPosValue);
-                            double currentY = Global.Clamp(maxZoneYNegValue, dState.RY, maxZoneYPosValue);
+                            double currentX = Global.Clamp(maxZoneXNegValue, dState.R.X, maxZoneXPosValue);
+                            double currentY = Global.Clamp(maxZoneYNegValue, dState.R.Y, maxZoneYPosValue);
 
                             tempOutputX = ((currentX - 128.0 - tempRsXDead) / (maxZoneX - tempRsXDead));
                             tempOutputY = ((currentY - 128.0 - tempRsYDead) / (maxZoneY - tempRsYDead));
@@ -789,8 +789,8 @@ namespace DS4Windows
                     }
                     else
                     {
-                        double currentX = Global.Clamp(maxZoneXNegValue, dState.RX, maxZoneXPosValue);
-                        double currentY = Global.Clamp(maxZoneYNegValue, dState.RY, maxZoneYPosValue);
+                        double currentX = Global.Clamp(maxZoneXNegValue, dState.R.X, maxZoneXPosValue);
+                        double currentY = Global.Clamp(maxZoneYNegValue, dState.R.Y, maxZoneYPosValue);
 
                         tempOutputX = (currentX - 128.0) / maxZoneX;
                         tempOutputY = (currentY - 128.0) / maxZoneY;
@@ -813,20 +813,20 @@ namespace DS4Windows
 
                     if (tempOutputX > 0.0)
                     {
-                        dState.RX = (byte)((((1.0 - tempRsXAntiDeadPercent) * tempOutputX + tempRsXAntiDeadPercent)) * maxXValue + 128.0);
+                        dState.R.X = (byte)((((1.0 - tempRsXAntiDeadPercent) * tempOutputX + tempRsXAntiDeadPercent)) * maxXValue + 128.0);
                     }
                     else
                     {
-                        dState.RX = 128;
+                        dState.R.X = 128;
                     }
 
                     if (tempOutputY > 0.0)
                     {
-                        dState.RY = (byte)((((1.0 - tempRsYAntiDeadPercent) * tempOutputY + tempRsYAntiDeadPercent)) * maxYValue + 128.0);
+                        dState.R.Y = (byte)((((1.0 - tempRsYAntiDeadPercent) * tempOutputY + tempRsYAntiDeadPercent)) * maxYValue + 128.0);
                     }
                     else
                     {
-                        dState.RY = 128;
+                        dState.R.Y = 128;
                     }
                 }
             }
@@ -945,15 +945,15 @@ namespace DS4Windows
             double lsSens = getLSSens(device);
             if (lsSens != 1.0)
             {
-                dState.LX = (byte)Global.Clamp(0, lsSens * (dState.LX - 128.0) + 128.0, 255);
-                dState.LY = (byte)Global.Clamp(0, lsSens * (dState.LY - 128.0) + 128.0, 255);
+                dState.L.X = (byte)Global.Clamp(0, lsSens * (dState.L.X - 128.0) + 128.0, 255);
+                dState.L.Y = (byte)Global.Clamp(0, lsSens * (dState.L.Y - 128.0) + 128.0, 255);
             }
 
             double rsSens = getRSSens(device);
             if (rsSens != 1.0)
             {
-                dState.RX = (byte)Global.Clamp(0, rsSens * (dState.RX - 128.0) + 128.0, 255);
-                dState.RY = (byte)Global.Clamp(0, rsSens * (dState.RY - 128.0) + 128.0, 255);
+                dState.R.X = (byte)Global.Clamp(0, rsSens * (dState.R.X - 128.0) + 128.0, 255);
+                dState.R.Y = (byte)Global.Clamp(0, rsSens * (dState.R.Y - 128.0) + 128.0, 255);
             }
 
             double l2Sens = getL2Sens(device);
@@ -965,12 +965,12 @@ namespace DS4Windows
                 dState.R2 = (byte)Global.Clamp(0, r2Sens * dState.R2, 255);
 
             SquareStickInfo squStk = GetSquareStickInfo(device);
-            if (squStk.lsMode && (dState.LX != 128 || dState.LY != 128))
+            if (squStk.lsMode && (dState.L.X != 128 || dState.L.Y != 128))
             {
-                double capX = dState.LX >= 128 ? 127.0 : 128.0;
-                double capY = dState.LY >= 128 ? 127.0 : 128.0;
-                double tempX = (dState.LX - 128.0) / capX;
-                double tempY = (dState.LY - 128.0) / capY;
+                double capX = dState.L.X >= 128 ? 127.0 : 128.0;
+                double capY = dState.L.Y >= 128 ? 127.0 : 128.0;
+                double tempX = (dState.L.X - 128.0) / capX;
+                double tempY = (dState.L.Y - 128.0) / capY;
                 DS4SquareStick sqstick = outSqrStk[device];
                 sqstick.current.x = tempX; sqstick.current.y = tempY;
                 sqstick.CircleToSquare(squStk.lsRoundness);
@@ -979,24 +979,24 @@ namespace DS4Windows
                     ? 1.0 : sqstick.current.x;
                 tempY = sqstick.current.y < -1.0 ? -1.0 : sqstick.current.y > 1.0
                     ? 1.0 : sqstick.current.y;
-                dState.LX = (byte)(tempX * capX + 128.0);
-                dState.LY = (byte)(tempY * capY + 128.0);
+                dState.L.X = (byte)(tempX * capX + 128.0);
+                dState.L.Y = (byte)(tempY * capY + 128.0);
             }
 
             int lsOutCurveMode = getLsOutCurveMode(device);
-            if (lsOutCurveMode > 0 && (dState.LX != 128 || dState.LY != 128))
+            if (lsOutCurveMode > 0 && (dState.L.X != 128 || dState.L.Y != 128))
             {
-                double r = Math.Atan2(-(dState.LY - 128.0), (dState.LX - 128.0));
+                double r = Math.Atan2(-(dState.L.Y - 128.0), (dState.L.X - 128.0));
                 double maxOutXRatio = Math.Abs(Math.Cos(r));
                 double maxOutYRatio = Math.Abs(Math.Sin(r));
-                double sideX = dState.LX - 128; double sideY = dState.LY - 128.0;
-                double capX = dState.LX >= 128 ? maxOutXRatio * 127.0 : maxOutXRatio * 128.0;
-                double capY = dState.LY >= 128 ? maxOutYRatio * 127.0 : maxOutYRatio * 128.0;
+                double sideX = dState.L.X - 128; double sideY = dState.L.Y - 128.0;
+                double capX = dState.L.X >= 128 ? maxOutXRatio * 127.0 : maxOutXRatio * 128.0;
+                double capY = dState.L.Y >= 128 ? maxOutYRatio * 127.0 : maxOutYRatio * 128.0;
                 double absSideX = Math.Abs(sideX); double absSideY = Math.Abs(sideY);
                 if (absSideX > capX) capX = absSideX;
                 if (absSideY > capY) capY = absSideY;
-                double tempRatioX = capX > 0 ? (dState.LX - 128.0) / capX : 0;
-                double tempRatioY = capY > 0 ? (dState.LY - 128.0) / capY : 0;
+                double tempRatioX = capX > 0 ? (dState.L.X - 128.0) / capX : 0;
+                double tempRatioY = capY > 0 ? (dState.L.Y - 128.0) / capY : 0;
                 double signX = tempRatioX >= 0.0 ? 1.0 : -1.0;
                 double signY = tempRatioY >= 0.0 ? 1.0 : -1.0;
 
@@ -1033,22 +1033,22 @@ namespace DS4Windows
                         outputY = (absY * 1.32) - 0.32;
                     }
 
-                    dState.LX = (byte)(outputX * signX * capX + 128.0);
-                    dState.LY = (byte)(outputY * signY * capY + 128.0);
+                    dState.L.X = (byte)(outputX * signX * capX + 128.0);
+                    dState.L.Y = (byte)(outputY * signY * capY + 128.0);
                 }
                 else if (lsOutCurveMode == 2)
                 {
                     double outputX = tempRatioX * tempRatioX;
                     double outputY = tempRatioY * tempRatioY;
-                    dState.LX = (byte)(outputX * signX * capX + 128.0);
-                    dState.LY = (byte)(outputY * signY * capY + 128.0);
+                    dState.L.X = (byte)(outputX * signX * capX + 128.0);
+                    dState.L.Y = (byte)(outputY * signY * capY + 128.0);
                 }
                 else if (lsOutCurveMode == 3)
                 {
                     double outputX = tempRatioX * tempRatioX * tempRatioX;
                     double outputY = tempRatioY * tempRatioY * tempRatioY;
-                    dState.LX = (byte)(outputX * capX + 128.0);
-                    dState.LY = (byte)(outputY * capY + 128.0);
+                    dState.L.X = (byte)(outputX * capX + 128.0);
+                    dState.L.Y = (byte)(outputY * capY + 128.0);
                 }
                 else if (lsOutCurveMode == 4)
                 {
@@ -1056,8 +1056,8 @@ namespace DS4Windows
                     double absY = Math.Abs(tempRatioY);
                     double outputX = absX * (absX - 2.0);
                     double outputY = absY * (absY - 2.0);
-                    dState.LX = (byte)(-1.0 * outputX * signX * capX + 128.0);
-                    dState.LY = (byte)(-1.0 * outputY * signY * capY + 128.0);
+                    dState.L.X = (byte)(-1.0 * outputX * signX * capX + 128.0);
+                    dState.L.Y = (byte)(-1.0 * outputY * signY * capY + 128.0);
                 }
                 else if (lsOutCurveMode == 5)
                 {
@@ -1065,22 +1065,22 @@ namespace DS4Windows
                     double innerY = Math.Abs(tempRatioY) - 1.0;
                     double outputX = innerX * innerX * innerX + 1.0;
                     double outputY = innerY * innerY * innerY + 1.0;
-                    dState.LX = (byte)(1.0 * outputX * signX * capX + 128.0);
-                    dState.LY = (byte)(1.0 * outputY * signY * capY + 128.0);
+                    dState.L.X = (byte)(1.0 * outputX * signX * capX + 128.0);
+                    dState.L.Y = (byte)(1.0 * outputY * signY * capY + 128.0);
                 }
                 else if (lsOutCurveMode == 6)
                 {
-                    dState.LX = lsOutBezierCurveObj[device].arrayBezierLUT[dState.LX];
-                    dState.LY = lsOutBezierCurveObj[device].arrayBezierLUT[dState.LY];
+                    dState.L.X = lsOutBezierCurveObj[device].arrayBezierLUT[dState.L.X];
+                    dState.L.Y = lsOutBezierCurveObj[device].arrayBezierLUT[dState.L.Y];
                 }
             }
             
-            if (squStk.rsMode && (dState.RX != 128 || dState.RY != 128))
+            if (squStk.rsMode && (dState.R.X != 128 || dState.R.Y != 128))
             {
-                double capX = dState.RX >= 128 ? 127.0 : 128.0;
-                double capY = dState.RY >= 128 ? 127.0 : 128.0;
-                double tempX = (dState.RX - 128.0) / capX;
-                double tempY = (dState.RY - 128.0) / capY;
+                double capX = dState.R.X >= 128 ? 127.0 : 128.0;
+                double capY = dState.R.Y >= 128 ? 127.0 : 128.0;
+                double tempX = (dState.R.X - 128.0) / capX;
+                double tempY = (dState.R.Y - 128.0) / capY;
                 DS4SquareStick sqstick = outSqrStk[device];
                 sqstick.current.x = tempX; sqstick.current.y = tempY;
                 sqstick.CircleToSquare(squStk.rsRoundness);
@@ -1089,24 +1089,24 @@ namespace DS4Windows
                 tempY = sqstick.current.y < -1.0 ? -1.0 : sqstick.current.y > 1.0
                     ? 1.0 : sqstick.current.y;
                 //Console.WriteLine("Input ({0}) | Output ({1})", tempY, sqstick.current.y);
-                dState.RX = (byte)(tempX * capX + 128.0);
-                dState.RY = (byte)(tempY * capY + 128.0);
+                dState.R.X = (byte)(tempX * capX + 128.0);
+                dState.R.Y = (byte)(tempY * capY + 128.0);
             }
 
             int rsOutCurveMode = getRsOutCurveMode(device);
-            if (rsOutCurveMode > 0 && (dState.RX != 128 || dState.RY != 128))
+            if (rsOutCurveMode > 0 && (dState.R.X != 128 || dState.R.Y != 128))
             {
-                double r = Math.Atan2(-(dState.RY - 128.0), (dState.RX - 128.0));
+                double r = Math.Atan2(-(dState.R.Y - 128.0), (dState.R.X - 128.0));
                 double maxOutXRatio = Math.Abs(Math.Cos(r));
                 double maxOutYRatio = Math.Abs(Math.Sin(r));
-                double sideX = dState.RX - 128; double sideY = dState.RY - 128.0;
-                double capX = dState.RX >= 128 ? maxOutXRatio * 127.0 : maxOutXRatio * 128.0;
-                double capY = dState.RY >= 128 ? maxOutYRatio * 127.0 : maxOutYRatio * 128.0;
+                double sideX = dState.R.X - 128; double sideY = dState.R.Y - 128.0;
+                double capX = dState.R.X >= 128 ? maxOutXRatio * 127.0 : maxOutXRatio * 128.0;
+                double capY = dState.R.Y >= 128 ? maxOutYRatio * 127.0 : maxOutYRatio * 128.0;
                 double absSideX = Math.Abs(sideX); double absSideY = Math.Abs(sideY);
                 if (absSideX > capX) capX = absSideX;
                 if (absSideY > capY) capY = absSideY;
-                double tempRatioX = capX > 0 ? (dState.RX - 128.0) / capX : 0;
-                double tempRatioY = capY > 0 ? (dState.RY - 128.0) / capY : 0;
+                double tempRatioX = capX > 0 ? (dState.R.X - 128.0) / capX : 0;
+                double tempRatioY = capY > 0 ? (dState.R.Y - 128.0) / capY : 0;
                 double signX = tempRatioX >= 0.0 ? 1.0 : -1.0;
                 double signY = tempRatioY >= 0.0 ? 1.0 : -1.0;
 
@@ -1143,22 +1143,22 @@ namespace DS4Windows
                         outputY = (absY * 1.32) - 0.32;
                     }
 
-                    dState.RX = (byte)(outputX * signX * capX + 128.0);
-                    dState.RY = (byte)(outputY * signY * capY + 128.0);
+                    dState.R.X = (byte)(outputX * signX * capX + 128.0);
+                    dState.R.Y = (byte)(outputY * signY * capY + 128.0);
                 }
                 else if (rsOutCurveMode == 2)
                 {
                     double outputX = tempRatioX * tempRatioX;
                     double outputY = tempRatioY * tempRatioY;
-                    dState.RX = (byte)(outputX * signX * capX + 128.0);
-                    dState.RY = (byte)(outputY * signY * capY + 128.0);
+                    dState.R.X = (byte)(outputX * signX * capX + 128.0);
+                    dState.R.Y = (byte)(outputY * signY * capY + 128.0);
                 }
                 else if (rsOutCurveMode == 3)
                 {
                     double outputX = tempRatioX * tempRatioX * tempRatioX;
                     double outputY = tempRatioY * tempRatioY * tempRatioY;
-                    dState.RX = (byte)(outputX * capX + 128.0);
-                    dState.RY = (byte)(outputY * capY + 128.0);
+                    dState.R.X = (byte)(outputX * capX + 128.0);
+                    dState.R.Y = (byte)(outputY * capY + 128.0);
                 }
                 else if (rsOutCurveMode == 4)
                 {
@@ -1166,8 +1166,8 @@ namespace DS4Windows
                     double absY = Math.Abs(tempRatioY);
                     double outputX = absX * (absX - 2.0);
                     double outputY = absY * (absY - 2.0);
-                    dState.RX = (byte)(-1.0 * outputX * signX * capX + 128.0);
-                    dState.RY = (byte)(-1.0 * outputY * signY * capY + 128.0);
+                    dState.R.X = (byte)(-1.0 * outputX * signX * capX + 128.0);
+                    dState.R.Y = (byte)(-1.0 * outputY * signY * capY + 128.0);
                 }
                 else if (rsOutCurveMode == 5)
                 {
@@ -1175,13 +1175,13 @@ namespace DS4Windows
                     double innerY = Math.Abs(tempRatioY) - 1.0;
                     double outputX = innerX * innerX * innerX + 1.0;
                     double outputY = innerY * innerY * innerY + 1.0;
-                    dState.RX = (byte)(1.0 * outputX * signX * capX + 128.0);
-                    dState.RY = (byte)(1.0 * outputY * signY * capY + 128.0);
+                    dState.R.X = (byte)(1.0 * outputX * signX * capX + 128.0);
+                    dState.R.Y = (byte)(1.0 * outputY * signY * capY + 128.0);
                 }
                 else if (rsOutCurveMode == 6)
                 {
-                    dState.RX = rsOutBezierCurveObj[device].arrayBezierLUT[dState.RX];
-                    dState.RY = rsOutBezierCurveObj[device].arrayBezierLUT[dState.RY];
+                    dState.R.X = rsOutBezierCurveObj[device].arrayBezierLUT[dState.R.X];
+                    dState.R.Y = rsOutBezierCurveObj[device].arrayBezierLUT[dState.R.Y];
                 }
             }
 
@@ -1945,14 +1945,14 @@ namespace DS4Windows
                 if (macroControl[14]) MappedState.R2 = 255;
                 if (macroControl[15]) MappedState.L3 = true;
                 if (macroControl[16]) MappedState.R3 = true;
-                if (macroControl[17]) MappedState.LX = 255;
-                if (macroControl[18]) MappedState.LX = 0;
-                if (macroControl[19]) MappedState.LY = 255;
-                if (macroControl[20]) MappedState.LY = 0;
-                if (macroControl[21]) MappedState.RX = 255;
-                if (macroControl[22]) MappedState.RX = 0;
-                if (macroControl[23]) MappedState.RY = 255;
-                if (macroControl[24]) MappedState.RY = 0;
+                if (macroControl[17]) MappedState.L.X = 255;
+                if (macroControl[18]) MappedState.L.X = 0;
+                if (macroControl[19]) MappedState.L.Y = 255;
+                if (macroControl[20]) MappedState.L.Y = 0;
+                if (macroControl[21]) MappedState.R.X = 255;
+                if (macroControl[22]) MappedState.R.X = 0;
+                if (macroControl[23]) MappedState.R.Y = 255;
+                if (macroControl[24]) MappedState.R.Y = 0;
             }
 
             if (GetSASteeringWheelEmulationAxis(device) != SASteeringWheelEmulationAxisType.None)
@@ -1963,21 +1963,21 @@ namespace DS4Windows
             ref byte gyroTempX = ref gyroStickX[device];
             if (gyroTempX != 128)
             {
-                if (MappedState.RX != 128)
-                    MappedState.RX = Math.Abs(gyroTempX - 128) > Math.Abs(MappedState.RX - 128) ?
-                        gyroTempX : MappedState.RX;
+                if (MappedState.R.X != 128)
+                    MappedState.R.X = Math.Abs(gyroTempX - 128) > Math.Abs(MappedState.R.X - 128) ?
+                        gyroTempX : MappedState.R.X;
                 else
-                    MappedState.RX = gyroTempX;
+                    MappedState.R.X = gyroTempX;
             }
 
             ref byte gyroTempY = ref gyroStickY[device];
             if (gyroTempY != 128)
             {
-                if (MappedState.RY != 128)
-                    MappedState.RY = Math.Abs(gyroTempY - 128) > Math.Abs(MappedState.RY - 128) ?
-                        gyroTempY : MappedState.RY;
+                if (MappedState.R.Y != 128)
+                    MappedState.R.Y = Math.Abs(gyroTempY - 128) > Math.Abs(MappedState.R.Y - 128) ?
+                        gyroTempY : MappedState.R.Y;
                 else
-                    MappedState.RY = gyroTempY;
+                    MappedState.R.Y = gyroTempY;
             }
 
             gyroTempX = gyroTempY = 128;
@@ -3000,12 +3000,12 @@ namespace DS4Windows
                 {
                     case DS4Controls.LXNeg:
                     {
-                        if (cState.LX < 128 - deadzoneL)
+                        if (cState.L.X < 128 - deadzoneL)
                         {
-                            double diff = -(cState.LX - 128 - deadzoneL) / (double)(0 - 128 - deadzoneL);
+                            double diff = -(cState.L.X - 128 - deadzoneL) / (double)(0 - 128 - deadzoneL);
                             //tempMouseOffsetX = Math.Abs(Math.Cos(cState.LSAngleRad)) * MOUSESTICKOFFSET;
                             //tempMouseOffsetX = MOUSESTICKOFFSET;
-                            tempMouseOffsetX = cState.LXUnit * mouseOffset;
+                            tempMouseOffsetX = cState.L.XUnit * mouseOffset;
                             value = (mouseVelocity - tempMouseOffsetX) * timeDelta * diff + (tempMouseOffsetX * -1.0 * timeDelta);
                             //value = diff * MOUSESPEEDFACTOR * (timeElapsed * 0.001) * speed;
                             //value = -(cState.LX - 127 - deadzoneL) / 2550d * speed;
@@ -3015,10 +3015,10 @@ namespace DS4Windows
                     }
                     case DS4Controls.LXPos:
                     {
-                        if (cState.LX > 128 + deadzoneL)
+                        if (cState.L.X > 128 + deadzoneL)
                         {
-                            double diff = (cState.LX - 128 + deadzoneL) / (double)(255 - 128 + deadzoneL);
-                            tempMouseOffsetX = cState.LXUnit * mouseOffset;
+                            double diff = (cState.L.X - 128 + deadzoneL) / (double)(255 - 128 + deadzoneL);
+                            tempMouseOffsetX = cState.L.XUnit * mouseOffset;
                             //tempMouseOffsetX = Math.Abs(Math.Cos(cState.LSAngleRad)) * MOUSESTICKOFFSET;
                             //tempMouseOffsetX = MOUSESTICKOFFSET;
                             value = (mouseVelocity - tempMouseOffsetX) * timeDelta * diff + (tempMouseOffsetX * timeDelta);
@@ -3030,10 +3030,10 @@ namespace DS4Windows
                     }
                     case DS4Controls.RXNeg:
                     {
-                        if (cState.RX < 128 - deadzoneR)
+                        if (cState.R.X < 128 - deadzoneR)
                         {
-                            double diff = -(cState.RX - 128 - deadzoneR) / (double)(0 - 128 - deadzoneR);
-                            tempMouseOffsetX = cState.RXUnit * mouseOffset;
+                            double diff = -(cState.R.X - 128 - deadzoneR) / (double)(0 - 128 - deadzoneR);
+                            tempMouseOffsetX = cState.R.XUnit * mouseOffset;
                             //tempMouseOffsetX = MOUSESTICKOFFSET;
                             //tempMouseOffsetX = Math.Abs(Math.Cos(cState.RSAngleRad)) * MOUSESTICKOFFSET;
                             value = (mouseVelocity - tempMouseOffsetX) * timeDelta * diff + (tempMouseOffsetX * -1.0 * timeDelta);
@@ -3045,10 +3045,10 @@ namespace DS4Windows
                     }
                     case DS4Controls.RXPos:
                     {
-                        if (cState.RX > 128 + deadzoneR)
+                        if (cState.R.X > 128 + deadzoneR)
                         {
-                            double diff = (cState.RX - 128 + deadzoneR) / (double)(255 - 128 + deadzoneR);
-                            tempMouseOffsetX = cState.RXUnit * mouseOffset;
+                            double diff = (cState.R.X - 128 + deadzoneR) / (double)(255 - 128 + deadzoneR);
+                            tempMouseOffsetX = cState.R.XUnit * mouseOffset;
                             //tempMouseOffsetX = MOUSESTICKOFFSET;
                             //tempMouseOffsetX = Math.Abs(Math.Cos(cState.RSAngleRad)) * MOUSESTICKOFFSET;
                             value = (mouseVelocity - tempMouseOffsetX) * timeDelta * diff + (tempMouseOffsetX * timeDelta);
@@ -3060,10 +3060,10 @@ namespace DS4Windows
                     }
                     case DS4Controls.LYNeg:
                     {
-                        if (cState.LY < 128 - deadzoneL)
+                        if (cState.L.Y < 128 - deadzoneL)
                         {
-                            double diff = -(cState.LY - 128 - deadzoneL) / (double)(0 - 128 - deadzoneL);
-                            tempMouseOffsetY = cState.LYUnit * mouseOffset;
+                            double diff = -(cState.L.Y - 128 - deadzoneL) / (double)(0 - 128 - deadzoneL);
+                            tempMouseOffsetY = cState.L.YUnit * mouseOffset;
                             //tempMouseOffsetY = MOUSESTICKOFFSET;
                             //tempMouseOffsetY = Math.Abs(Math.Sin(cState.LSAngleRad)) * MOUSESTICKOFFSET;
                             value = (mouseVelocity - tempMouseOffsetY) * timeDelta * diff + (tempMouseOffsetY * -1.0 * timeDelta);
@@ -3075,10 +3075,10 @@ namespace DS4Windows
                     }
                     case DS4Controls.LYPos:
                     {
-                        if (cState.LY > 128 + deadzoneL)
+                        if (cState.L.Y > 128 + deadzoneL)
                         {
-                            double diff = (cState.LY - 128 + deadzoneL) / (double)(255 - 128 + deadzoneL);
-                            tempMouseOffsetY = cState.LYUnit * mouseOffset;
+                            double diff = (cState.L.Y - 128 + deadzoneL) / (double)(255 - 128 + deadzoneL);
+                            tempMouseOffsetY = cState.L.YUnit * mouseOffset;
                             //tempMouseOffsetY = MOUSESTICKOFFSET;
                             //tempMouseOffsetY = Math.Abs(Math.Sin(cState.LSAngleRad)) * MOUSESTICKOFFSET;
                             value = (mouseVelocity - tempMouseOffsetY) * timeDelta * diff + (tempMouseOffsetY * timeDelta);
@@ -3090,10 +3090,10 @@ namespace DS4Windows
                     }
                     case DS4Controls.RYNeg:
                     {
-                        if (cState.RY < 128 - deadzoneR)
+                        if (cState.R.Y < 128 - deadzoneR)
                         {
-                            double diff = -(cState.RY - 128 - deadzoneR) / (double)(0 - 128 - deadzoneR);
-                            tempMouseOffsetY = cState.RYUnit * mouseOffset;
+                            double diff = -(cState.R.Y - 128 - deadzoneR) / (double)(0 - 128 - deadzoneR);
+                            tempMouseOffsetY = cState.R.YUnit * mouseOffset;
                             //tempMouseOffsetY = MOUSESTICKOFFSET;
                             //tempMouseOffsetY = Math.Abs(Math.Sin(cState.RSAngleRad)) * MOUSESTICKOFFSET;
                             value = (mouseVelocity - tempMouseOffsetY) * timeDelta * diff + (tempMouseOffsetY * -1.0 * timeDelta);
@@ -3105,10 +3105,10 @@ namespace DS4Windows
                     }
                     case DS4Controls.RYPos:
                     {
-                        if (cState.RY > 128 + deadzoneR)
+                        if (cState.R.Y > 128 + deadzoneR)
                         {
-                            double diff = (cState.RY - 128 + deadzoneR) / (double)(255 - 128 + deadzoneR);
-                            tempMouseOffsetY = cState.RYUnit * mouseOffset;
+                            double diff = (cState.R.Y - 128 + deadzoneR) / (double)(255 - 128 + deadzoneR);
+                            tempMouseOffsetY = cState.R.YUnit * mouseOffset;
                             //tempMouseOffsetY = MOUSESTICKOFFSET;
                             //tempMouseOffsetY = Math.Abs(Math.Sin(cState.RSAngleRad)) * MOUSESTICKOFFSET;
                             value = (mouseVelocity - tempMouseOffsetY) * timeDelta * diff + (tempMouseOffsetY * timeDelta);
@@ -3357,14 +3357,14 @@ namespace DS4Windows
             {
                 switch (control)
                 {
-                    case DS4Controls.LXNeg: result = (byte)(cState.LX - 128.0f >= 0 ? 0 : -(cState.LX - 128.0f) * 1.9921875f); break;
-                    case DS4Controls.LYNeg: result = (byte)(cState.LY - 128.0f >= 0 ? 0 : -(cState.LY - 128.0f) * 1.9921875f); break;
-                    case DS4Controls.RXNeg: result = (byte)(cState.RX - 128.0f >= 0 ? 0 : -(cState.RX - 128.0f) * 1.9921875f); break;
-                    case DS4Controls.RYNeg: result = (byte)(cState.RY - 128.0f >= 0 ? 0 : -(cState.RY - 128.0f) * 1.9921875f); break;
-                    case DS4Controls.LXPos: result = (byte)(cState.LX - 128.0f < 0 ? 0 : (cState.LX - 128.0f) * 2.0078740157480315f); break;
-                    case DS4Controls.LYPos: result = (byte)(cState.LY - 128.0f < 0 ? 0 : (cState.LY - 128.0f) * 2.0078740157480315f); break;
-                    case DS4Controls.RXPos: result = (byte)(cState.RX - 128.0f < 0 ? 0 : (cState.RX - 128.0f) * 2.0078740157480315f); break;
-                    case DS4Controls.RYPos: result = (byte)(cState.RY - 128.0f < 0 ? 0 : (cState.RY - 128.0f) * 2.0078740157480315f); break;
+                    case DS4Controls.LXNeg: result = (byte)(cState.L.X - 128.0f >= 0 ? 0 : -(cState.L.X - 128.0f) * 1.9921875f); break;
+                    case DS4Controls.LYNeg: result = (byte)(cState.L.Y - 128.0f >= 0 ? 0 : -(cState.L.Y - 128.0f) * 1.9921875f); break;
+                    case DS4Controls.RXNeg: result = (byte)(cState.R.X - 128.0f >= 0 ? 0 : -(cState.R.X - 128.0f) * 1.9921875f); break;
+                    case DS4Controls.RYNeg: result = (byte)(cState.R.Y - 128.0f >= 0 ? 0 : -(cState.R.Y - 128.0f) * 1.9921875f); break;
+                    case DS4Controls.LXPos: result = (byte)(cState.L.X - 128.0f < 0 ? 0 : (cState.L.X - 128.0f) * 2.0078740157480315f); break;
+                    case DS4Controls.LYPos: result = (byte)(cState.L.Y - 128.0f < 0 ? 0 : (cState.L.Y - 128.0f) * 2.0078740157480315f); break;
+                    case DS4Controls.RXPos: result = (byte)(cState.R.X - 128.0f < 0 ? 0 : (cState.R.X - 128.0f) * 2.0078740157480315f); break;
+                    case DS4Controls.RYPos: result = (byte)(cState.R.Y - 128.0f < 0 ? 0 : (cState.R.Y - 128.0f) * 2.0078740157480315f); break;
                     default: break;
                 }
             }
@@ -3485,14 +3485,14 @@ namespace DS4Windows
             {
                 switch (control)
                 {
-                    case DS4Controls.LXNeg: result = cState.LX < 128 - 55; break;
-                    case DS4Controls.LYNeg: result = cState.LY < 128 - 55; break;
-                    case DS4Controls.RXNeg: result = cState.RX < 128 - 55; break;
-                    case DS4Controls.RYNeg: result = cState.RY < 128 - 55; break;
-                    case DS4Controls.LXPos: result = cState.LX > 128 + 55; break;
-                    case DS4Controls.LYPos: result = cState.LY > 128 + 55; break;
-                    case DS4Controls.RXPos: result = cState.RX > 128 + 55; break;
-                    case DS4Controls.RYPos: result = cState.RY > 128 + 55; break;
+                    case DS4Controls.LXNeg: result = cState.L.X < 128 - 55; break;
+                    case DS4Controls.LYNeg: result = cState.L.Y < 128 - 55; break;
+                    case DS4Controls.RXNeg: result = cState.R.X < 128 - 55; break;
+                    case DS4Controls.RYNeg: result = cState.R.Y < 128 - 55; break;
+                    case DS4Controls.LXPos: result = cState.L.X > 128 + 55; break;
+                    case DS4Controls.LYPos: result = cState.L.Y > 128 + 55; break;
+                    case DS4Controls.RXPos: result = cState.R.X > 128 + 55; break;
+                    case DS4Controls.RYPos: result = cState.R.Y > 128 + 55; break;
                     default: break;
                 }
             }
@@ -3562,10 +3562,10 @@ namespace DS4Windows
 
                 switch (control)
                 {
-                    case DS4Controls.LXNeg: result = cState.LX < 128 - 55; break;
-                    case DS4Controls.LYNeg: result = cState.LY < 128 - 55; break;
-                    case DS4Controls.RXNeg: result = cState.RX < 128 - 55; break;
-                    case DS4Controls.RYNeg: result = cState.RY < 128 - 55; break;
+                    case DS4Controls.LXNeg: result = cState.L.X < 128 - 55; break;
+                    case DS4Controls.LYNeg: result = cState.L.Y < 128 - 55; break;
+                    case DS4Controls.RXNeg: result = cState.R.X < 128 - 55; break;
+                    case DS4Controls.RYNeg: result = cState.R.Y < 128 - 55; break;
                     default: result = axisValue > 128 + 55; break;
                 }
             }
@@ -3618,10 +3618,10 @@ namespace DS4Windows
 
                 switch (control)
                 {
-                    case DS4Controls.LXNeg: result = cState.LX < 128 - 55; break;
-                    case DS4Controls.LYNeg: result = cState.LY < 128 - 55; break;
-                    case DS4Controls.RXNeg: result = cState.RX < 128 - 55; break;
-                    case DS4Controls.RYNeg: result = cState.RY < 128 - 55; break;
+                    case DS4Controls.LXNeg: result = cState.L.X < 128 - 55; break;
+                    case DS4Controls.LYNeg: result = cState.L.Y < 128 - 55; break;
+                    case DS4Controls.RXNeg: result = cState.R.X < 128 - 55; break;
+                    case DS4Controls.RYNeg: result = cState.R.Y < 128 - 55; break;
                     default: result = axisValue > 128 + 55; break;
                 }
             }
@@ -3674,50 +3674,50 @@ namespace DS4Windows
                 {
                     case DS4Controls.LXNeg:
                     {
-                        double angle = cState.LSAngle;
-                        result = cState.LX < 128 && (angle >= 112.5 && angle <= 247.5);
+                        double angle = cState.L.Angle;
+                        result = cState.L.X < 128 && (angle >= 112.5 && angle <= 247.5);
                         break;
                     }
                     case DS4Controls.LYNeg:
                     {
-                        double angle = cState.LSAngle;
-                        result = cState.LY < 128 && (angle >= 22.5 && angle <= 157.5);
+                        double angle = cState.L.Angle;
+                        result = cState.L.Y < 128 && (angle >= 22.5 && angle <= 157.5);
                         break;
                     }
                     case DS4Controls.RXNeg:
                     {
-                        double angle = cState.RSAngle;
-                        result = cState.RX < 128 && (angle >= 112.5 && angle <= 247.5);
+                        double angle = cState.R.Angle;
+                        result = cState.R.X < 128 && (angle >= 112.5 && angle <= 247.5);
                         break;
                     }
                     case DS4Controls.RYNeg:
                     {
-                        double angle = cState.RSAngle;
-                        result = cState.RY < 128 && (angle >= 22.5 && angle <= 157.5);
+                        double angle = cState.R.Angle;
+                        result = cState.R.Y < 128 && (angle >= 22.5 && angle <= 157.5);
                         break;
                     }
                     case DS4Controls.LXPos:
                     {
-                        double angle = cState.LSAngle;
-                        result = cState.LX > 128 && (angle <= 67.5 || angle >= 292.5);
+                        double angle = cState.L.Angle;
+                        result = cState.L.X > 128 && (angle <= 67.5 || angle >= 292.5);
                         break;
                     }
                     case DS4Controls.LYPos:
                     {
-                        double angle = cState.LSAngle;
-                        result = cState.LY > 128 && (angle >= 202.5 && angle <= 337.5);
+                        double angle = cState.L.Angle;
+                        result = cState.L.Y > 128 && (angle >= 202.5 && angle <= 337.5);
                         break;
                     }
                     case DS4Controls.RXPos:
                     {
-                        double angle = cState.RSAngle;
-                        result = cState.RX > 128 && (angle <= 67.5 || angle >= 292.5);
+                        double angle = cState.R.Angle;
+                        result = cState.R.X > 128 && (angle <= 67.5 || angle >= 292.5);
                         break;
                     }
                     case DS4Controls.RYPos:
                     {
-                        double angle = cState.RSAngle;
-                        result = cState.RY > 128 && (angle >= 202.5 && angle <= 337.5);
+                        double angle = cState.R.Angle;
+                        result = cState.R.Y > 128 && (angle >= 202.5 && angle <= 337.5);
                         break;
                     }
                     default: break;
@@ -3929,14 +3929,14 @@ namespace DS4Windows
             {
                 switch (control)
                 {
-                    case DS4Controls.LXNeg: if (!alt) result = cState.LX; else result = (byte)(255 - cState.LX); break;
-                    case DS4Controls.LYNeg: if (!alt) result = cState.LY; else result = (byte)(255 - cState.LY); break;
-                    case DS4Controls.RXNeg: if (!alt) result = cState.RX; else result = (byte)(255 - cState.RX); break;
-                    case DS4Controls.RYNeg: if (!alt) result = cState.RY; else result = (byte)(255 - cState.RY); break;
-                    case DS4Controls.LXPos: if (!alt) result = (byte)(255 - cState.LX); else result = cState.LX; break;
-                    case DS4Controls.LYPos: if (!alt) result = (byte)(255 - cState.LY); else result = cState.LY; break;
-                    case DS4Controls.RXPos: if (!alt) result = (byte)(255 - cState.RX); else result = cState.RX; break;
-                    case DS4Controls.RYPos: if (!alt) result = (byte)(255 - cState.RY); else result = cState.RY; break;
+                    case DS4Controls.LXNeg: if (!alt) result = cState.L.X; else result = (byte)(255 - cState.L.X); break;
+                    case DS4Controls.LYNeg: if (!alt) result = cState.L.Y; else result = (byte)(255 - cState.L.Y); break;
+                    case DS4Controls.RXNeg: if (!alt) result = cState.R.X; else result = (byte)(255 - cState.R.X); break;
+                    case DS4Controls.RYNeg: if (!alt) result = cState.R.Y; else result = (byte)(255 - cState.R.Y); break;
+                    case DS4Controls.LXPos: if (!alt) result = (byte)(255 - cState.L.X); else result = cState.L.X; break;
+                    case DS4Controls.LYPos: if (!alt) result = (byte)(255 - cState.L.Y); else result = cState.L.Y; break;
+                    case DS4Controls.RXPos: if (!alt) result = (byte)(255 - cState.R.X); else result = cState.R.X; break;
+                    case DS4Controls.RYPos: if (!alt) result = (byte)(255 - cState.R.Y); else result = cState.R.Y; break;
                     default: break;
                 }
             }

--- a/DS4Windows/DS4Control/UdpServer.cs
+++ b/DS4Windows/DS4Control/UdpServer.cs
@@ -506,13 +506,13 @@ namespace DS4Windows
                 outputData[++outIdx] = (hidReport.TouchButton) ? (byte)1 : (byte)0;
 
                 //Left stick
-                outputData[++outIdx] = hidReport.LX;
-                outputData[++outIdx] = hidReport.LY;
+                outputData[++outIdx] = hidReport.L.X;
+                outputData[++outIdx] = hidReport.L.Y;
                 outputData[outIdx] = (byte)(255 - outputData[outIdx]); //invert Y by convention
 
                 //Right stick
-                outputData[++outIdx] = hidReport.RX;
-                outputData[++outIdx] = hidReport.RY;
+                outputData[++outIdx] = hidReport.R.X;
+                outputData[++outIdx] = hidReport.R.Y;
                 outputData[outIdx] = (byte)(255 - outputData[outIdx]); //invert Y by convention
 
                 //we don't have analog buttons on DS4 :(

--- a/DS4Windows/DS4Control/Xbox360OutDevice.cs
+++ b/DS4Windows/DS4Control/Xbox360OutDevice.cs
@@ -62,37 +62,37 @@ namespace DS4Windows
             switch (steeringWheelMappedAxis)
             {
                 case SASteeringWheelEmulationAxisType.None:
-                    cont.LeftThumbX = AxisScale(state.LX, false);
-                    cont.LeftThumbY = AxisScale(state.LY, true);
-                    cont.RightThumbX = AxisScale(state.RX, false);
-                    cont.RightThumbY = AxisScale(state.RY, true);
+                    cont.LeftThumbX = AxisScale(state.L.X, false);
+                    cont.LeftThumbY = AxisScale(state.L.Y, true);
+                    cont.RightThumbX = AxisScale(state.R.X, false);
+                    cont.RightThumbY = AxisScale(state.R.Y, true);
                     break;
 
                 case SASteeringWheelEmulationAxisType.LX:
                     cont.LeftThumbX = (short)state.SASteeringWheelEmulationUnit;
-                    cont.LeftThumbY = AxisScale(state.LY, true);
-                    cont.RightThumbX = AxisScale(state.RX, false);
-                    cont.RightThumbY = AxisScale(state.RY, true);
+                    cont.LeftThumbY = AxisScale(state.L.Y, true);
+                    cont.RightThumbX = AxisScale(state.R.X, false);
+                    cont.RightThumbY = AxisScale(state.R.Y, true);
                     break;
 
                 case SASteeringWheelEmulationAxisType.LY:
-                    cont.LeftThumbX = AxisScale(state.LX, false);
+                    cont.LeftThumbX = AxisScale(state.L.X, false);
                     cont.LeftThumbY = (short)state.SASteeringWheelEmulationUnit;
-                    cont.RightThumbX = AxisScale(state.RX, false);
-                    cont.RightThumbY = AxisScale(state.RY, true);
+                    cont.RightThumbX = AxisScale(state.R.X, false);
+                    cont.RightThumbY = AxisScale(state.R.Y, true);
                     break;
 
                 case SASteeringWheelEmulationAxisType.RX:
-                    cont.LeftThumbX = AxisScale(state.LX, false);
-                    cont.LeftThumbY = AxisScale(state.LY, true);
+                    cont.LeftThumbX = AxisScale(state.L.X, false);
+                    cont.LeftThumbY = AxisScale(state.L.Y, true);
                     cont.RightThumbX = (short)state.SASteeringWheelEmulationUnit;
-                    cont.RightThumbY = AxisScale(state.RY, true);
+                    cont.RightThumbY = AxisScale(state.R.Y, true);
                     break;
 
                 case SASteeringWheelEmulationAxisType.RY:
-                    cont.LeftThumbX = AxisScale(state.LX, false);
-                    cont.LeftThumbY = AxisScale(state.LY, true);
-                    cont.RightThumbX = AxisScale(state.RX, false);
+                    cont.LeftThumbX = AxisScale(state.L.X, false);
+                    cont.LeftThumbY = AxisScale(state.L.Y, true);
+                    cont.RightThumbX = AxisScale(state.R.X, false);
                     cont.RightThumbY = (short)state.SASteeringWheelEmulationUnit;
                     break;
 

--- a/DS4Windows/DS4Forms/ControllerReadingsControl.xaml.cs
+++ b/DS4Windows/DS4Forms/ControllerReadingsControl.xaml.cs
@@ -214,24 +214,24 @@ namespace DS4WinWPF.DS4Forms
 
                 Dispatcher.Invoke(() =>
                 {
-                    int x = baseState.LX;
-                    int y = baseState.LY;
+                    int x = baseState.L.X;
+                    int y = baseState.L.Y;
 
                     Canvas.SetLeft(lsValRec, x / 255.0 * CANVAS_WIDTH - 3);
                     Canvas.SetTop(lsValRec, y / 255.0 * CANVAS_WIDTH - 3);
                     //bool mappedLS = interState.LX != x || interState.LY != y;
                     //if (mappedLS)
                     //{
-                        Canvas.SetLeft(lsMapValRec, interState.LX / 255.0 * CANVAS_WIDTH - 3);
-                        Canvas.SetTop(lsMapValRec, interState.LY / 255.0 * CANVAS_WIDTH - 3);
+                        Canvas.SetLeft(lsMapValRec, interState.L.X / 255.0 * CANVAS_WIDTH - 3);
+                        Canvas.SetTop(lsMapValRec, interState.L.Y / 255.0 * CANVAS_WIDTH - 3);
                     //}
 
-                    x = baseState.RX;
-                    y = baseState.RY;
+                    x = baseState.R.X;
+                    y = baseState.R.Y;
                     Canvas.SetLeft(rsValRec, x / 255.0 * CANVAS_WIDTH - 3);
                     Canvas.SetTop(rsValRec, y / 255.0 * CANVAS_WIDTH - 3);
-                    Canvas.SetLeft(rsMapValRec, interState.RX / 255.0 * CANVAS_WIDTH - 3);
-                    Canvas.SetTop(rsMapValRec, interState.RY / 255.0 * CANVAS_WIDTH - 3);
+                    Canvas.SetLeft(rsMapValRec, interState.R.X / 255.0 * CANVAS_WIDTH - 3);
+                    Canvas.SetTop(rsMapValRec, interState.R.Y / 255.0 * CANVAS_WIDTH - 3);
 
                     x = exposeState.getAccelX() + 127;
                     y = exposeState.getAccelZ() + 127;
@@ -317,15 +317,15 @@ namespace DS4WinWPF.DS4Forms
         private void UpdateCoordLabels(DS4State inState, DS4State mapState,
             DS4StateExposed exposeState)
         {
-            lxInValLb.Content = inState.LX;
-            lxOutValLb.Content = mapState.LX;
-            lyInValLb.Content = inState.LY;
-            lyOutValLb.Content = mapState.LY;
+            lxInValLb.Content = inState.L.X;
+            lxOutValLb.Content = mapState.L.X;
+            lyInValLb.Content = inState.L.Y;
+            lyOutValLb.Content = mapState.L.Y;
 
-            rxInValLb.Content = inState.RX;
-            rxOutValLb.Content = mapState.RX;
-            ryInValLb.Content = inState.RY;
-            ryOutValLb.Content = mapState.RY;
+            rxInValLb.Content = inState.R.X;
+            rxOutValLb.Content = mapState.R.X;
+            ryInValLb.Content = inState.R.Y;
+            ryOutValLb.Content = mapState.R.Y;
 
             sixAxisXInValLb.Content = exposeState.AccelX;
             sixAxisXOutValLb.Content = mapState.Motion.outputAccelX;

--- a/DS4Windows/DS4Library/DS4Device.cs
+++ b/DS4Windows/DS4Library/DS4Device.cs
@@ -617,8 +617,10 @@ namespace DS4Windows
             }
             else
             {
-                hDevice.readFeatureData(calibration);
-                sixAxis.setCalibrationData(ref calibration, conType == ConnectionType.USB);
+                if (hDevice.readFeatureData(calibration))
+                {
+                    sixAxis.setCalibrationData(ref calibration, conType == ConnectionType.USB);
+                }
             }
         }
 
@@ -1002,10 +1004,10 @@ namespace DS4Windows
 
                     cState.PacketCounter = pState.PacketCounter + 1;
                     cState.ReportTimeStamp = utcNow;
-                    cState.LX = inputReport[1];
-                    cState.LY = inputReport[2];
-                    cState.RX = inputReport[3];
-                    cState.RY = inputReport[4];
+                    cState.L.X = inputReport[1];
+                    cState.L.Y = inputReport[2];
+                    cState.R.X = inputReport[3];
+                    cState.R.Y = inputReport[4];
                     cState.L2 = inputReport[8];
                     cState.R2 = inputReport[9];
 
@@ -1641,9 +1643,9 @@ namespace DS4Windows
                 return false;
             // TODO calibrate to get an accurate jitter and center-play range and centered position
             const int slop = 64;
-            if (cState.LX <= 127 - slop || cState.LX >= 128 + slop || cState.LY <= 127 - slop || cState.LY >= 128 + slop)
+            if (cState.L.X <= 127 - slop || cState.L.X >= 128 + slop || cState.L.Y <= 127 - slop || cState.L.Y >= 128 + slop)
                 return false;
-            if (cState.RX <= 127 - slop || cState.RX >= 128 + slop || cState.RY <= 127 - slop || cState.RY >= 128 + slop)
+            if (cState.R.X <= 127 - slop || cState.R.X >= 128 + slop || cState.R.Y <= 127 - slop || cState.R.Y >= 128 + slop)
                 return false;
             if (cState.Touch1 || cState.Touch2 || cState.TouchButton)
                 return false;

--- a/DS4Windows/DS4Library/DS4State.cs
+++ b/DS4Windows/DS4Library/DS4State.cs
@@ -12,23 +12,70 @@ namespace DS4Windows
         public bool Share, Options, PS, Touch1, Touch2, TouchButton, TouchRight,
             TouchLeft, Touch1Finger, Touch2Fingers;
         public byte Touch1Identifier, Touch2Identifier;
-        public byte LX, RX, LY, RY, L2, R2;
+        public Stick L, R; // Left and right Sticks
+        public byte L2, R2;
         public byte FrameCounter; // 0, 1, 2...62, 63, 0....
         public byte TouchPacketCounter; // we break these out automatically
         public byte Battery; // 0 for charging, 10/20/30/40/50/60/70/80/90/100 for percentage of full
-        public double LSAngle; // Calculated bearing of the LS X,Y coordinates
-        public double RSAngle; // Calculated bearing of the RS X,Y coordinates
-        public double LSAngleRad; // Calculated bearing of the LS X,Y coordinates (in radians)
-        public double RSAngleRad; // Calculated bearing of the RS X,Y coordinates (in radians)
-        public double LXUnit;
-        public double LYUnit;
-        public double RXUnit;
-        public double RYUnit;
         public double elapsedTime = 0.0;
         public ulong totalMicroSec = 0;
         public SixAxis Motion = null;
         public static readonly int DEFAULT_AXISDIR_VALUE = 127;
         public Int32 SASteeringWheelEmulationUnit;
+
+        public class Stick
+        {
+            public byte X = 128;
+            public byte Y = 128;
+
+            public double Angle; // Calculated bearing of the LS X,Y coordinates
+            public double AngleRad; // Calculated bearing of the LS X,Y coordinates (in radians)
+            public double XUnit;
+            public double YUnit;
+
+            public Stick()
+            {
+                X = 128;
+                Y = 128;
+                Angle = 0.0;
+                AngleRad = 0.0;
+                XUnit = 0.0;
+                YUnit = 0.0;
+            }
+
+            public Stick(Stick other)
+            {
+                other.CopyTo(this);
+            }
+
+            public void CopyTo(Stick other)
+            {
+                other.X = X;
+                other.Y = Y;
+                other.Angle = Angle;
+                other.AngleRad = AngleRad;
+                other.XUnit = XUnit;
+                other.YUnit = XUnit;
+            }
+
+            public void CalculateAngles()
+            {
+                double lsangle = Math.Atan2(-(Y - 128), (X - 128));
+                AngleRad = lsangle;
+                lsangle = (lsangle >= 0 ? lsangle : (2 * Math.PI + lsangle)) * 180 / Math.PI;
+                Angle = lsangle;
+                XUnit = Math.Abs(Math.Cos(AngleRad));
+                YUnit = Math.Abs(Math.Sin(AngleRad));
+            }
+
+            public void RotateCoordinates(double rotation)
+            {
+                double sinAngle = Math.Sin(rotation), cosAngle = Math.Cos(rotation);
+                double tempX = X - 128.0, tempY = Y - 128.0;
+                X = (Byte)(Global.Clamp(-128.0, (tempX * cosAngle - tempY * sinAngle), 127.0) + 128.0);
+                Y = (Byte)(Global.Clamp(-128.0, (tempX * sinAngle + tempY * cosAngle), 127.0) + 128.0);
+            }
+        }
 
         public struct TrackPadTouch
         {
@@ -49,19 +96,13 @@ namespace DS4Windows
             L1 = L2Btn = L3 = R1 = R2Btn = R3 = false;
             Share = Options = PS = Touch1 = Touch2 = TouchButton = TouchRight = TouchLeft = false;
             Touch1Finger = Touch2Fingers = false;
-            LX = RX = LY = RY = 128;
-            L2 = R2 = 0;
+            L = new Stick();
+            R = new Stick();
+            L2 = 0;
+            R2 = 0;
             FrameCounter = 255; // only actually has 6 bits, so this is a null indicator
             TouchPacketCounter = 255; // 8 bits, no great junk value
             Battery = 0;
-            LSAngle = 0.0;
-            LSAngleRad = 0.0;
-            RSAngle = 0.0;
-            RSAngleRad = 0.0;
-            LXUnit = 0.0;
-            LYUnit = 0.0;
-            RXUnit = 0.0;
-            RYUnit = 0.0;
             elapsedTime = 0.0;
             totalMicroSec = 0;
             Motion = new SixAxis(0, 0, 0, 0, 0, 0, 0.0);
@@ -103,20 +144,10 @@ namespace DS4Windows
             TouchPacketCounter = state.TouchPacketCounter;
             Touch1Finger = state.Touch1Finger;
             Touch2Fingers = state.Touch2Fingers;
-            LX = state.LX;
-            RX = state.RX;
-            LY = state.LY;
-            RY = state.RY;
+            L = new Stick(state.L);
+            R = new Stick(state.R);
             FrameCounter = state.FrameCounter;
             Battery = state.Battery;
-            LSAngle = state.LSAngle;
-            LSAngleRad = state.LSAngleRad;
-            RSAngle = state.RSAngle;
-            RSAngleRad = state.RSAngleRad;
-            LXUnit = state.LXUnit;
-            LYUnit = state.LYUnit;
-            RXUnit = state.RXUnit;
-            RYUnit = state.RYUnit;
             elapsedTime = state.elapsedTime;
             totalMicroSec = state.totalMicroSec;
             Motion = state.Motion;
@@ -163,20 +194,10 @@ namespace DS4Windows
             state.TouchPacketCounter = TouchPacketCounter;
             state.Touch1Finger = Touch1Finger;
             state.Touch2Fingers = Touch2Fingers;
-            state.LX = LX;
-            state.RX = RX;
-            state.LY = LY;
-            state.RY = RY;
+            L.CopyTo(state.L);
+            R.CopyTo(state.R);
             state.FrameCounter = FrameCounter;
             state.Battery = Battery;
-            state.LSAngle = LSAngle;
-            state.LSAngleRad = LSAngleRad;
-            state.RSAngle = RSAngle;
-            state.RSAngleRad = RSAngleRad;
-            state.LXUnit = LXUnit;
-            state.LYUnit = LYUnit;
-            state.RXUnit = RXUnit;
-            state.RYUnit = RYUnit;
             state.elapsedTime = elapsedTime;
             state.totalMicroSec = totalMicroSec;
             state.Motion = Motion;
@@ -187,35 +208,18 @@ namespace DS4Windows
 
         public void calculateStickAngles()
         {
-            double lsangle = Math.Atan2(-(LY - 128), (LX - 128));
-            LSAngleRad = lsangle;
-            lsangle = (lsangle >= 0 ? lsangle : (2 * Math.PI + lsangle)) * 180 / Math.PI;
-            LSAngle = lsangle;
-            LXUnit = Math.Abs(Math.Cos(LSAngleRad));
-            LYUnit = Math.Abs(Math.Sin(LSAngleRad));
-
-            double rsangle = Math.Atan2(-(RY - 128), (RX - 128));
-            RSAngleRad = rsangle;
-            rsangle = (rsangle >= 0 ? rsangle : (2 * Math.PI + rsangle)) * 180 / Math.PI;
-            RSAngle = rsangle;
-            RXUnit = Math.Abs(Math.Cos(RSAngleRad));
-            RYUnit = Math.Abs(Math.Sin(RSAngleRad));
+            L.CalculateAngles();
+            R.CalculateAngles();
         }
 
         public void rotateLSCoordinates(double rotation)
         {
-            double sinAngle = Math.Sin(rotation), cosAngle = Math.Cos(rotation);
-            double tempLX = LX - 128.0, tempLY = LY - 128.0;
-            LX = (Byte)(Global.Clamp(-128.0, (tempLX * cosAngle - tempLY * sinAngle), 127.0) + 128.0);
-            LY = (Byte)(Global.Clamp(-128.0, (tempLX * sinAngle + tempLY * cosAngle), 127.0) + 128.0);
+            L.RotateCoordinates(rotation);
         }
 
         public void rotateRSCoordinates(double rotation)
         {
-            double sinAngle = Math.Sin(rotation), cosAngle = Math.Cos(rotation);
-            double tempRX = RX - 128.0, tempRY = RY - 128.0;
-            RX = (Byte)(Global.Clamp(-128.0, (tempRX * cosAngle - tempRY * sinAngle), 127.0) + 128.0);
-            RY = (Byte)(Global.Clamp(-128.0, (tempRX * sinAngle + tempRY * cosAngle), 127.0) + 128.0);
+            R.RotateCoordinates(rotation);
         }
     }
 }

--- a/DS4Windows/DS4Library/DS4StateExposed.cs
+++ b/DS4Windows/DS4Library/DS4StateExposed.cs
@@ -35,10 +35,10 @@ namespace DS4Windows
         bool TouchButton { get { return _state.TouchButton; } }
         bool Touch1Finger { get { return _state.Touch1Finger; } }
         bool Touch2Fingers { get { return _state.Touch2Fingers; } }
-        byte LX { get { return _state.LX; } }
-        byte RX { get { return _state.RX; } }
-        byte LY { get { return _state.LY; } }
-        byte RY { get { return _state.RY; } }
+        byte LX { get { return _state.L.X; } }
+        byte RX { get { return _state.R.X; } }
+        byte LY { get { return _state.L.Y; } }
+        byte RY { get { return _state.R.Y; } }
         byte L2 { get { return _state.L2; } }
         byte R2 { get { return _state.R2; } }
         int Battery { get { return _state.Battery; } }


### PR DESCRIPTION
This refactoring is needed to unify the code that handles transformation of left and right stick coordinates.