### PR TITLE
fixed "index out of bounds" error in localized resoure string value w…

### DIFF
--- a/DS4Windows/Properties/Resources.Designer.cs
+++ b/DS4Windows/Properties/Resources.Designer.cs
@@ -928,7 +928,7 @@ namespace DS4WinWPF.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Controller {0} is not using a profile. Battery level is {2}%.
+        ///   Looks up a localized string similar to Controller {0} is not using a profile. Battery level is {1}%.
         /// </summary>
         public static string NotUsingProfile {
             get {

--- a/DS4Windows/Properties/Resources.resx
+++ b/DS4Windows/Properties/Resources.resx
@@ -386,7 +386,7 @@
     <value>No Profile Loaded</value>
   </data>
   <data name="NotUsingProfile" xml:space="preserve">
-    <value>Controller {0} is not using a profile. Battery level is {2}%</value>
+    <value>Controller {0} is not using a profile. Battery level is {1}%</value>
   </data>
   <data name="NotValid" xml:space="preserve">
     <value>Not valid</value>


### PR DESCRIPTION
…hen a gamepad is connected and the specified default profile is not found.  Related to #1468 issue