### PR TITLE
Workaround to app launch crash issue if TaskService COM objects doesn't work

### DIFF
--- a/DS4Windows/StartupMethods.cs
+++ b/DS4Windows/StartupMethods.cs
@@ -17,14 +17,30 @@ namespace DS4WinWPF
 
         public static bool HasStartProgEntry()
         {
-            bool exists = File.Exists(Environment.GetFolderPath(Environment.SpecialFolder.Startup) + "\\DS4Windows.lnk");
+            bool exists = false;
+            try
+            {
+                exists = File.Exists(Environment.GetFolderPath(Environment.SpecialFolder.Startup) + "\\DS4Windows.lnk");
+            }
+            catch (Exception ex)
+            {
+                DS4Windows.AppLogger.LogToGui($"Error while checking existence of DS4Windows.lnk shortcut. {ex.Message}", true);
+            }
             return exists;
         }
 
         public static bool HasTaskEntry()
         {
-            TaskService ts = new TaskService();
-            Task tasker = ts.FindTask("RunDS4Windows");
+            Task tasker = null;
+            try
+            {
+                TaskService ts = new TaskService();
+                tasker = ts.FindTask("RunDS4Windows");
+            }
+            catch (Exception ex)
+            {
+                DS4Windows.AppLogger.LogToGui($"Error in TaskService. Check WinOS TaskScheduler service functionality. {ex.Message}", true);
+            }
             return tasker != null;
         }
 


### PR DESCRIPTION
Workaround to app launch crash issue if TaskService COM objects doesn't work (TaskService corrupted or disabled in WinOS level?) or there are shortcut file access permission problems. These issues are WinOS issues, but this fix makes it possible to launch the DS4Windows app even when those errors occur. Issue #1475 