### PR TITLE
Make updates on startup more understandable

### DIFF
--- a/DS4Windows/Translations/Strings.resx
+++ b/DS4Windows/Translations/Strings.resx
@@ -157,7 +157,7 @@
     <value>Check For Update Now</value>
   </data>
   <data name="CheckUpdateStartup" xml:space="preserve">
-    <value>Check for DS4Windows Updates at Startup</value>
+    <value>Check for updates at DS4Windows startup</value>
   </data>
   <data name="Clear" xml:space="preserve">
     <value>Clear</value>


### PR DESCRIPTION
AFAIK this tickbox will check for updates every DS4 statup, not the PC startup.

In case it's a PC startup, this could also be a bit more clear.