### PR TITLE
Re-enabled rumble in dualshock4 mode but made it also possible to disable rumble/lightbar via profile settings.

### DIFF
--- a/DS4Windows/DS4Control/ControlService.cs
+++ b/DS4Windows/DS4Control/ControlService.cs
@@ -562,6 +562,7 @@ namespace DS4Windows
             else if (contType == OutContType.DS4)
             {
                 DS4OutDevice tempDS4 = outDevice as DS4OutDevice;
+                LightbarSettingInfo deviceLightbarSettingsInfo = Global.LightbarSettingsInfo[devIndex];
 
                 Nefarius.ViGEm.Client.Targets.DualShock4FeedbackReceivedEventHandler p = (sender, args) =>
                 {
@@ -582,7 +583,8 @@ namespace DS4Windows
                         useRumble = true;
                     }
 
-                    if (color.red != 0 || color.green != 0 || color.blue != 0)
+                    // Let games to control lightbar only when the mode is Passthru (otherwise DS4Windows controls the light)
+                    if (deviceLightbarSettingsInfo.Mode == LightbarMode.Passthru && (color.red != 0 || color.green != 0 || color.blue != 0))
                     {
                         useLight = true;
                     }
@@ -594,9 +596,10 @@ namespace DS4Windows
                         {
                             useRumble = true;
                         }
-                        else if (device.LightBarColor.red != 0 ||
+                        else if (deviceLightbarSettingsInfo.Mode == LightbarMode.Passthru && 
+                            (device.LightBarColor.red != 0 ||
                             device.LightBarColor.green != 0 ||
-                            device.LightBarColor.blue != 0)
+                            device.LightBarColor.blue != 0))
                         {
                             useLight = true;
                         }
@@ -637,7 +640,7 @@ namespace DS4Windows
             else if (contType == OutContType.DS4)
             {
                 DS4OutDevice tempDS4 = outDevice as DS4OutDevice;
-                //tempDS4.cont.FeedbackReceived -= tempDS4.forceFeedbackCall;
+                tempDS4.cont.FeedbackReceived -= tempDS4.forceFeedbackCall;
                 tempDS4.forceFeedbackCall = null;
             }
         }
@@ -696,7 +699,11 @@ namespace DS4Windows
                             Xbox360OutDevice tempXbox = EstablishOutDevice(index, OutContType.X360)
                             as Xbox360OutDevice;
                             //outputDevices[index] = tempXbox;
-                            EstablishOutFeedback(index, OutContType.X360, tempXbox, device);
+                            
+                            // Enable ViGem feedback callback handler only if lightbar/rumble data output is enabled (if those are disabled then no point enabling ViGem callback handler call)
+                            if (Global.EnableOutputDataToDS4[index])
+                                EstablishOutFeedback(index, OutContType.X360, tempXbox, device);
+                            
                             outputslotMan.DeferredPlugin(tempXbox, index, outputDevices, contType);
                             //slotDevice.CurrentInputBound = OutSlotDevice.InputBound.Bound;
 
@@ -712,7 +719,10 @@ namespace DS4Windows
                     {
                         slotDevice.CurrentInputBound = OutSlotDevice.InputBound.Bound;
                         Xbox360OutDevice tempXbox = slotDevice.OutputDevice as Xbox360OutDevice;
-                        EstablishOutFeedback(index, OutContType.X360, tempXbox, device);
+
+                        // Enable ViGem feedback callback handler only if lightbar/rumble data output is enabled (if those are disabled then no point enabling ViGem callback handler call)
+                        if (Global.EnableOutputDataToDS4[index])
+                            EstablishOutFeedback(index, OutContType.X360, tempXbox, device);
 
                         outputslotMan.EventDispatcher.BeginInvoke((Action)(() =>
                         {
@@ -737,7 +747,11 @@ namespace DS4Windows
                         {
                             DS4OutDevice tempDS4 = EstablishOutDevice(index, OutContType.DS4)
                             as DS4OutDevice;
-                            //EstablishOutFeedback(index, OutContType.DS4, tempDS4, device);
+
+                            // Enable ViGem feedback callback handler only if DS4 lightbar/rumble data output is enabled (if those are disabled then no point enabling ViGem callback handler call)
+                            if (Global.EnableOutputDataToDS4[index])
+                                EstablishOutFeedback(index, OutContType.DS4, tempDS4, device);
+                                
                             outputslotMan.DeferredPlugin(tempDS4, index, outputDevices, contType);
                             //slotDevice.CurrentInputBound = OutSlotDevice.InputBound.Bound;
 
@@ -753,7 +767,10 @@ namespace DS4Windows
                     {
                         slotDevice.CurrentInputBound = OutSlotDevice.InputBound.Bound;
                         DS4OutDevice tempDS4 = slotDevice.OutputDevice as DS4OutDevice;
-                        //EstablishOutFeedback(index, OutContType.DS4, tempDS4, device);
+
+                        // Enable ViGem feedback callback handler only if lightbar/rumble data output is enabled (if those are disabled then no point enabling ViGem callback handler call)
+                        if (Global.EnableOutputDataToDS4[index])
+                            EstablishOutFeedback(index, OutContType.DS4, tempDS4, device);
 
                         outputslotMan.EventDispatcher.BeginInvoke((Action)(() =>
                         {

--- a/DS4Windows/DS4Forms/MainWindow.xaml.cs
+++ b/DS4Windows/DS4Forms/MainWindow.xaml.cs
@@ -1111,35 +1111,39 @@ Suspend support not enabled.", true);
                                         // Name of the property to query from a profile or DS4Windows app engine
                                         propName = strData[2].ToLower();
 
-                                        if (propName == "profilename")
-                                        {
-                                            if (Global.useTempProfile[tdevice])
-                                                propValue = Global.tempprofilename[tdevice];
-                                            else
-                                                propValue = Global.ProfilePath[tdevice];
-                                        }
-                                        else if (propName == "outconttype")
-                                            propValue = Global.OutContType[tdevice].ToString();
-                                        else if (propName == "activeoutdevtype")
-                                            propValue = Global.activeOutDevType[tdevice].ToString();
-                                        else if (propName == "usedinputonly")
-                                            propValue = Global.useDInputOnly[tdevice].ToString();
+                                            if (propName == "profilename")
+                                            {
+                                                if (Global.useTempProfile[tdevice])
+                                                    propValue = Global.tempprofilename[tdevice];
+                                                else
+                                                    propValue = Global.ProfilePath[tdevice];
+                                            }
+                                            else if (propName == "outconttype")
+                                                propValue = Global.OutContType[tdevice].ToString();
+                                            else if (propName == "activeoutdevtype")
+                                                propValue = Global.activeOutDevType[tdevice].ToString();
+                                            else if (propName == "usedinputonly")
+                                                propValue = Global.useDInputOnly[tdevice].ToString();
 
-                                        else if (propName == "devicevidpid" && App.rootHub.DS4Controllers[tdevice] != null)
-                                            propValue = $"VID={App.rootHub.DS4Controllers[tdevice].HidDevice.Attributes.VendorHexId}, PID={App.rootHub.DS4Controllers[tdevice].HidDevice.Attributes.ProductHexId}";
-                                        else if (propName == "devicepath" && App.rootHub.DS4Controllers[tdevice] != null)
-                                            propValue = App.rootHub.DS4Controllers[tdevice].HidDevice.DevicePath;
-                                        else if (propName == "macaddress" && App.rootHub.DS4Controllers[tdevice] != null)
-                                            propValue = App.rootHub.DS4Controllers[tdevice].MacAddress;
-                                        else if (propName == "displayname" && App.rootHub.DS4Controllers[tdevice] != null)
-                                            propValue = App.rootHub.DS4Controllers[tdevice].DisplayName;
-                                        else if (propName == "conntype" && App.rootHub.DS4Controllers[tdevice] != null)
-                                            propValue = App.rootHub.DS4Controllers[tdevice].ConnectionType.ToString();
-                                        else if (propName == "exclusivestatus" && App.rootHub.DS4Controllers[tdevice] != null)
-                                            propValue = App.rootHub.DS4Controllers[tdevice].CurrentExclusiveStatus.ToString();
+                                            else if (propName == "devicevidpid" && App.rootHub.DS4Controllers[tdevice] != null)
+                                                propValue = $"VID={App.rootHub.DS4Controllers[tdevice].HidDevice.Attributes.VendorHexId}, PID={App.rootHub.DS4Controllers[tdevice].HidDevice.Attributes.ProductHexId}";
+                                            else if (propName == "devicepath" && App.rootHub.DS4Controllers[tdevice] != null)
+                                                propValue = App.rootHub.DS4Controllers[tdevice].HidDevice.DevicePath;
+                                            else if (propName == "macaddress" && App.rootHub.DS4Controllers[tdevice] != null)
+                                                propValue = App.rootHub.DS4Controllers[tdevice].MacAddress;
+                                            else if (propName == "displayname" && App.rootHub.DS4Controllers[tdevice] != null)
+                                                propValue = App.rootHub.DS4Controllers[tdevice].DisplayName;
+                                            else if (propName == "conntype" && App.rootHub.DS4Controllers[tdevice] != null)
+                                                propValue = App.rootHub.DS4Controllers[tdevice].ConnectionType.ToString();
+                                            else if (propName == "exclusivestatus" && App.rootHub.DS4Controllers[tdevice] != null)
+                                                propValue = App.rootHub.DS4Controllers[tdevice].CurrentExclusiveStatus.ToString();
+                                            else if (propName == "battery" && App.rootHub.DS4Controllers[tdevice] != null)
+                                                propValue = App.rootHub.DS4Controllers[tdevice].Battery.ToString();
+                                            else if (propName == "charging" && App.rootHub.DS4Controllers[tdevice] != null)
+                                                propValue = App.rootHub.DS4Controllers[tdevice].Charging.ToString();
 
-                                        else if (propName == "apprunning")
-                                            propValue = App.rootHub.running.ToString(); // Controller idx value is ignored, but it still needs to be in 1..4 range in a cmdline call
+                                            else if (propName == "apprunning")
+                                                propValue = App.rootHub.running.ToString(); // Controller idx value is ignored, but it still needs to be in 1..4 range in a cmdline call
                                     }
 
                                     // Write out the property value to MMF result data file and notify a client process that the data is available

--- a/DS4Windows/DS4Library/DS4Device.cs
+++ b/DS4Windows/DS4Library/DS4Device.cs
@@ -1639,7 +1639,7 @@ namespace DS4Windows
             {
                 if (testRumble.RumbleMotorsExplicitlyOff)
                     rumbleAutostopTimer.Reset();   // Stop an autostop timer because ViGem driver sent properly a zero rumble notification
-                else
+                else if (currentHap.RumbleMotorStrengthLeftHeavySlow != leftHeavySlowMotor || currentHap.RumbleMotorStrengthRightLightFast != rightLightFastMotor)
                     rumbleAutostopTimer.Restart(); // Start an autostop timer to stop potentially stuck rumble motor because of lost rumble notification events from ViGem driver
             }
         }


### PR DESCRIPTION
Re-enabled rumble in dualshock4 mode. Made it possible to let user to decide (profile settings) if a game can control the rumble and the lightbar. Rumble=0% profile setting is used to disable rumble. A game can control Lightbar only when lightbar mode is Passthru (by default DS4Windows controls the light). Additionally if user doesn't want to use rumble and lighbar ViGem feedback servies at all then unticking "Enable data output to DS4" option disables Vigem feedback handler. So, now user can decide via profile settings if she or he wants to use rumble or lightbar in DS4 or XBox360 mode.

Many users have reported an issue ticket and asking why rumble doesn' work in ds4 output mode. Now it works by default, but also there is possibility to disable Vigem feedback events or ligthbar and/or rumble via profile settings. If a game causes issues with rumble or lightbar then user can create a game specific profile to disable those.

