### PR TITLE
Support Brook Mars controller

### DIFF
--- a/DS4Windows/DS4Library/DS4Devices.cs
+++ b/DS4Windows/DS4Library/DS4Devices.cs
@@ -129,6 +129,7 @@ namespace DS4Windows
             new VidPidInfo(0x7545, 0x0104, "Armor 3 LU Cobra"), // Armor 3 Level Up Cobra
             new VidPidInfo(0x2E95, 0x7725, "Scuf Vantage"), // Scuf Vantage gamepad
             new VidPidInfo(0x11C0, 0x4001, "PS4 Fun"), // PS4 Fun Controller
+            new VidPidInfo(0x0C12, 0x0E20, "Brook Mars Controller"), // Brook Mars controller (wired) with DS4 mode
             new VidPidInfo(RAZER_VID, 0x1007, "Razer Raiju TE"), // Razer Raiju Tournament Edition (wired)
             new VidPidInfo(RAZER_VID, 0x100A, "Razer Raiju TE BT", InputDeviceType.DS4, VidPidFeatureSet.OnlyInputData0x01 | VidPidFeatureSet.OnlyOutputData0x05 | VidPidFeatureSet.NoBatteryReading | VidPidFeatureSet.NoGyroCalib), // Razer Raiju Tournament Edition (BT). Incoming report data is in "ds4 USB format" (32 bytes) in BT. Also, WriteOutput uses "usb" data packet type in BT.
             new VidPidInfo(RAZER_VID, 0x1004, "Razer Raiju UE USB"), // Razer Raiju Ultimate Edition (wired)


### PR DESCRIPTION
Hi this adds support for Brook Mars universal controller when connected in DualShock4 mode. They are fully compatible with the DualShock 4, but it has a different PID and VID.

I have already checked it works. To check this with other users, need to update the controller firmware to 17 beta 2 (by renaming the firmware installer to "MarsWiredController_Online_BETA2.exe"), connect controller with hold down the B button (Y on Xbox layout) and the controller will connect in DualShock 4 compatible mode.

Thanks.

https://github.com/Ryochan7/DS4Windows/issues/1625