### PR TITLE
Fix out-of-bounds access when enabling square stick

### DIFF
--- a/DS4Windows/DS4Control/Mapping.cs
+++ b/DS4Windows/DS4Control/Mapping.cs
@@ -161,10 +161,11 @@ namespace DS4Windows
             }
         }
 
-        private static DS4SquareStick[] outSqrStk = new DS4SquareStick[Global.MAX_DS4_CONTROLLER_COUNT]
+        private static DS4SquareStick[] outSqrStk = new DS4SquareStick[Global.TEST_PROFILE_ITEM_COUNT]
         {
             new DS4SquareStick(), new DS4SquareStick(), new DS4SquareStick(), new DS4SquareStick(),
             new DS4SquareStick(), new DS4SquareStick(), new DS4SquareStick(), new DS4SquareStick(),
+            new DS4SquareStick(),
         };
 
         public static byte[] gyroStickX = new byte[Global.MAX_DS4_CONTROLLER_COUNT] { 128, 128, 128, 128, 128, 128, 128, 128 };


### PR DESCRIPTION
Having only just looked at the code, I'm not sure if this is the correct fix, or if it is, whether there are other arrays that should be +1 size, but this seems to fix the issue described in #1409.

For reference, I have only one profile, with default settings. When I open the profile, `ControllerReadingsControl.UseDevice` is called with arguments `(0, 8)` by `ProfileEditor.Reload` line 529:

```
                conReadingsUserCon.UseDevice(0, Global.TEST_PROFILE_INDEX);
```

When I go to the "Controller Readings" tab, check the LS "Square Stick" (I assume it also happens for RS) and move the stick, `Mapping.SetCurveAndDeadzone` is called and line 1037 does an out-of-bounds access because `device` equals 8:

```
                DS4SquareStick sqstick = outSqrStk[device];
```

This was called by `DS4Forms.ControllerReadingsControl.ControllerReadingTimer_Elapsed` at line 210, which passes an 8 because `profileDeviceNum` was set by the afforementioned call to `UseDevice`:

```
                    Mapping.SetCurveAndDeadzone(profileDeviceNum, baseState, interState);
```

The result of this is that the readings freeze up, the controller doesn't seem to work, and DS4Windows refuses to close.