### PR TITLE
Add square stick amount and process before sensitivity

### DIFF
--- a/DS4Windows/DS4Control/ProfilePropGroups.cs
+++ b/DS4Windows/DS4Control/ProfilePropGroups.cs
@@ -7,6 +7,8 @@ namespace DS4Windows
     {
         public bool lsMode;
         public bool rsMode;
+        public double lsAmount = 100.0;
+        public double rsAmount = 100.0;
         public double lsRoundness = 5.0;
         public double rsRoundness = 5.0;
     }

--- a/DS4Windows/DS4Control/ScpUtil.cs
+++ b/DS4Windows/DS4Control/ScpUtil.cs
@@ -2256,9 +2256,19 @@ namespace DS4Windows
             return (value < min) ? min : (value > max) ? max : value;
         }
 
+        public static byte Clamp(byte min, byte value, byte max)
+        {
+            return Math.Min(Math.Max(value, min), max);
+        }
+
         private static int ClampInt(int min, int value, int max)
         {
             return (value < min) ? min : (value > max) ? max : value;
+        }
+
+        public static double Lerp(double a, double b, double t)
+        {
+            return a * (1.0 - t) + b * t;
         }
     }
 
@@ -3101,6 +3111,9 @@ namespace DS4Windows
 
                 XmlNode xmlLsSquareStickMode = m_Xdoc.CreateNode(XmlNodeType.Element, "LSSquareStick", null); xmlLsSquareStickMode.InnerText = squStickInfo[device].lsMode.ToString(); rootElement.AppendChild(xmlLsSquareStickMode);
                 XmlNode xmlRsSquareStickMode = m_Xdoc.CreateNode(XmlNodeType.Element, "RSSquareStick", null); xmlRsSquareStickMode.InnerText = squStickInfo[device].rsMode.ToString(); rootElement.AppendChild(xmlRsSquareStickMode);
+
+                XmlNode xmlSquareStickAmount = m_Xdoc.CreateNode(XmlNodeType.Element, "SquareStickAmount", null); xmlSquareStickAmount.InnerText = squStickInfo[device].lsAmount.ToString(); rootElement.AppendChild(xmlSquareStickAmount);
+                XmlNode xmlSquareRStickAmount = m_Xdoc.CreateNode(XmlNodeType.Element, "SquareRStickAmount", null); xmlSquareRStickAmount.InnerText = squStickInfo[device].rsAmount.ToString(); rootElement.AppendChild(xmlSquareRStickAmount);
 
                 XmlNode xmlSquareStickRoundness = m_Xdoc.CreateNode(XmlNodeType.Element, "SquareStickRoundness", null); xmlSquareStickRoundness.InnerText = squStickInfo[device].lsRoundness.ToString(); rootElement.AppendChild(xmlSquareStickRoundness);
                 XmlNode xmlSquareRStickRoundness = m_Xdoc.CreateNode(XmlNodeType.Element, "SquareRStickRoundness", null); xmlSquareRStickRoundness.InnerText = squStickInfo[device].rsRoundness.ToString(); rootElement.AppendChild(xmlSquareRStickRoundness);
@@ -4420,6 +4433,11 @@ namespace DS4Windows
 
                 try { Item = m_Xdoc.SelectSingleNode("/" + rootname + "/LSSquareStick"); bool.TryParse(Item.InnerText, out squStickInfo[device].lsMode); }
                 catch { squStickInfo[device].lsMode = false; missingSetting = true; }
+
+                try { Item = m_Xdoc.SelectSingleNode("/" + rootname + "/SquareStickAmount"); double.TryParse(Item.InnerText, out squStickInfo[device].lsAmount); }
+                catch { squStickInfo[device].lsAmount = 100.0; missingSetting = true; }
+                try { Item = m_Xdoc.SelectSingleNode("/" + rootname + "/SquareRStickAmount"); double.TryParse(Item.InnerText, out squStickInfo[device].rsAmount); }
+                catch { squStickInfo[device].rsAmount = 100.0; missingSetting = true; }
 
                 try { Item = m_Xdoc.SelectSingleNode("/" + rootname + "/SquareStickRoundness"); double.TryParse(Item.InnerText, out squStickInfo[device].lsRoundness); }
                 catch { squStickInfo[device].lsRoundness = 5.0; missingSetting = true; }
@@ -5977,6 +5995,8 @@ namespace DS4Windows
             gyroMouseToggle[device] = false;
             squStickInfo[device].lsMode = false;
             squStickInfo[device].rsMode = false;
+            squStickInfo[device].lsAmount = 100.0;
+            squStickInfo[device].rsAmount = 100.0;
             squStickInfo[device].lsRoundness = 5.0;
             squStickInfo[device].rsRoundness = 5.0;
             setLsOutCurveMode(device, 0);

--- a/DS4Windows/DS4Forms/ProfileEditor.xaml
+++ b/DS4Windows/DS4Forms/ProfileEditor.xaml
@@ -319,6 +319,10 @@
                                             <Label Content="Square Stick:" Grid.Row="7" Grid.Column="0" />
                                             <StackPanel Orientation="Horizontal" Grid.Row="7" Grid.Column="1" HorizontalAlignment="Right">
                                                 <CheckBox IsChecked="{Binding LSSquareStick}" Margin="{StaticResource spaceMargin}" VerticalAlignment="Center" />
+                                                <xctk:DoubleUpDown d:IsHidden="True" FormatString="F1" Value="{Binding LSSquareAmount,FallbackValue=100}"
+                                                       MinWidth="60" Minimum="0.0" Maximum="100.0" Increment="1.0" IsEnabled="{Binding LSSquareStick}"
+                                                       Margin="{StaticResource spaceMargin}" />
+                                                <Label Content="%" />
                                                 <xctk:DoubleUpDown d:IsHidden="True" FormatString="F1" Value="{Binding LSSquareRoundness,FallbackValue=5}"
                                                        MinWidth="100" Minimum="0.0" Maximum="1000.0" Increment="1.0" IsEnabled="{Binding LSSquareStick}"
                                                        Margin="{StaticResource spaceMargin}" />
@@ -467,6 +471,10 @@
                                             <Label Content="Square Stick:" Grid.Row="7" Grid.Column="0" />
                                             <StackPanel Orientation="Horizontal" Grid.Row="7" Grid.Column="1" HorizontalAlignment="Right">
                                                 <CheckBox IsChecked="{Binding RSSquareStick}" Margin="{StaticResource spaceMargin}" VerticalAlignment="Center" />
+                                                <xctk:DoubleUpDown d:IsHidden="True" FormatString="F1" Value="{Binding RSSquareAmount,FallbackValue=100}"
+                                                       MinWidth="60" Minimum="0.0" Maximum="100.0" Increment="1.0" IsEnabled="{Binding RSSquareStick}"
+                                                       Margin="{StaticResource spaceMargin}" />
+                                                <Label Content="%" />
                                                 <xctk:DoubleUpDown d:IsHidden="True" FormatString="F1" Value="{Binding RSSquareRoundness,FallbackValue=5}"
                                                        MinWidth="100" Minimum="0.0" Maximum="1000.0" Increment="1.0" IsEnabled="{Binding RSSquareStick}"
                                                        Margin="{StaticResource spaceMargin}" />

--- a/DS4Windows/DS4Forms/ViewModels/ProfileSettingsViewModel.cs
+++ b/DS4Windows/DS4Forms/ViewModels/ProfileSettingsViewModel.cs
@@ -885,6 +885,18 @@ namespace DS4WinWPF.DS4Forms.ViewModels
             set => Global.SquStickInfo[device].rsMode = value;
         }
 
+        public double LSSquareAmount
+        {
+            get => Global.SquStickInfo[device].lsAmount;
+            set => Global.SquStickInfo[device].lsAmount = value;
+        }
+
+        public double RSSquareAmount
+        {
+            get => Global.SquStickInfo[device].rsAmount;
+            set => Global.SquStickInfo[device].rsAmount = value;
+        }
+
         public double LSSquareRoundness
         {
             get => Global.SquStickInfo[device].lsRoundness;


### PR DESCRIPTION
After looking at that bug, I looked into how the square stick worked, as it seemed to be behaving in unexpected ways. I've made a few changes:

- The square stick is now applied before the sensitivity. This allows you to change the sensitivity and still get sensible square stick behaviour.
- Added a square stick "amount", which globally blends between the circle and square mappings, rather than just adjusting the corner behaviour. This is another useful way to get a more "circular" stick behaviour while still reaching the corners (e.g. by lowering the amount to 50% and upping the sensitivity to 1.1).
- Simplified some of the code.

I hope my changes are clear. I may have made some incorrect assumptions. Feedback welcome.