### PR TITLE
AutoProfile EXE file extension check was case-sensitive. Changed the file extension logic to be case-insensitive.

### DIFF
--- a/DS4Windows/DS4Forms/ViewModels/AutoProfilesViewModel.cs
+++ b/DS4Windows/DS4Forms/ViewModels/AutoProfilesViewModel.cs
@@ -189,7 +189,7 @@ namespace DS4WinWPF.DS4Forms.ViewModels
         {
             foreach (string target in exepaths)
             {
-                bool skip = !File.Exists(target) || Path.GetExtension(target) != ".exe";
+                bool skip = !File.Exists(target) || Path.GetExtension(target).ToLower() != ".exe";
                 skip = skip || (skipsetupapps && (target.Contains("etup") || target.Contains("dotnet") || target.Contains("SETUP")
                     || target.Contains("edist") || target.Contains("nstall") || string.IsNullOrEmpty(target)));
                 skip = skip || (checkexisting && existingapps.Contains(target));

--- a/DS4Windows/DS4Forms/ViewModels/ProfileSettingsViewModel.cs
+++ b/DS4Windows/DS4Forms/ViewModels/ProfileSettingsViewModel.cs
@@ -562,7 +562,7 @@ namespace DS4WinWPF.DS4Forms.ViewModels
             {
                 ImageSource exeicon = null;
                 string path = Global.LaunchProgram[device];
-                if (File.Exists(path) && Path.GetExtension(path) == ".exe")
+                if (File.Exists(path) && Path.GetExtension(path).ToLower() == ".exe")
                 {
                     using (Icon ico = Icon.ExtractAssociatedIcon(path))
                     {
@@ -2444,14 +2444,14 @@ namespace DS4WinWPF.DS4Forms.ViewModels
                     {
                         using (RegistryKey browserPathCmdKey = Registry.ClassesRoot.OpenSubKey($"{progId}\\shell\\open\\command"))
                         {
-                            defaultBrowserCmd = browserPathCmdKey?.GetValue(null).ToString();
+                            defaultBrowserCmd = browserPathCmdKey?.GetValue(null).ToString().ToLower();
                         }
 
                         if (!String.IsNullOrEmpty(defaultBrowserCmd))
                         {
                             int iStartPos = (defaultBrowserCmd[0] == '"' ? 1 : 0);
                             defaultBrowserCmd = defaultBrowserCmd.Substring(iStartPos, defaultBrowserCmd.LastIndexOf(".exe") + 4 - iStartPos);
-                            if (Path.GetFileName(defaultBrowserCmd).ToLower() == "launchwinapp.exe")
+                            if (Path.GetFileName(defaultBrowserCmd) == "launchwinapp.exe")
                                 defaultBrowserCmd = String.Empty;
                         }
 

--- a/DS4Windows/DS4Forms/ViewModels/SpecialActions/LaunchProgramViewModel.cs
+++ b/DS4Windows/DS4Forms/ViewModels/SpecialActions/LaunchProgramViewModel.cs
@@ -40,7 +40,7 @@ namespace DS4WinWPF.DS4Forms.ViewModels.SpecialActions
             {
                 ImageSource exeicon = null;
                 string path = filepath;
-                if (File.Exists(path) && Path.GetExtension(path) == ".exe")
+                if (File.Exists(path) && Path.GetExtension(path).ToLower() == ".exe")
                 {
                     using (Icon ico = Icon.ExtractAssociatedIcon(path))
                     {


### PR DESCRIPTION
AutoProfile EXE file extension check was case-sensitive. Changed the extension logic to be case insensitive. Related to #1670