### PR TITLE
Supports .BAT/.CMD batch scripts in specAction "LaunchProgram" and a new "$hidden" argument modifier to keep the child process wnd hidden

### DIFF
--- a/DS4Windows/DS4Forms/SpecialActionEditor.xaml.cs
+++ b/DS4Windows/DS4Forms/SpecialActionEditor.xaml.cs
@@ -460,7 +460,7 @@ namespace DS4WinWPF.DS4Forms
             dialog.Multiselect = false;
             dialog.AddExtension = true;
             dialog.DefaultExt = ".exe";
-            dialog.Filter = "Exe (*.exe)|*.exe";
+            dialog.Filter = "Exe (*.exe)|*.exe|Batch (*.bat,*.cmd)|*.bat;*.cmd";
             dialog.Title = "Select Program";
 
             dialog.InitialDirectory = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);


### PR DESCRIPTION
Supports .BAT/.CMD batch scripts in specAction "LaunchProgram". Related to #1714 issue. 

Also added a new $hidden argument keyword to indicate that the child process wnd should be hidden (especially useful when launching BAT/CMD scripts and the cmd shell window should stay hidden).

![ds4Windows_LaunchBatchScriptInSpecAction](https://user-images.githubusercontent.com/35538525/103484045-5fd3b100-4df4-11eb-8dae-784394dad34d.png)
