### PR TITLE
tweak: add a 'understood' button for the deprecated warning

### DIFF
--- a/DS4Windows/DS4Forms/MainWindow.xaml.cs
+++ b/DS4Windows/DS4Forms/MainWindow.xaml.cs
@@ -1288,7 +1288,22 @@ Suspend support not enabled.", true);
         // Ex Mode Re-Enable
         private async void HideDS4ContCk_Click(object sender, RoutedEventArgs e)
         {
-            if (DS4Windows.Global.UseExclusiveMode == true) { MessageBox.Show("This feature is depreciated and no longer supported. Exclusive mode usage is provided mearly as a legacy feature. Do NOT ask for help for this feature, you will not recieve any.", "Feature no longer supported"); }
+            if (DS4Windows.Global.UseExclusiveMode == true && !Properties.Settings.Default.ContCk_Understood)
+            {
+                MessageBoxResult result = MessageBox.Show
+                (
+                    "This feature is deprecated and no longer supported. Exclusive mode usage is provided mearly as a legacy feature. Do NOT ask for help for this feature, you will not recieve any.\n\nDo you understand?",
+                    "Deprecation Warning",
+                    MessageBoxButton.YesNo,
+                    MessageBoxImage.Warning,
+                    MessageBoxResult.None
+                );
+
+                if (result != MessageBoxResult.Yes) return;
+
+                Properties.Settings.Default.ContCk_Understood = true;
+                Properties.Settings.Default.Save();
+            }
             StartStopBtn.IsEnabled = false;
             //bool checkStatus = hideDS4ContCk.IsChecked == true;
             hideDS4ContCk.IsEnabled = false;

--- a/DS4Windows/Properties/Settings.Designer.cs
+++ b/DS4Windows/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace DS4WinWPF.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.2.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.8.1.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -20,6 +20,18 @@ namespace DS4WinWPF.Properties {
         public static Settings Default {
             get {
                 return defaultInstance;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool ContCk_Understood {
+            get {
+                return ((bool)(this["ContCk_Understood"]));
+            }
+            set {
+                this["ContCk_Understood"] = value;
             }
         }
     }

--- a/DS4Windows/Properties/Settings.settings
+++ b/DS4Windows/Properties/Settings.settings
@@ -1,7 +1,9 @@
 ﻿<?xml version='1.0' encoding='utf-8'?>
-<SettingsFile xmlns="uri:settings" CurrentProfile="(Default)">
-  <Profiles>
-    <Profile Name="(Default)" />
-  </Profiles>
-  <Settings />
+<SettingsFile xmlns="http://schemas.microsoft.com/VisualStudio/2004/01/settings" CurrentProfile="(Default)" GeneratedClassNamespace="DS4WinWPF.Properties" GeneratedClassName="Settings">
+  <Profiles />
+  <Settings>
+    <Setting Name="ContCk_Understood" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+  </Settings>
 </SettingsFile>

--- a/DS4Windows/app.config
+++ b/DS4Windows/app.config
@@ -1,5 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
+    <configSections>
+        <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" >
+            <section name="DS4WinWPF.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
+        </sectionGroup>
+    </configSections>
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
     </startup>
@@ -9,4 +14,11 @@
       </assemblyBinding>
       <gcServer enabled="true"/>
     </runtime>
+    <userSettings>
+        <DS4WinWPF.Properties.Settings>
+            <setting name="ContCk_Understood" serializeAs="String">
+                <value>False</value>
+            </setting>
+        </DS4WinWPF.Properties.Settings>
+    </userSettings>
 </configuration>


### PR DESCRIPTION
it's a bit tedious having that prompt pop up each time we use it. yes, it's deprecated, but those who use it probably know why they're using it