### PR TITLE
feat: gyro calibration

### DIFF
--- a/DS4Windows/DS4Forms/ControllerReadingsControl.xaml
+++ b/DS4Windows/DS4Forms/ControllerReadingsControl.xaml
@@ -117,6 +117,7 @@
                     </Rectangle>
                     <Rectangle x:Name="sixAxisValRec" Width="6" Height="6" Canvas.Left="62" Canvas.Top="62" Fill="{DynamicResource ForegroundColor}">
                     </Rectangle>
+                    <Ellipse x:Name="gyroCalEllipse" Fill="#FF1FCF1F" Height="32" Canvas.Left="90" Canvas.Top="10" Width="32"/>
                 </Canvas>
                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
                     <StackPanel Orientation="Horizontal">

--- a/DS4Windows/DS4Forms/ControllerReadingsControl.xaml.cs
+++ b/DS4Windows/DS4Forms/ControllerReadingsControl.xaml.cs
@@ -197,6 +197,7 @@ namespace DS4WinWPF.DS4Forms
                 //DS4StateExposed tmpexposeState = Program.rootHub.ExposedState[deviceNum];
                 DS4State tmpbaseState = Program.rootHub.getDS4State(deviceNum);
                 DS4State tmpinterState = Program.rootHub.getDS4StateTemp(deviceNum);
+                long cntCalibrating = ds.SixAxis.CntCalibrating;
 
                 // Wait for controller to be in a wait period
                 ds.ReadWaitEv.Wait();
@@ -305,7 +306,7 @@ namespace DS4WinWPF.DS4Forms
                     prevWarnMode = warnMode;
 
                     batteryLvlLb.Content = $"{Translations.Strings.Battery}: {baseState.Battery}%";
-
+                    gyroCalEllipse.Visibility = cntCalibrating > 0 && ((cntCalibrating / 250) % 2 == 1) ? Visibility.Visible : Visibility.Hidden;
                     UpdateCoordLabels(baseState, interState, exposeState);
                 });
             }

--- a/DS4Windows/DS4Forms/ProfileEditor.xaml
+++ b/DS4Windows/DS4Forms/ProfileEditor.xaml
@@ -1069,6 +1069,10 @@
                                 </StackPanel>
                             </StackPanel>
                         </GroupBox>
+
+                        <StackPanel Orientation="Horizontal" Margin="0,8,0,8">
+                            <Button x:Name="gyroCalBtn" Content="Gyro Calibration" Width="100"  Click="GyroCalibration_Click" />
+                        </StackPanel>
                     </StackPanel>
 
                     <StackPanel x:Name="gyroMousePanel" Visibility="Collapsed" Margin="{StaticResource spaceMargin}">

--- a/DS4Windows/DS4Forms/ProfileEditor.xaml.cs
+++ b/DS4Windows/DS4Forms/ProfileEditor.xaml.cs
@@ -1368,6 +1368,16 @@ namespace DS4WinWPF.DS4Forms
         {
             ApplyProfileStep();
         }
+
+        private void GyroCalibration_Click(object sender, RoutedEventArgs e)
+        {
+            int deviceNum = profileSettingsVM.FuncDevNum;
+            if (deviceNum < ControlService.CURRENT_DS4_CONTROLLER_LIMIT)
+            {
+                DS4Device d = App.rootHub.DS4Controllers[deviceNum];
+                d.SixAxis.ResetContinuousCalibration();
+            }
+        }
     }
 
     public class ControlIndexCheck


### PR DESCRIPTION
Here is PR to solve gyro-drift.  
1. Run calibration at start automatically.
2. Add calibration button to do manually, and show the indicator on Readings tab.
3. Calibration takes 5 secs with the Gamepad should be left as is on the table.

The idea is from: https://github.com/Ryochan7/DS4Windows/issues/1289

![2021-01-18 (2)](https://user-images.githubusercontent.com/1750918/104877255-0c349c00-598c-11eb-8069-185bad450afc.png)

