### PR TITLE
Anti bouncy stick

### DIFF
--- a/DS4Windows/DS4Control/Mapping.cs
+++ b/DS4Windows/DS4Control/Mapping.cs
@@ -5450,8 +5450,7 @@ namespace DS4Windows
         {
             long timestamp = DateTimeOffset.Now.ToUnixTimeMilliseconds();
             ref Queue<DS4TimedStickAxisValue> queue = ref stickValueHistory[device][stickId];
-            queue.Enqueue(new DS4TimedStickAxisValue(axisXValue, axisYValue, timestamp));
-            while(queue.Peek().timestamp < timestamp - timeout)
+            while(queue.Count > 0 && queue.Peek().timestamp < timestamp - timeout)
             {
                 queue.Dequeue();
             }
@@ -5478,6 +5477,7 @@ namespace DS4Windows
                 useAxisX = axisXValue;
                 useAxisY = axisYValue;
             }
+            queue.Enqueue(new DS4TimedStickAxisValue(axisXValue, axisYValue, timestamp));
         }
     }
 }

--- a/DS4Windows/DS4Control/Mapping.cs
+++ b/DS4Windows/DS4Control/Mapping.cs
@@ -717,17 +717,17 @@ namespace DS4Windows
             if (rotationRS > 0.0 || rotationRS < 0.0)
                 cState.rotateRSCoordinates(rotationRS);
 
-            StickAntiBounceInfo lsAntiBounce = GetLSAntiBounceInfo(device);
-            StickAntiBounceInfo rsAntiBounce = GetRSAntiBounceInfo(device);
+            StickAntiSnapbackInfo lsAntiSnapback = GetLSAntiSnapbackInfo(device);
+            StickAntiSnapbackInfo rsAntiSnapback = GetRSAntiSnapbackInfo(device);
 
-            if (lsAntiBounce.enabled)
+            if (lsAntiSnapback.enabled)
             {
-                CalcBouncyStick(device, 0, lsAntiBounce.delta, lsAntiBounce.timeout, cState.LX, cState.LY, out cState.LX, out cState.LY);
+                CalcAntiSnapbackStick(device, 0, lsAntiSnapback.delta, lsAntiSnapback.timeout, cState.LX, cState.LY, out cState.LX, out cState.LY);
             }
 
-            if (rsAntiBounce.enabled)
+            if (rsAntiSnapback.enabled)
             {
-                CalcBouncyStick(device, 1, rsAntiBounce.delta, rsAntiBounce.timeout, cState.RX, cState.RY, out cState.RX, out cState.RY);
+                CalcAntiSnapbackStick(device, 1, rsAntiSnapback.delta, rsAntiSnapback.timeout, cState.RX, cState.RY, out cState.RX, out cState.RY);
             }
 
             StickDeadZoneInfo lsMod = GetLSDeadInfo(device);
@@ -5444,7 +5444,7 @@ namespace DS4Windows
             }
         }
 
-        private static void CalcBouncyStick(int device,
+        private static void CalcAntiSnapbackStick(int device,
             int stickId, double delta, long timeout, byte axisXValue, byte axisYValue,
             out byte useAxisX, out byte useAxisY)
         {

--- a/DS4Windows/DS4Control/Mapping.cs
+++ b/DS4Windows/DS4Control/Mapping.cs
@@ -5455,7 +5455,21 @@ namespace DS4Windows
             {
                 queue.Dequeue();
             }
-            if (queue.Any(oldValues => Math.Sqrt(Math.Pow(axisXValue - oldValues.x, 2) + Math.Pow(axisYValue - oldValues.y, 2)) >= delta))
+            if (queue.Any(oldValues => {
+                double distanceSquared = Math.Pow(axisXValue - oldValues.x, 2) + Math.Pow(axisYValue - oldValues.y, 2);
+                if (distanceSquared >= (delta * delta))
+                { 
+                    //Checks if the line between two points touches a 15 unit circle in the middle
+                    double t = ((128 - axisXValue) * (oldValues.x - axisXValue) + (128 - axisYValue) * (oldValues.y - axisYValue)) / distanceSquared;
+                    t = Math.Max(0, Math.Min(1, t));
+                    double distanceToMiddleSquared = Math.Pow(128 - (axisXValue + t * (oldValues.x - axisXValue)), 2) + Math.Pow(128 - (axisYValue + t * (oldValues.y - axisYValue)), 2);
+                    return distanceToMiddleSquared <= 15 * 15;
+                }
+                else
+                {
+                    return false;
+                }
+            }))
             {
                 useAxisX = useAxisY = 128;
             }

--- a/DS4Windows/DS4Control/Mapping.cs
+++ b/DS4Windows/DS4Control/Mapping.cs
@@ -174,12 +174,13 @@ namespace DS4Windows
         public static byte[] gyroStickY = new byte[Global.MAX_DS4_CONTROLLER_COUNT] { 128, 128, 128, 128, 128, 128, 128, 128 };
 
         // [<Device>][<AxisId>]. LX = 0, LY = 1, RX = 2, RY = 3
-        public static byte[][] lastStickAxisValues = new byte[Global.MAX_DS4_CONTROLLER_COUNT][]
+        public static byte[][] lastStickAxisValues = new byte[Global.TEST_PROFILE_ITEM_COUNT][]
         {
             new byte[4] {128, 128, 128, 128}, new byte[4] {128, 128, 128, 128},
             new byte[4] {128, 128, 128, 128}, new byte[4] {128, 128, 128, 128},
             new byte[4] {128, 128, 128, 128}, new byte[4] {128, 128, 128, 128},
             new byte[4] {128, 128, 128, 128}, new byte[4] {128, 128, 128, 128},
+            new byte[4] {128, 128, 128, 128}
         };
 
         private class LastWheelGyroCoord

--- a/DS4Windows/DS4Control/ProfilePropGroups.cs
+++ b/DS4Windows/DS4Control/ProfilePropGroups.cs
@@ -24,6 +24,17 @@ namespace DS4Windows
         public int fuzz = DEFAULT_FUZZ;
     }
 
+    public class StickAntiBounceInfo
+    {
+        public const double DEFAULT_DELTA = 135;
+        public const int DEFAULT_TIMEOUT = 50;
+        public const bool DEFAULT_ENABLED = false;
+
+        public bool enabled = DEFAULT_ENABLED;
+        public double delta = DEFAULT_DELTA;
+        public int timeout = DEFAULT_TIMEOUT;
+    }
+
     public class TriggerDeadZoneZInfo
     {
         public byte deadZone; // Trigger deadzone is expressed in axis units

--- a/DS4Windows/DS4Control/ProfilePropGroups.cs
+++ b/DS4Windows/DS4Control/ProfilePropGroups.cs
@@ -24,7 +24,7 @@ namespace DS4Windows
         public int fuzz = DEFAULT_FUZZ;
     }
 
-    public class StickAntiBounceInfo
+    public class StickAntiSnapbackInfo
     {
         public const double DEFAULT_DELTA = 135;
         public const int DEFAULT_TIMEOUT = 50;

--- a/DS4Windows/DS4Control/ScpUtil.cs
+++ b/DS4Windows/DS4Control/ScpUtil.cs
@@ -1923,6 +1923,18 @@ namespace DS4Windows
             return m_Config.squStickInfo[device];
         }
 
+        public static StickAntiBounceInfo[] LSAntiBounceInfo => m_Config.lsAntiBounceInfo;
+        public static StickAntiBounceInfo GetLSAntiBounceInfo(int device)
+        {
+            return m_Config.lsAntiBounceInfo[device];
+        }
+
+        public static StickAntiBounceInfo[] RSAntiBounceInfo => m_Config.rsAntiBounceInfo;
+        public static StickAntiBounceInfo GetRSAntiBounceInfo(int device)
+        {
+            return m_Config.rsAntiBounceInfo[device];
+        }
+
         public static StickOutputSetting[] LSOutputSettings => m_Config.lsOutputSettings;
         public static StickOutputSetting[] RSOutputSettings => m_Config.rsOutputSettings;
 
@@ -2509,6 +2521,24 @@ namespace DS4Windows
             new SquareStickInfo(), new SquareStickInfo(),
             new SquareStickInfo(), new SquareStickInfo(),
             new SquareStickInfo(),
+        };
+
+        public StickAntiBounceInfo[] lsAntiBounceInfo = new StickAntiBounceInfo[Global.TEST_PROFILE_ITEM_COUNT]
+        {
+            new StickAntiBounceInfo(), new StickAntiBounceInfo(),
+            new StickAntiBounceInfo(), new StickAntiBounceInfo(),
+            new StickAntiBounceInfo(), new StickAntiBounceInfo(),
+            new StickAntiBounceInfo(), new StickAntiBounceInfo(),
+            new StickAntiBounceInfo(),
+        };
+
+        public StickAntiBounceInfo[] rsAntiBounceInfo = new StickAntiBounceInfo[Global.TEST_PROFILE_ITEM_COUNT]
+        {
+            new StickAntiBounceInfo(), new StickAntiBounceInfo(),
+            new StickAntiBounceInfo(), new StickAntiBounceInfo(),
+            new StickAntiBounceInfo(), new StickAntiBounceInfo(),
+            new StickAntiBounceInfo(), new StickAntiBounceInfo(),
+            new StickAntiBounceInfo(),
         };
 
         public StickOutputSetting[] lsOutputSettings = new StickOutputSetting[Global.TEST_PROFILE_ITEM_COUNT]
@@ -3320,6 +3350,15 @@ namespace DS4Windows
 
                 XmlNode xmlSquareStickRoundness = m_Xdoc.CreateNode(XmlNodeType.Element, "SquareStickRoundness", null); xmlSquareStickRoundness.InnerText = squStickInfo[device].lsRoundness.ToString(); rootElement.AppendChild(xmlSquareStickRoundness);
                 XmlNode xmlSquareRStickRoundness = m_Xdoc.CreateNode(XmlNodeType.Element, "SquareRStickRoundness", null); xmlSquareRStickRoundness.InnerText = squStickInfo[device].rsRoundness.ToString(); rootElement.AppendChild(xmlSquareRStickRoundness);
+
+                XmlNode xmlLsAntiBounceEnabled = m_Xdoc.CreateNode(XmlNodeType.Element, "LSAntiBounce", null); xmlLsAntiBounceEnabled.InnerText = lsAntiBounceInfo[device].enabled.ToString(); rootElement.AppendChild(xmlLsAntiBounceEnabled);
+                XmlNode xmlRsAntiBounceEnabled = m_Xdoc.CreateNode(XmlNodeType.Element, "RSAntiBounce", null); xmlRsAntiBounceEnabled.InnerText = rsAntiBounceInfo[device].enabled.ToString(); rootElement.AppendChild(xmlRsAntiBounceEnabled);
+
+                XmlNode xmlLsAntiBounceDelta = m_Xdoc.CreateNode(XmlNodeType.Element, "LSAntiBounceDelta", null); xmlLsAntiBounceDelta.InnerText = lsAntiBounceInfo[device].delta.ToString(); rootElement.AppendChild(xmlLsAntiBounceDelta);
+                XmlNode xmlRsAntiBounceDelta = m_Xdoc.CreateNode(XmlNodeType.Element, "RSAntiBounceDelta", null); xmlRsAntiBounceDelta.InnerText = rsAntiBounceInfo[device].delta.ToString(); rootElement.AppendChild(xmlRsAntiBounceDelta);
+
+                XmlNode xmlLsAntiBounceTimeout = m_Xdoc.CreateNode(XmlNodeType.Element, "LSAntiBounceTimeout", null); xmlLsAntiBounceTimeout.InnerText = lsAntiBounceInfo[device].timeout.ToString(); rootElement.AppendChild(xmlLsAntiBounceTimeout);
+                XmlNode xmlRsAntiBounceTimeout = m_Xdoc.CreateNode(XmlNodeType.Element, "RSAntiBounceTimeout", null); xmlRsAntiBounceTimeout.InnerText = rsAntiBounceInfo[device].timeout.ToString(); rootElement.AppendChild(xmlRsAntiBounceTimeout);
 
                 XmlNode xmlLsOutputMode = m_Xdoc.CreateNode(XmlNodeType.Element, "LSOutputMode", null); xmlLsOutputMode.InnerText = lsOutputSettings[device].mode.ToString(); rootElement.AppendChild(xmlLsOutputMode);
                 XmlNode xmlRsOutputMode = m_Xdoc.CreateNode(XmlNodeType.Element, "RSOutputMode", null); xmlRsOutputMode.InnerText = rsOutputSettings[device].mode.ToString(); rootElement.AppendChild(xmlRsOutputMode);
@@ -4780,6 +4819,22 @@ namespace DS4Windows
 
                 try { Item = m_Xdoc.SelectSingleNode("/" + rootname + "/RSSquareStick"); bool.TryParse(Item.InnerText, out squStickInfo[device].rsMode); }
                 catch { squStickInfo[device].rsMode = false; missingSetting = true; }
+
+
+                try { Item = m_Xdoc.SelectSingleNode("/" + rootname + "/LSAntiBounce"); bool.TryParse(Item.InnerText, out lsAntiBounceInfo[device].enabled); }
+                catch { lsAntiBounceInfo[device].enabled = StickAntiBounceInfo.DEFAULT_ENABLED; missingSetting = true; }
+                try { Item = m_Xdoc.SelectSingleNode("/" + rootname + "/RSAntiBounce"); bool.TryParse(Item.InnerText, out rsAntiBounceInfo[device].enabled); }
+                catch { rsAntiBounceInfo[device].enabled = StickAntiBounceInfo.DEFAULT_ENABLED; missingSetting = true; }
+
+                try { Item = m_Xdoc.SelectSingleNode("/" + rootname + "/LSAntiBounceDelta"); double.TryParse(Item.InnerText, out lsAntiBounceInfo[device].delta); }
+                catch { lsAntiBounceInfo[device].delta = StickAntiBounceInfo.DEFAULT_DELTA; missingSetting = true; }
+                try { Item = m_Xdoc.SelectSingleNode("/" + rootname + "/RSAntiBounceDelta"); double.TryParse(Item.InnerText, out rsAntiBounceInfo[device].delta); }
+                catch { rsAntiBounceInfo[device].delta = StickAntiBounceInfo.DEFAULT_DELTA; missingSetting = true; }
+
+                try { Item = m_Xdoc.SelectSingleNode("/" + rootname + "/LSAntiBounceTimeout"); int.TryParse(Item.InnerText, out lsAntiBounceInfo[device].timeout); }
+                catch { lsAntiBounceInfo[device].timeout = StickAntiBounceInfo.DEFAULT_TIMEOUT; missingSetting = true; }
+                try { Item = m_Xdoc.SelectSingleNode("/" + rootname + "/RSAntiBounceTimeout"); int.TryParse(Item.InnerText, out rsAntiBounceInfo[device].timeout); }
+                catch { rsAntiBounceInfo[device].timeout = StickAntiBounceInfo.DEFAULT_TIMEOUT; missingSetting = true; }
 
                 try { Item = m_Xdoc.SelectSingleNode("/" + rootname + "/LSOutputMode"); Enum.TryParse(Item.InnerText, out lsOutputSettings[device].mode); }
                 catch { missingSetting = true; }
@@ -6553,6 +6608,9 @@ namespace DS4Windows
             squStickInfo[device].rsMode = false;
             squStickInfo[device].lsRoundness = 5.0;
             squStickInfo[device].rsRoundness = 5.0;
+            lsAntiBounceInfo[device].timeout = StickAntiBounceInfo.DEFAULT_TIMEOUT;
+            lsAntiBounceInfo[device].delta = StickAntiBounceInfo.DEFAULT_DELTA;
+            lsAntiBounceInfo[device].enabled = StickAntiBounceInfo.DEFAULT_ENABLED;
             setLsOutCurveMode(device, 0);
             setRsOutCurveMode(device, 0);
             setL2OutCurveMode(device, 0);

--- a/DS4Windows/DS4Control/ScpUtil.cs
+++ b/DS4Windows/DS4Control/ScpUtil.cs
@@ -1923,16 +1923,16 @@ namespace DS4Windows
             return m_Config.squStickInfo[device];
         }
 
-        public static StickAntiBounceInfo[] LSAntiBounceInfo => m_Config.lsAntiBounceInfo;
-        public static StickAntiBounceInfo GetLSAntiBounceInfo(int device)
+        public static StickAntiSnapbackInfo[] LSAntiSnapbackInfo => m_Config.lsAntiSnapbackInfo;
+        public static StickAntiSnapbackInfo GetLSAntiSnapbackInfo(int device)
         {
-            return m_Config.lsAntiBounceInfo[device];
+            return m_Config.lsAntiSnapbackInfo[device];
         }
 
-        public static StickAntiBounceInfo[] RSAntiBounceInfo => m_Config.rsAntiBounceInfo;
-        public static StickAntiBounceInfo GetRSAntiBounceInfo(int device)
+        public static StickAntiSnapbackInfo[] RSAntiSnapbackInfo => m_Config.rsAntiSnapbackInfo;
+        public static StickAntiSnapbackInfo GetRSAntiSnapbackInfo(int device)
         {
-            return m_Config.rsAntiBounceInfo[device];
+            return m_Config.rsAntiSnapbackInfo[device];
         }
 
         public static StickOutputSetting[] LSOutputSettings => m_Config.lsOutputSettings;
@@ -2523,22 +2523,22 @@ namespace DS4Windows
             new SquareStickInfo(),
         };
 
-        public StickAntiBounceInfo[] lsAntiBounceInfo = new StickAntiBounceInfo[Global.TEST_PROFILE_ITEM_COUNT]
+        public StickAntiSnapbackInfo[] lsAntiSnapbackInfo = new StickAntiSnapbackInfo[Global.TEST_PROFILE_ITEM_COUNT]
         {
-            new StickAntiBounceInfo(), new StickAntiBounceInfo(),
-            new StickAntiBounceInfo(), new StickAntiBounceInfo(),
-            new StickAntiBounceInfo(), new StickAntiBounceInfo(),
-            new StickAntiBounceInfo(), new StickAntiBounceInfo(),
-            new StickAntiBounceInfo(),
+            new StickAntiSnapbackInfo(), new StickAntiSnapbackInfo(),
+            new StickAntiSnapbackInfo(), new StickAntiSnapbackInfo(),
+            new StickAntiSnapbackInfo(), new StickAntiSnapbackInfo(),
+            new StickAntiSnapbackInfo(), new StickAntiSnapbackInfo(),
+            new StickAntiSnapbackInfo(),
         };
 
-        public StickAntiBounceInfo[] rsAntiBounceInfo = new StickAntiBounceInfo[Global.TEST_PROFILE_ITEM_COUNT]
+        public StickAntiSnapbackInfo[] rsAntiSnapbackInfo = new StickAntiSnapbackInfo[Global.TEST_PROFILE_ITEM_COUNT]
         {
-            new StickAntiBounceInfo(), new StickAntiBounceInfo(),
-            new StickAntiBounceInfo(), new StickAntiBounceInfo(),
-            new StickAntiBounceInfo(), new StickAntiBounceInfo(),
-            new StickAntiBounceInfo(), new StickAntiBounceInfo(),
-            new StickAntiBounceInfo(),
+            new StickAntiSnapbackInfo(), new StickAntiSnapbackInfo(),
+            new StickAntiSnapbackInfo(), new StickAntiSnapbackInfo(),
+            new StickAntiSnapbackInfo(), new StickAntiSnapbackInfo(),
+            new StickAntiSnapbackInfo(), new StickAntiSnapbackInfo(),
+            new StickAntiSnapbackInfo(),
         };
 
         public StickOutputSetting[] lsOutputSettings = new StickOutputSetting[Global.TEST_PROFILE_ITEM_COUNT]
@@ -3351,14 +3351,14 @@ namespace DS4Windows
                 XmlNode xmlSquareStickRoundness = m_Xdoc.CreateNode(XmlNodeType.Element, "SquareStickRoundness", null); xmlSquareStickRoundness.InnerText = squStickInfo[device].lsRoundness.ToString(); rootElement.AppendChild(xmlSquareStickRoundness);
                 XmlNode xmlSquareRStickRoundness = m_Xdoc.CreateNode(XmlNodeType.Element, "SquareRStickRoundness", null); xmlSquareRStickRoundness.InnerText = squStickInfo[device].rsRoundness.ToString(); rootElement.AppendChild(xmlSquareRStickRoundness);
 
-                XmlNode xmlLsAntiBounceEnabled = m_Xdoc.CreateNode(XmlNodeType.Element, "LSAntiBounce", null); xmlLsAntiBounceEnabled.InnerText = lsAntiBounceInfo[device].enabled.ToString(); rootElement.AppendChild(xmlLsAntiBounceEnabled);
-                XmlNode xmlRsAntiBounceEnabled = m_Xdoc.CreateNode(XmlNodeType.Element, "RSAntiBounce", null); xmlRsAntiBounceEnabled.InnerText = rsAntiBounceInfo[device].enabled.ToString(); rootElement.AppendChild(xmlRsAntiBounceEnabled);
+                XmlNode xmlLsAntiSnapbackEnabled = m_Xdoc.CreateNode(XmlNodeType.Element, "LSAntiSnapback", null); xmlLsAntiSnapbackEnabled.InnerText = lsAntiSnapbackInfo[device].enabled.ToString(); rootElement.AppendChild(xmlLsAntiSnapbackEnabled);
+                XmlNode xmlRsAntiSnapbackEnabled = m_Xdoc.CreateNode(XmlNodeType.Element, "RSAntiSnapback", null); xmlRsAntiSnapbackEnabled.InnerText = rsAntiSnapbackInfo[device].enabled.ToString(); rootElement.AppendChild(xmlRsAntiSnapbackEnabled);
 
-                XmlNode xmlLsAntiBounceDelta = m_Xdoc.CreateNode(XmlNodeType.Element, "LSAntiBounceDelta", null); xmlLsAntiBounceDelta.InnerText = lsAntiBounceInfo[device].delta.ToString(); rootElement.AppendChild(xmlLsAntiBounceDelta);
-                XmlNode xmlRsAntiBounceDelta = m_Xdoc.CreateNode(XmlNodeType.Element, "RSAntiBounceDelta", null); xmlRsAntiBounceDelta.InnerText = rsAntiBounceInfo[device].delta.ToString(); rootElement.AppendChild(xmlRsAntiBounceDelta);
+                XmlNode xmlLsAntiSnapbackDelta = m_Xdoc.CreateNode(XmlNodeType.Element, "LSAntiSnapbackDelta", null); xmlLsAntiSnapbackDelta.InnerText = lsAntiSnapbackInfo[device].delta.ToString(); rootElement.AppendChild(xmlLsAntiSnapbackDelta);
+                XmlNode xmlRsAntiSnapbackDelta = m_Xdoc.CreateNode(XmlNodeType.Element, "RSAntiSnapbackDelta", null); xmlRsAntiSnapbackDelta.InnerText = rsAntiSnapbackInfo[device].delta.ToString(); rootElement.AppendChild(xmlRsAntiSnapbackDelta);
 
-                XmlNode xmlLsAntiBounceTimeout = m_Xdoc.CreateNode(XmlNodeType.Element, "LSAntiBounceTimeout", null); xmlLsAntiBounceTimeout.InnerText = lsAntiBounceInfo[device].timeout.ToString(); rootElement.AppendChild(xmlLsAntiBounceTimeout);
-                XmlNode xmlRsAntiBounceTimeout = m_Xdoc.CreateNode(XmlNodeType.Element, "RSAntiBounceTimeout", null); xmlRsAntiBounceTimeout.InnerText = rsAntiBounceInfo[device].timeout.ToString(); rootElement.AppendChild(xmlRsAntiBounceTimeout);
+                XmlNode xmlLsAntiSnapbackTimeout = m_Xdoc.CreateNode(XmlNodeType.Element, "LSAntiSnapbackTimeout", null); xmlLsAntiSnapbackTimeout.InnerText = lsAntiSnapbackInfo[device].timeout.ToString(); rootElement.AppendChild(xmlLsAntiSnapbackTimeout);
+                XmlNode xmlRsAntiSnapbackTimeout = m_Xdoc.CreateNode(XmlNodeType.Element, "RSAntiSnapbackTimeout", null); xmlRsAntiSnapbackTimeout.InnerText = rsAntiSnapbackInfo[device].timeout.ToString(); rootElement.AppendChild(xmlRsAntiSnapbackTimeout);
 
                 XmlNode xmlLsOutputMode = m_Xdoc.CreateNode(XmlNodeType.Element, "LSOutputMode", null); xmlLsOutputMode.InnerText = lsOutputSettings[device].mode.ToString(); rootElement.AppendChild(xmlLsOutputMode);
                 XmlNode xmlRsOutputMode = m_Xdoc.CreateNode(XmlNodeType.Element, "RSOutputMode", null); xmlRsOutputMode.InnerText = rsOutputSettings[device].mode.ToString(); rootElement.AppendChild(xmlRsOutputMode);
@@ -4821,20 +4821,20 @@ namespace DS4Windows
                 catch { squStickInfo[device].rsMode = false; missingSetting = true; }
 
 
-                try { Item = m_Xdoc.SelectSingleNode("/" + rootname + "/LSAntiBounce"); bool.TryParse(Item.InnerText, out lsAntiBounceInfo[device].enabled); }
-                catch { lsAntiBounceInfo[device].enabled = StickAntiBounceInfo.DEFAULT_ENABLED; missingSetting = true; }
-                try { Item = m_Xdoc.SelectSingleNode("/" + rootname + "/RSAntiBounce"); bool.TryParse(Item.InnerText, out rsAntiBounceInfo[device].enabled); }
-                catch { rsAntiBounceInfo[device].enabled = StickAntiBounceInfo.DEFAULT_ENABLED; missingSetting = true; }
+                try { Item = m_Xdoc.SelectSingleNode("/" + rootname + "/LSAntiSnapback"); bool.TryParse(Item.InnerText, out lsAntiSnapbackInfo[device].enabled); }
+                catch { lsAntiSnapbackInfo[device].enabled = StickAntiSnapbackInfo.DEFAULT_ENABLED; missingSetting = true; }
+                try { Item = m_Xdoc.SelectSingleNode("/" + rootname + "/RSAntiSnapback"); bool.TryParse(Item.InnerText, out rsAntiSnapbackInfo[device].enabled); }
+                catch { rsAntiSnapbackInfo[device].enabled = StickAntiSnapbackInfo.DEFAULT_ENABLED; missingSetting = true; }
 
-                try { Item = m_Xdoc.SelectSingleNode("/" + rootname + "/LSAntiBounceDelta"); double.TryParse(Item.InnerText, out lsAntiBounceInfo[device].delta); }
-                catch { lsAntiBounceInfo[device].delta = StickAntiBounceInfo.DEFAULT_DELTA; missingSetting = true; }
-                try { Item = m_Xdoc.SelectSingleNode("/" + rootname + "/RSAntiBounceDelta"); double.TryParse(Item.InnerText, out rsAntiBounceInfo[device].delta); }
-                catch { rsAntiBounceInfo[device].delta = StickAntiBounceInfo.DEFAULT_DELTA; missingSetting = true; }
+                try { Item = m_Xdoc.SelectSingleNode("/" + rootname + "/LSAntiSnapbackDelta"); double.TryParse(Item.InnerText, out lsAntiSnapbackInfo[device].delta); }
+                catch { lsAntiSnapbackInfo[device].delta = StickAntiSnapbackInfo.DEFAULT_DELTA; missingSetting = true; }
+                try { Item = m_Xdoc.SelectSingleNode("/" + rootname + "/RSAntiSnapbackDelta"); double.TryParse(Item.InnerText, out rsAntiSnapbackInfo[device].delta); }
+                catch { rsAntiSnapbackInfo[device].delta = StickAntiSnapbackInfo.DEFAULT_DELTA; missingSetting = true; }
 
-                try { Item = m_Xdoc.SelectSingleNode("/" + rootname + "/LSAntiBounceTimeout"); int.TryParse(Item.InnerText, out lsAntiBounceInfo[device].timeout); }
-                catch { lsAntiBounceInfo[device].timeout = StickAntiBounceInfo.DEFAULT_TIMEOUT; missingSetting = true; }
-                try { Item = m_Xdoc.SelectSingleNode("/" + rootname + "/RSAntiBounceTimeout"); int.TryParse(Item.InnerText, out rsAntiBounceInfo[device].timeout); }
-                catch { rsAntiBounceInfo[device].timeout = StickAntiBounceInfo.DEFAULT_TIMEOUT; missingSetting = true; }
+                try { Item = m_Xdoc.SelectSingleNode("/" + rootname + "/LSAntiSnapbackTimeout"); int.TryParse(Item.InnerText, out lsAntiSnapbackInfo[device].timeout); }
+                catch { lsAntiSnapbackInfo[device].timeout = StickAntiSnapbackInfo.DEFAULT_TIMEOUT; missingSetting = true; }
+                try { Item = m_Xdoc.SelectSingleNode("/" + rootname + "/RSAntiSnapbackTimeout"); int.TryParse(Item.InnerText, out rsAntiSnapbackInfo[device].timeout); }
+                catch { rsAntiSnapbackInfo[device].timeout = StickAntiSnapbackInfo.DEFAULT_TIMEOUT; missingSetting = true; }
 
                 try { Item = m_Xdoc.SelectSingleNode("/" + rootname + "/LSOutputMode"); Enum.TryParse(Item.InnerText, out lsOutputSettings[device].mode); }
                 catch { missingSetting = true; }
@@ -6608,9 +6608,9 @@ namespace DS4Windows
             squStickInfo[device].rsMode = false;
             squStickInfo[device].lsRoundness = 5.0;
             squStickInfo[device].rsRoundness = 5.0;
-            lsAntiBounceInfo[device].timeout = StickAntiBounceInfo.DEFAULT_TIMEOUT;
-            lsAntiBounceInfo[device].delta = StickAntiBounceInfo.DEFAULT_DELTA;
-            lsAntiBounceInfo[device].enabled = StickAntiBounceInfo.DEFAULT_ENABLED;
+            lsAntiSnapbackInfo[device].timeout = StickAntiSnapbackInfo.DEFAULT_TIMEOUT;
+            lsAntiSnapbackInfo[device].delta = StickAntiSnapbackInfo.DEFAULT_DELTA;
+            lsAntiSnapbackInfo[device].enabled = StickAntiSnapbackInfo.DEFAULT_ENABLED;
             setLsOutCurveMode(device, 0);
             setRsOutCurveMode(device, 0);
             setL2OutCurveMode(device, 0);

--- a/DS4Windows/DS4Forms/ProfileEditor.xaml
+++ b/DS4Windows/DS4Forms/ProfileEditor.xaml
@@ -275,7 +275,9 @@
                                                 <RowDefinition Style="{StaticResource gridRowHeight}" />
                                                 <RowDefinition Style="{StaticResource gridRowHeight}" />
                                                 <RowDefinition Style="{StaticResource gridRowHeight}" />
-                                                <RowDefinition Style="{StaticResource gridRowHeight}"/>
+                                                <RowDefinition Style="{StaticResource gridRowHeight}" />
+                                                <RowDefinition Style="{StaticResource gridRowHeight}" />
+                                                <RowDefinition Style="{StaticResource gridRowHeight}" />
                                                 <RowDefinition Style="{StaticResource gridRowHeight}" />
                                                 <RowDefinition Style="{StaticResource gridRowHeight}" />
                                                 <RowDefinition Style="{StaticResource gridRowHeight}" />
@@ -350,6 +352,23 @@
                                                     Minimum="0" Maximum="100"
                                                     Margin="{StaticResource spaceMargin}" />
                                             </DockPanel>
+                                            
+                                            <Label Content="Anti Bounce:" Grid.Row="11" Grid.Column="0" />
+                                            <StackPanel Orientation="Horizontal" Grid.Row="11" Grid.Column="1" HorizontalAlignment="Right">
+                                                <CheckBox IsChecked="{Binding LSAntiBounce}" Margin="{StaticResource spaceMargin}" VerticalAlignment="Center" />
+                                                <xctk:DoubleUpDown d:IsHidden="True" FormatString="F1" Value="{Binding LSAntiBounceDelta, FallbackValue=135}"
+                                                       MinWidth="100" Minimum="0.0" Maximum="256.0" Increment="1.0" IsEnabled="{Binding LSAntiBounce}"
+                                                       Margin="{StaticResource spaceMargin}" />
+                                                <TextBlock Text="units" DockPanel.Dock="Right" FontSize="10" Margin="{StaticResource spaceMargin}" VerticalAlignment="Center" />
+                                            </StackPanel>
+                                            
+                                            <Label Content="Anti Bounce:" Grid.Row="12" Grid.Column="0" />
+                                            <StackPanel Orientation="Horizontal" Grid.Row="12" Grid.Column="1" HorizontalAlignment="Right">
+                                                <xctk:IntegerUpDown d:IsHidden="True" FormatString="F1" Value="{Binding LSAntiBounceTimeout}"
+                                                       MinWidth="100" Minimum="0" Maximum="1000" Increment="1" IsEnabled="{Binding LSAntiBounce}"
+                                                       Margin="{StaticResource spaceMargin}" />
+                                                <TextBlock Text="ms" DockPanel.Dock="Right" FontSize="10" Margin="{StaticResource spaceMargin}" VerticalAlignment="Center" />
+                                            </StackPanel>
                                         </Grid>
                                     </TabItem>
                                     <TabItem Header="FlickStick" Visibility="Collapsed">
@@ -423,7 +442,9 @@
                                                 <RowDefinition Style="{StaticResource gridRowHeight}" />
                                                 <RowDefinition Style="{StaticResource gridRowHeight}" />
                                                 <RowDefinition Style="{StaticResource gridRowHeight}" />
-                                                <RowDefinition Style="{StaticResource gridRowHeight}"/>
+                                                <RowDefinition Style="{StaticResource gridRowHeight}" />
+                                                <RowDefinition Style="{StaticResource gridRowHeight}" />
+                                                <RowDefinition Style="{StaticResource gridRowHeight}" />
                                                 <RowDefinition Style="{StaticResource gridRowHeight}" />
                                                 <RowDefinition Style="{StaticResource gridRowHeight}" />
                                                 <RowDefinition Style="{StaticResource gridRowHeight}" />
@@ -498,6 +519,23 @@
                                                     Minimum="0" Maximum="100"
                                                     Margin="{StaticResource spaceMargin}" />
                                             </DockPanel>
+                                            
+                                            <Label Content="Anti Bounce:" Grid.Row="11" Grid.Column="0" />
+                                            <StackPanel Orientation="Horizontal" Grid.Row="11" Grid.Column="1" HorizontalAlignment="Right">
+                                                <CheckBox IsChecked="{Binding RSAntiBounce}" Margin="{StaticResource spaceMargin}" VerticalAlignment="Center" />
+                                                <xctk:DoubleUpDown d:IsHidden="True" FormatString="F1" Value="{Binding RSAntiBounceDelta, FallbackValue=135}"
+                                                       MinWidth="100" Minimum="0.0" Maximum="256.0" Increment="1.0" IsEnabled="{Binding LSAntiBounce}"
+                                                       Margin="{StaticResource spaceMargin}" />
+                                                <TextBlock Text="units" DockPanel.Dock="Right" FontSize="10" Margin="{StaticResource spaceMargin}" VerticalAlignment="Center" />
+                                            </StackPanel>
+
+                                            <Label Content="Anti Bounce:" Grid.Row="12" Grid.Column="0" />
+                                            <StackPanel Orientation="Horizontal" Grid.Row="12" Grid.Column="1" HorizontalAlignment="Right">
+                                                <xctk:IntegerUpDown d:IsHidden="True" FormatString="F1" Value="{Binding RSAntiBounceTimeout}"
+                                                       MinWidth="100" Minimum="0" Maximum="1000" Increment="1" IsEnabled="{Binding RSAntiBounce}"
+                                                       Margin="{StaticResource spaceMargin}" />
+                                                <TextBlock Text="ms" DockPanel.Dock="Right" FontSize="10" Margin="{StaticResource spaceMargin}" VerticalAlignment="Center" />
+                                            </StackPanel>
                                         </Grid>
                                     </TabItem>
                                     <TabItem Header="FlickStick" Visibility="Collapsed">

--- a/DS4Windows/DS4Forms/ProfileEditor.xaml
+++ b/DS4Windows/DS4Forms/ProfileEditor.xaml
@@ -353,19 +353,19 @@
                                                     Margin="{StaticResource spaceMargin}" />
                                             </DockPanel>
                                             
-                                            <Label Content="Anti Bounce:" Grid.Row="11" Grid.Column="0" />
+                                            <Label Content="Anti Snapback:" Grid.Row="11" Grid.Column="0" />
                                             <StackPanel Orientation="Horizontal" Grid.Row="11" Grid.Column="1" HorizontalAlignment="Right">
-                                                <CheckBox IsChecked="{Binding LSAntiBounce}" Margin="{StaticResource spaceMargin}" VerticalAlignment="Center" />
-                                                <xctk:DoubleUpDown d:IsHidden="True" FormatString="F1" Value="{Binding LSAntiBounceDelta, FallbackValue=135}"
-                                                       MinWidth="100" Minimum="0.0" Maximum="256.0" Increment="1.0" IsEnabled="{Binding LSAntiBounce}"
+                                                <CheckBox IsChecked="{Binding LSAntiSnapback}" Margin="{StaticResource spaceMargin}" VerticalAlignment="Center" />
+                                                <xctk:DoubleUpDown d:IsHidden="True" FormatString="F1" Value="{Binding LSAntiSnapbackDelta, FallbackValue=135}"
+                                                       MinWidth="100" Minimum="0.0" Maximum="256.0" Increment="1.0" IsEnabled="{Binding LSAntiSnapback}"
                                                        Margin="{StaticResource spaceMargin}" />
                                                 <TextBlock Text="units" DockPanel.Dock="Right" FontSize="10" Margin="{StaticResource spaceMargin}" VerticalAlignment="Center" />
                                             </StackPanel>
 
-                                            <Label Content="Anti Bounce timing:" Grid.Row="12" Grid.Column="0" />
+                                            <Label Content="Anti Snapback timing:" Grid.Row="12" Grid.Column="0" />
                                             <StackPanel Orientation="Horizontal" Grid.Row="12" Grid.Column="1" HorizontalAlignment="Right">
-                                                <xctk:IntegerUpDown d:IsHidden="True" FormatString="F1" Value="{Binding LSAntiBounceTimeout}"
-                                                       MinWidth="100" Minimum="0" Maximum="1000" Increment="1" IsEnabled="{Binding LSAntiBounce}"
+                                                <xctk:IntegerUpDown d:IsHidden="True" FormatString="F1" Value="{Binding LSAntiSnapbackTimeout}"
+                                                       MinWidth="100" Minimum="0" Maximum="1000" Increment="1" IsEnabled="{Binding LSAntiSnapback}"
                                                        Margin="{StaticResource spaceMargin}" />
                                                 <TextBlock Text="ms" DockPanel.Dock="Right" FontSize="10" Margin="{StaticResource spaceMargin}" VerticalAlignment="Center" />
                                             </StackPanel>
@@ -520,19 +520,19 @@
                                                     Margin="{StaticResource spaceMargin}" />
                                             </DockPanel>
                                             
-                                            <Label Content="Anti Bounce:" Grid.Row="11" Grid.Column="0" />
+                                            <Label Content="Anti Snapback:" Grid.Row="11" Grid.Column="0" />
                                             <StackPanel Orientation="Horizontal" Grid.Row="11" Grid.Column="1" HorizontalAlignment="Right">
-                                                <CheckBox IsChecked="{Binding RSAntiBounce}" Margin="{StaticResource spaceMargin}" VerticalAlignment="Center" />
-                                                <xctk:DoubleUpDown d:IsHidden="True" FormatString="F1" Value="{Binding RSAntiBounceDelta, FallbackValue=135}"
-                                                       MinWidth="100" Minimum="0.0" Maximum="256.0" Increment="1.0" IsEnabled="{Binding LSAntiBounce}"
+                                                <CheckBox IsChecked="{Binding RSAntiSnapback}" Margin="{StaticResource spaceMargin}" VerticalAlignment="Center" />
+                                                <xctk:DoubleUpDown d:IsHidden="True" FormatString="F1" Value="{Binding RSAntiSnapbackDelta, FallbackValue=135}"
+                                                       MinWidth="100" Minimum="0.0" Maximum="256.0" Increment="1.0" IsEnabled="{Binding LSAntiSnapback}"
                                                        Margin="{StaticResource spaceMargin}" />
                                                 <TextBlock Text="units" DockPanel.Dock="Right" FontSize="10" Margin="{StaticResource spaceMargin}" VerticalAlignment="Center" />
                                             </StackPanel>
 
-                                            <Label Content="Anti Bounce timing:" Grid.Row="12" Grid.Column="0" />
+                                            <Label Content="Anti Snapback timing:" Grid.Row="12" Grid.Column="0" />
                                             <StackPanel Orientation="Horizontal" Grid.Row="12" Grid.Column="1" HorizontalAlignment="Right">
-                                                <xctk:IntegerUpDown d:IsHidden="True" FormatString="F1" Value="{Binding RSAntiBounceTimeout}"
-                                                       MinWidth="100" Minimum="0" Maximum="1000" Increment="1" IsEnabled="{Binding RSAntiBounce}"
+                                                <xctk:IntegerUpDown d:IsHidden="True" FormatString="F1" Value="{Binding RSAntiSnapbackTimeout}"
+                                                       MinWidth="100" Minimum="0" Maximum="1000" Increment="1" IsEnabled="{Binding RSAntiSnapback}"
                                                        Margin="{StaticResource spaceMargin}" />
                                                 <TextBlock Text="ms" DockPanel.Dock="Right" FontSize="10" Margin="{StaticResource spaceMargin}" VerticalAlignment="Center" />
                                             </StackPanel>

--- a/DS4Windows/DS4Forms/ProfileEditor.xaml
+++ b/DS4Windows/DS4Forms/ProfileEditor.xaml
@@ -361,8 +361,8 @@
                                                        Margin="{StaticResource spaceMargin}" />
                                                 <TextBlock Text="units" DockPanel.Dock="Right" FontSize="10" Margin="{StaticResource spaceMargin}" VerticalAlignment="Center" />
                                             </StackPanel>
-                                            
-                                            <Label Content="Anti Bounce:" Grid.Row="12" Grid.Column="0" />
+
+                                            <Label Content="Anti Bounce timing:" Grid.Row="12" Grid.Column="0" />
                                             <StackPanel Orientation="Horizontal" Grid.Row="12" Grid.Column="1" HorizontalAlignment="Right">
                                                 <xctk:IntegerUpDown d:IsHidden="True" FormatString="F1" Value="{Binding LSAntiBounceTimeout}"
                                                        MinWidth="100" Minimum="0" Maximum="1000" Increment="1" IsEnabled="{Binding LSAntiBounce}"
@@ -529,7 +529,7 @@
                                                 <TextBlock Text="units" DockPanel.Dock="Right" FontSize="10" Margin="{StaticResource spaceMargin}" VerticalAlignment="Center" />
                                             </StackPanel>
 
-                                            <Label Content="Anti Bounce:" Grid.Row="12" Grid.Column="0" />
+                                            <Label Content="Anti Bounce timing:" Grid.Row="12" Grid.Column="0" />
                                             <StackPanel Orientation="Horizontal" Grid.Row="12" Grid.Column="1" HorizontalAlignment="Right">
                                                 <xctk:IntegerUpDown d:IsHidden="True" FormatString="F1" Value="{Binding RSAntiBounceTimeout}"
                                                        MinWidth="100" Minimum="0" Maximum="1000" Increment="1" IsEnabled="{Binding RSAntiBounce}"

--- a/DS4Windows/DS4Forms/ViewModels/ProfileSettingsViewModel.cs
+++ b/DS4Windows/DS4Forms/ViewModels/ProfileSettingsViewModel.cs
@@ -985,6 +985,41 @@ namespace DS4WinWPF.DS4Forms.ViewModels
             set => Global.RSModInfo[device].fuzz = value;
         }
 
+        public bool LSAntiBounce
+        {
+            get => Global.LSAntiBounceInfo[device].enabled;
+            set => Global.LSAntiBounceInfo[device].enabled = value;
+        }
+
+        public bool RSAntiBounce
+        {
+            get => Global.RSAntiBounceInfo[device].enabled;
+            set => Global.RSAntiBounceInfo[device].enabled = value;
+        }
+
+        public double LSAntiBounceDelta
+        {
+            get => Global.LSAntiBounceInfo[device].delta;
+            set => Global.LSAntiBounceInfo[device].delta = value;
+        }
+
+        public double RSAntiBounceDelta
+        {
+            get => Global.RSAntiBounceInfo[device].delta;
+            set => Global.RSAntiBounceInfo[device].delta = value;
+        }
+        public int LSAntiBounceTimeout
+        {
+            get => Global.LSAntiBounceInfo[device].timeout;
+            set => Global.LSAntiBounceInfo[device].timeout = value;
+        }
+
+        public int RSAntiBounceTimeout
+        {
+            get => Global.RSAntiBounceInfo[device].timeout;
+            set => Global.RSAntiBounceInfo[device].timeout = value;
+        }
+
         public int LSOutputIndex
         {
             get

--- a/DS4Windows/DS4Forms/ViewModels/ProfileSettingsViewModel.cs
+++ b/DS4Windows/DS4Forms/ViewModels/ProfileSettingsViewModel.cs
@@ -985,39 +985,39 @@ namespace DS4WinWPF.DS4Forms.ViewModels
             set => Global.RSModInfo[device].fuzz = value;
         }
 
-        public bool LSAntiBounce
+        public bool LSAntiSnapback
         {
-            get => Global.LSAntiBounceInfo[device].enabled;
-            set => Global.LSAntiBounceInfo[device].enabled = value;
+            get => Global.LSAntiSnapbackInfo[device].enabled;
+            set => Global.LSAntiSnapbackInfo[device].enabled = value;
         }
 
-        public bool RSAntiBounce
+        public bool RSAntiSnapback
         {
-            get => Global.RSAntiBounceInfo[device].enabled;
-            set => Global.RSAntiBounceInfo[device].enabled = value;
+            get => Global.RSAntiSnapbackInfo[device].enabled;
+            set => Global.RSAntiSnapbackInfo[device].enabled = value;
         }
 
-        public double LSAntiBounceDelta
+        public double LSAntiSnapbackDelta
         {
-            get => Global.LSAntiBounceInfo[device].delta;
-            set => Global.LSAntiBounceInfo[device].delta = value;
+            get => Global.LSAntiSnapbackInfo[device].delta;
+            set => Global.LSAntiSnapbackInfo[device].delta = value;
         }
 
-        public double RSAntiBounceDelta
+        public double RSAntiSnapbackDelta
         {
-            get => Global.RSAntiBounceInfo[device].delta;
-            set => Global.RSAntiBounceInfo[device].delta = value;
+            get => Global.RSAntiSnapbackInfo[device].delta;
+            set => Global.RSAntiSnapbackInfo[device].delta = value;
         }
-        public int LSAntiBounceTimeout
+        public int LSAntiSnapbackTimeout
         {
-            get => Global.LSAntiBounceInfo[device].timeout;
-            set => Global.LSAntiBounceInfo[device].timeout = value;
+            get => Global.LSAntiSnapbackInfo[device].timeout;
+            set => Global.LSAntiSnapbackInfo[device].timeout = value;
         }
 
-        public int RSAntiBounceTimeout
+        public int RSAntiSnapbackTimeout
         {
-            get => Global.RSAntiBounceInfo[device].timeout;
-            set => Global.RSAntiBounceInfo[device].timeout = value;
+            get => Global.RSAntiSnapbackInfo[device].timeout;
+            set => Global.RSAntiSnapbackInfo[device].timeout = value;
         }
 
         public int LSOutputIndex


### PR DESCRIPTION
This feature helps solve the bouncy stick problem that happens when you let go of the joystick and the inertia makes it bounce beyond it's natural position. Read more about it here: http://joostdevblog.blogspot.com/2011/10/bouncy-stick-problem.html
I implemented it as a profile option and as configured in the screenshot it would check if in the last 50 milliseconds the stick was 135 units or more away from it's current position (EDIT) and the line between the two points has to go through the middle (touch a 15 unit circle to be exact), if it was the position will be set to 128; 128. 
![image](https://user-images.githubusercontent.com/55197768/108906470-99bd7880-7629-11eb-96cd-872055d0e954.png)
It might introduce slight delay if you wanted to flick the stick to the opposite side but it wasn't noticeable in my testing and the feature is disabled by default anyway.

I also fixed a bug where doing anything with the fuzz option would cause the application to hang due to IndexOutOfRangeException (in cases where device id was 8).