### PR TITLE
Adds DualShock 3 support when running under DsHidMini drivers

### DIFF
--- a/DS4Windows/DS4Library/DS4Devices.cs
+++ b/DS4Windows/DS4Library/DS4Devices.cs
@@ -157,6 +157,7 @@ namespace DS4Windows
             new VidPidInfo(NINTENDO_VENDOR_ID, JOYCON_L_PRODUCT_ID, "JoyCon (L)", InputDeviceType.JoyConL, VidPidFeatureSet.DefaultDS4, checkConnection: JoyConDevice.DetermineConnectionType),
             new VidPidInfo(NINTENDO_VENDOR_ID, JOYCON_R_PRODUCT_ID, "JoyCon (R)", InputDeviceType.JoyConR, VidPidFeatureSet.DefaultDS4, checkConnection: JoyConDevice.DetermineConnectionType),
             new VidPidInfo(0x7545, 0x1122, "Gioteck VX4", InputDeviceType.DS4), // Gioteck VX4 (no real lightbar, only some RGB leds)
+            new VidPidInfo(0x7331, 0x0001, "DualShock 3 (DS4 mode)", InputDeviceType.DS4, VidPidFeatureSet.NoGyroCalib), // Sony DualShock 3 running DsHidMini driver
         };
 
         public static string devicePathToInstanceId(string devicePath)


### PR DESCRIPTION
This change adds transparent support for a Sony DualShock 3 when running under [DsHidMini drivers](https://github.com/ViGEm/DsHidMini) (which are currently in BETA but in a working state).

This is achieved by DsHidMini emulating a DualShock 4 and transparently translating the input and output report formats so the only change necessary in DS4Windows is an "artificial" entry of VID/PID pair that DsHidMini exposes to the system.

[Check out this article for more details](https://vigem.org/projects/DsHidMini/HID-Device-Modes-Explained/#ds4).

Cheers 😁 