### PR TITLE
Allow ControllerReadingsControl to use different controller

### DIFF
--- a/DS4Windows/DS4Forms/ControllerReadingsControl.xaml
+++ b/DS4Windows/DS4Forms/ControllerReadingsControl.xaml
@@ -13,7 +13,7 @@
     <DockPanel LastChildFill="False">
         <StackPanel Orientation="Horizontal" DockPanel.Dock="Top">
             <StackPanel Orientation="Horizontal" Width="200">
-                <Label x:Name="inputContNum" Content="#" FontWeight="Bold"/>
+                <Label x:Name="inputContNum" Content="#" FontWeight="Bold" MouseLeftButtonUp="inputContNum_MouseLeftButtonUp"/>
                 <Label x:Name="inputDelayLb" Content="Input Delay: N/A"  Margin="8,0,0,0">
                     <Label.Background>
                         <SolidColorBrush x:Name="inpuDelayBackBrush" Color="Transparent" />

--- a/DS4Windows/DS4Forms/ControllerReadingsControl.xaml
+++ b/DS4Windows/DS4Forms/ControllerReadingsControl.xaml
@@ -13,7 +13,7 @@
     <DockPanel LastChildFill="False">
         <StackPanel Orientation="Horizontal" DockPanel.Dock="Top">
             <StackPanel Orientation="Horizontal" Width="200">
-                <Label x:Name="inputContNum" Content="#" FontWeight="Bold" MouseLeftButtonUp="inputContNum_MouseLeftButtonUp"/>
+                <TextBlock x:Name="inputContNum" Text="#" TextDecorations="Underline" FontWeight="Bold" Foreground="{DynamicResource AccentColor}" Cursor="Hand" MouseLeftButtonUp="inputContNum_MouseLeftButtonUp" VerticalAlignment="Center"/>
                 <Label x:Name="inputDelayLb" Content="Input Delay: N/A"  Margin="8,0,0,0">
                     <Label.Background>
                         <SolidColorBrush x:Name="inpuDelayBackBrush" Color="Transparent" />

--- a/DS4Windows/DS4Forms/ControllerReadingsControl.xaml.cs
+++ b/DS4Windows/DS4Forms/ControllerReadingsControl.xaml.cs
@@ -340,5 +340,10 @@ namespace DS4WinWPF.DS4Forms
             r2InValLb.Content = inState.R2;
             r2OutValLb.Content = mapState.R2;
         }
+
+        private void inputContNum_MouseLeftButtonUp(object sender, MouseButtonEventArgs e)
+        {
+            UseDevice(deviceNum + 1 >= Program.rootHub.DS4Controllers.Where(i => i != null).Count() ? 0 : deviceNum + 1, profileDeviceNum);
+        }
     }
 }

--- a/DS4Windows/DS4Forms/ControllerReadingsControl.xaml.cs
+++ b/DS4Windows/DS4Forms/ControllerReadingsControl.xaml.cs
@@ -119,7 +119,7 @@ namespace DS4WinWPF.DS4Forms
         public ControllerReadingsControl()
         {
             InitializeComponent();
-            inputContNum.Content = $"#{deviceNum+1}";
+            inputContNum.Text = $"#{deviceNum+1}";
             exposeState = new DS4StateExposed(baseState);
 
             readingTimer = new NonFormTimer();
@@ -134,7 +134,7 @@ namespace DS4WinWPF.DS4Forms
 
         private void ControllerReadingsControl_DeviceNumChanged(object sender, EventArgs e)
         {
-            inputContNum.Content = $"#{deviceNum+1}";
+            inputContNum.Text = $"#{deviceNum+1}";
         }
 
         private void ChangeSixAxisDeadControls(object sender, EventArgs e)


### PR DESCRIPTION
When using multiple devices, the ControllerReadingsControl will only show the first device's reading. This is inconvenient for adjusting dead zone per device. Additionally, when SONYWA is plugged in the computer, it will become the first device even when no controller is connected to it, making the ControllerReadingsControl useless.