### PR TITLE
Fix ColorByBattery panel visibility for first open

### DIFF
--- a/DS4Windows/DS4Forms/ProfileEditor.xaml.cs
+++ b/DS4Windows/DS4Forms/ProfileEditor.xaml.cs
@@ -76,7 +76,6 @@ namespace DS4WinWPF.DS4Forms
             PopulateHoverIndexes();
             PopulateReverseHoverIndexes();
 
-            ColorByBatteryPerCheck();
             AssignTiltAssociation();
             AssignSwipeAssociation();
             AssignTriggerFullPullAssociation();
@@ -547,6 +546,8 @@ namespace DS4WinWPF.DS4Forms
                     Global.LoadBlankDevProfile(device, false, App.rootHub, false);
                 }
             }
+
+            ColorByBatteryPerCheck();
 
             if (device < Global.TEST_PROFILE_INDEX)
             {


### PR DESCRIPTION
ColorByBattery panel is always hidden when the user opens Profile Editor for the first time, even when ledAsBattery is set to true. This is due to profile loading happens after ColorByBatteryPerCheck, which is called in the constructor. This PR moves the call after the profile is loaded.