### PR TITLE
Properly handle SONYWA's ContinuousCalibration

### DIFF
--- a/DS4Windows/DS4Library/DS4Device.cs
+++ b/DS4Windows/DS4Library/DS4Device.cs
@@ -831,6 +831,7 @@ namespace DS4Windows
             {
                 hDevice.readFeatureData(calibration);
                 sixAxis.setCalibrationData(ref calibration, conType == ConnectionType.USB);
+                sixAxis.ResetContinuousCalibration();
             }
         }
 

--- a/DS4Windows/DS4Library/DS4Device.cs
+++ b/DS4Windows/DS4Library/DS4Device.cs
@@ -1454,7 +1454,7 @@ namespace DS4Windows
                         }
                         else
                         {
-                            sixAxis.stopCalibration();
+                            sixAxis.StopContinuousCalibration();
                         }
                     }
 

--- a/DS4Windows/DS4Library/DS4Device.cs
+++ b/DS4Windows/DS4Library/DS4Device.cs
@@ -1452,6 +1452,10 @@ namespace DS4Windows
                         {
                             sixAxis.handleSixaxis(pbGyro, pbAccel, cState, elapsedDeltaTime);
                         }
+                        else
+                        {
+                            sixAxis.stopCalibration();
+                        }
                     }
 
                     /* Debug output of incoming HID data:

--- a/DS4Windows/DS4Library/DS4Sixaxis.cs
+++ b/DS4Windows/DS4Library/DS4Sixaxis.cs
@@ -198,6 +198,11 @@ namespace DS4Windows
             gyroAverageTimer.Start();
         }
 
+        public void stopCalibration()
+        {
+            gyroAverageTimer.Stop();
+        }
+
         int temInt = 0;
         public void setCalibrationData(ref byte[] calibData, bool useAltGyroCalib)
         {

--- a/DS4Windows/DS4Library/DS4Sixaxis.cs
+++ b/DS4Windows/DS4Library/DS4Sixaxis.cs
@@ -194,13 +194,7 @@ namespace DS4Windows
         {
             sPrev = new SixAxis(0, 0, 0, 0, 0, 0, 0.0);
             now = new SixAxis(0, 0, 0, 0, 0, 0, 0.0);
-            for (int i = 0; i < gyro_average_window.Length; i++) gyro_average_window[i] = new GyroAverageWindow();
-            gyroAverageTimer.Start();
-        }
-
-        public void stopCalibration()
-        {
-            gyroAverageTimer.Stop();
+            StartContinuousCalibration();
         }
 
         int temInt = 0;
@@ -400,12 +394,24 @@ namespace DS4Windows
             SixAccelMoved?.Invoke(this, args);
         }
 
+        public void StartContinuousCalibration()
+        {
+            for (int i = 0; i < gyro_average_window.Length; i++) gyro_average_window[i] = new GyroAverageWindow();
+            gyroAverageTimer.Start();
+        }
+
+        public void StopContinuousCalibration()
+        {
+            gyroAverageTimer.Stop();
+            gyroAverageTimer.Reset();
+            for (int i = 0; i < gyro_average_window.Length; i++) gyro_average_window[i].Reset();
+        }
+
         public void ResetContinuousCalibration()
         {
-            for (int i = 0; i < num_gyro_average_windows; i++)
-                gyro_average_window[i].Reset();
-
-            gyroAverageTimer.Restart();
+            // Potential race condition with CalcSensorCamples() since this method is called after checking gyroAverageTimer.IsRunning == true
+            StopContinuousCalibration();
+            StartContinuousCalibration();
         }
 
         public unsafe void PushSensorSamples(int x, int y, int z, double accelMagnitude)


### PR DESCRIPTION
Currently the ContinuousCalibration will not stop when no device is attached to SONYWA, resulting a blinking green circle in ControllerReadingsControl. This PR will stop ContinuousCalibration when no device is attached on SONYWA, and restart ContinuousCalibration when a device is attached on SONYWA.