### PR TITLE
Support for DS3 gamepad as vendor defined device over DsHidMini driver

### DIFF
--- a/DS4Windows/DS4Library/DS4Devices.cs
+++ b/DS4Windows/DS4Library/DS4Devices.cs
@@ -158,7 +158,7 @@ namespace DS4Windows
             new VidPidInfo(NINTENDO_VENDOR_ID, JOYCON_L_PRODUCT_ID, "JoyCon (L)", InputDeviceType.JoyConL, VidPidFeatureSet.DefaultDS4, checkConnection: JoyConDevice.DetermineConnectionType),
             new VidPidInfo(NINTENDO_VENDOR_ID, JOYCON_R_PRODUCT_ID, "JoyCon (R)", InputDeviceType.JoyConR, VidPidFeatureSet.DefaultDS4, checkConnection: JoyConDevice.DetermineConnectionType),
             new VidPidInfo(0x7545, 0x1122, "Gioteck VX4", InputDeviceType.DS4), // Gioteck VX4 (no real lightbar, only some RGB leds)
-            new VidPidInfo(0x7331, 0x0001, "DualShock 3 (DS4 mode)", InputDeviceType.DS4, VidPidFeatureSet.NoGyroCalib | VidPidFeatureSet.VendorDefinedDevice), // Sony DualShock 3 using DsHidMini driver both in DS4 mode and as vendor-defined HID device
+            new VidPidInfo(0x7331, 0x0001, "DualShock 3 (DS4 Emulation)", InputDeviceType.DS4, VidPidFeatureSet.NoGyroCalib | VidPidFeatureSet.VendorDefinedDevice), // Sony DualShock 3 using DsHidMini driver. DsHidMini uses vendor-defined HID device type when it's emulating DS3 using DS4 button layout
         };
 
         public static string devicePathToInstanceId(string devicePath)

--- a/DS4Windows/HidLibrary/HidDevices.cs
+++ b/DS4Windows/HidLibrary/HidDevices.cs
@@ -62,7 +62,8 @@ namespace DS4Windows
                 {
                     VidPidInfo tempInfo = devInfo[j];
                     if ((tempDev.Capabilities.Usage == HID_USAGE_GAMEPAD ||
-                        tempDev.Capabilities.Usage == HID_USAGE_JOYSTICK)  &&
+                        tempDev.Capabilities.Usage == HID_USAGE_JOYSTICK ||
+                        tempInfo.featureSet.HasFlag(VidPidFeatureSet.VendorDefinedDevice))  &&
                         tempDev.Attributes.VendorId == tempInfo.vid &&
                         tempDev.Attributes.ProductId == tempInfo.pid)
                     {


### PR DESCRIPTION
Support for DS3 gamepad as vendor defined device over DsHidMini driver (with this change DS4Windows supports DS3 both as "true" native DS4 device and as a special vendor defined HID device).  When DS3 is configured as VendorDefinedDevice in DsHidMini then it doesn't need exclusive mode or DsHidMini/HidGuardian trick. Related to https://github.com/Ryochan7/DS4Windows/issues/2060 ticket
#2060 