### PR TITLE
Connect/Disconnect log message shows now slot# and if the slot is permanent and the real controller displayName

### DIFF
--- a/DS4Windows/DS4Control/ControlService.cs
+++ b/DS4Windows/DS4Control/ControlService.cs
@@ -1017,7 +1017,7 @@ namespace DS4Windows
                         success = true;
                     }
 
-                    if (success) LogDebug("Associate X360 Controller for input DS4 #" + (index + 1));
+                    if (success) LogDebug($"Associate X360 Controller in{(slotDevice.PermanentType != OutContType.None ? " permanent" : "")} slot #{slotDevice.Index+1} for input {device.DisplayName} controller #{index + 1}");
 
                     //tempXbox.Connect();
                     //LogDebug("X360 Controller #" + (index + 1) + " connected");
@@ -1087,7 +1087,7 @@ namespace DS4Windows
                         success = true;
                     }
 
-                    if (success) LogDebug("Associate DS4 Controller for input DS4 #" + (index + 1));
+                    if (success) LogDebug($"Associate DS4 Controller in{(slotDevice.PermanentType != OutContType.None ? " permanent" : "")} slot #{slotDevice.Index + 1} for input {device.DisplayName} controller #{index + 1}");
 
                     //DS4OutDevice tempDS4 = new DS4OutDevice(vigemTestClient);
                     //DS4OutDevice tempDS4 = outputslotMan.AllocateController(OutContType.DS4, vigemTestClient)
@@ -1115,7 +1115,7 @@ namespace DS4Windows
                 if (dev != null && slotDevice != null)
                 {
                     string tempType = dev.GetDeviceType();
-                    LogDebug("Disassociate " + tempType + " Controller for input DS4 #" + (index + 1), false);
+                    LogDebug($"Disassociate {tempType} Controller from{(slotDevice.CurrentReserveStatus == OutSlotDevice.ReserveStatus.Permanent ? " permanent" : "")} slot #{slotDevice.Index+1} for input {device.DisplayName} controller #{index + 1}", false);
 
                     OutContType currentType = activeOutDevType[index];
                     outputDevices[index] = null;

--- a/DS4Windows/DS4Control/OutSlotDevice.cs
+++ b/DS4Windows/DS4Control/OutSlotDevice.cs
@@ -68,6 +68,10 @@ namespace DS4WinWPF.DS4Control
             set
             {
                 if (permanentType == value) return;
+
+                if(value != OutContType.None)
+                    AppLogger.LogToGui($"Output slot #{this.index+1} has permanent type {value}", false);
+
                 permanentType = value;
                 PermanentTypeChanged?.Invoke(this, EventArgs.Empty);
             }


### PR DESCRIPTION
Added slot# log messages to a gamepad connect/disconnect handler and "permanent" slot debug msg (makes it easier to track down slot based issues). Tweaked also a connection log msg to show the real controller displayName instead of hard-coded DS4 text string as a controller type (nowadays this app supports lots of other input controllers and not just DS4).
