### PR TITLE
Make more strings localization ready

### DIFF
--- a/DS4Windows/DS4Forms/About.xaml
+++ b/DS4Windows/DS4Forms/About.xaml
@@ -3,6 +3,10 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:lex="http://wpflocalizeextension.codeplex.com"
+        lex:LocalizeDictionary.DesignCulture=""
+        lex:ResxLocalizationProvider.DefaultAssembly="DS4Windows"
+        lex:ResxLocalizationProvider.DefaultDictionary="Strings"
         xmlns:local="clr-namespace:DS4WinWPF.DS4Forms"
         mc:Ignorable="d"
         Title="Hotkeys/About" Height="450" Width="800"
@@ -11,7 +15,7 @@
         <local:AboutImgPathLocations x:Key="aboutImgPathLocs" />
     </Window.Resources>
     <DockPanel>
-        <Label x:Name="headerLb" Content="DS4Windows - Ryochan7 Build (Version " DockPanel.Dock="Top" HorizontalAlignment="Center" />
+        <Label x:Name="headerLb" Content="{lex:Loc ProgramName}" DockPanel.Dock="Top" HorizontalAlignment="Center" />
         <StackPanel Orientation="Horizontal" DockPanel.Dock="Top" HorizontalAlignment="Center" Margin="0,4,0,0">
             <Button x:Name="githubSocialBtn" Click="GithubSocialBtn_Click"
                     BorderBrush="{x:Null}" Background="{x:Null}" Cursor="Hand" ToolTip="GitHub">
@@ -46,7 +50,7 @@
             <Hyperlink x:Name="changeLogLink" Click="ChangeLogLink_Click" Foreground="{DynamicResource AccentColor}">Changelog</Hyperlink>
         </TextBlock>
         <TabControl>
-            <TabItem Header="Hotkeys">
+            <TabItem Header="{lex:Loc Hotkeys}">
                 <TextBlock TextWrapping="Wrap" xml:space="preserve">Hide DS4 Controller: Hides the DS4's regular input (Dinput) from other programs, check if you are getting double input in games or R2 pauses games
 Click left side of touchpad: Left Touch
 Click right side of touchpad: Right Touch
@@ -65,7 +69,7 @@ Macro: Assign multiple keys to one input
 Scan Code: Keys are interpreted differently. May be needed for certain games
 *If enabled</TextBlock>
             </TabItem>
-            <TabItem Header="Credits">
+            <TabItem Header="{lex:Loc Credits}">
                 <DockPanel>
                     <StackPanel DockPanel.Dock="Top" Margin="10,0">
                         <StackPanel Orientation="Horizontal">
@@ -79,7 +83,7 @@ Scan Code: Keys are interpreted differently. May be needed for certain games
                         <StackPanel Orientation="Horizontal">
                             <TextBlock><Hyperlink x:Name="electrobrainsLink" Click="ElectrobrainsLink_Click" Foreground="{DynamicResource AccentColor}">electrobrains (Branched off of)</Hyperlink></TextBlock>
                         </StackPanel>
-                        <Label Content="Translators:" Margin="0,20,0,0" />
+                        <Label Content="{lex:Loc Translators}" Margin="0,20,0,0" />
                     </StackPanel>
                     <TextBox TextWrapping="Wrap" xml:space="preserve" IsReadOnly="True"
                              DockPanel.Dock="Bottom" VerticalScrollBarVisibility="Auto" Margin="10,0,10,10">xLive - Arabic
@@ -100,7 +104,7 @@ dondrakon - Ukranian
                     </TextBox>
                 </DockPanel>
             </TabItem>
-            <TabItem Header="Tip">
+            <TabItem Header="{lex:Loc Tip}">
                 <StackPanel>
                     <TextBox Background="Transparent" BorderThickness="0" IsReadOnly="True" TextWrapping="Wrap"
                          IsUndoEnabled="False" xml:space="preserve">Bitcoin: 1DnMJwjdd7JRfHJap2mmTmADYm38SzR2z9

--- a/DS4Windows/DS4Forms/AutoProfiles.xaml
+++ b/DS4Windows/DS4Forms/AutoProfiles.xaml
@@ -205,7 +205,7 @@
                             </ComboBox>
                         </Grid>
 
-                        <CheckBox Content="Turn Off DS4Window Temporarily" Margin="{StaticResource spaceMargin}"
+                        <CheckBox Content="{lex:Loc TurnOffTemporarily}" Margin="{StaticResource spaceMargin}"
                           IsChecked="{Binding Turnoff}" />
                         <TextBox Text="{Binding Path}" Margin="{StaticResource spaceMargin}" ToolTip="{lex:Loc AutoProfPathTip}"/>
 
@@ -232,8 +232,8 @@
 
                         <Border Height="4" Background="#FFDADADA" Margin="0,10,0,0" />
                     </StackPanel>
-                    <CheckBox x:Name="revertDefaultProfileOnUnknownCk" Content="Revert to default profile on unknown" Margin="0,10,0,0" IsChecked="{Binding RevertDefaultProfileOnUnknown}" />
-                    <CheckBox x:Name="showAutoDebugCk" Content="Show auto-profile debug messages" Margin="0,10,0,0" Click="ShowAutoDebugCk_Click" />
+                    <CheckBox x:Name="revertDefaultProfileOnUnknownCk" Content="{lex:Loc RevertDefaultProfile}" Margin="0,10,0,0" IsChecked="{Binding RevertDefaultProfileOnUnknown}" />
+                    <CheckBox x:Name="showAutoDebugCk" Content="{lex:Loc ShowAutoDebug}" Margin="0,10,0,0" Click="ShowAutoDebugCk_Click" />
 
                 </StackPanel>
             </ScrollViewer>

--- a/DS4Windows/DS4Forms/AxialStickUserControl.xaml
+++ b/DS4Windows/DS4Forms/AxialStickUserControl.xaml
@@ -35,25 +35,25 @@
         <TextBlock Text="X" Grid.Column="1" FontWeight="Bold" HorizontalAlignment="Center" Margin="0,0,0,8" />
         <TextBlock Text="Y" Grid.Column="2"  FontWeight="Bold" HorizontalAlignment="Center" Margin="0,0,0,8" />
 
-        <Label Content="Dead Zone:" Grid.Row="1" Grid.Column="0" />
+        <Label Content="{lex:Loc DeadZone_}" Grid.Row="1" Grid.Column="0" />
         <xctk:DoubleUpDown d:IsHidden="True" Value="{Binding DeadZoneX,UpdateSourceTrigger=LostFocus}" FormatString="F2" MinWidth="50" Grid.Row="1" Grid.Column="1" Maximum="1.0" Minimum="0.0" Increment="0.1"
                                                    Margin="{StaticResource spaceMargin}" />
         <xctk:DoubleUpDown d:IsHidden="True" Value="{Binding DeadZoneY,UpdateSourceTrigger=LostFocus}" FormatString="F2" MinWidth="50" Grid.Row="1" Grid.Column="2" Maximum="1.0" Minimum="0.0" Increment="0.1"
                                                    Margin="{StaticResource spaceMargin}" />
 
-        <Label Content="Max Zone:" Grid.Row="2" Grid.Column="0" />
+        <Label Content="{lex:Loc MaxZone_}" Grid.Row="2" Grid.Column="0" />
         <xctk:DoubleUpDown d:IsHidden="True" Value="{Binding MaxZoneX}" FormatString="F2" MinWidth="50" Grid.Row="2" Grid.Column="1" Maximum="1.0" Minimum="0.0" Increment="0.1"
                                                    Margin="{StaticResource spaceMargin}" />
         <xctk:DoubleUpDown d:IsHidden="True" Value="{Binding MaxZoneY}" FormatString="F2" MinWidth="50" Grid.Row="2" Grid.Column="2" Maximum="1.0" Minimum="0.0" Increment="0.1"
                                                    Margin="{StaticResource spaceMargin}" />
 
-        <Label Content="Anti-dead Zone:" Grid.Row="3" Grid.Column="0" />
+        <Label Content="{lex:Loc AntiDeadZone}" Grid.Row="3" Grid.Column="0" />
         <xctk:DoubleUpDown d:IsHidden="True" Value="{Binding AntiDeadZoneX}" FormatString="F2" MinWidth="50" Grid.Row="3" Grid.Column="1" Maximum="1.0" Minimum="0.0" Increment="0.1"
                                                    Margin="{StaticResource spaceMargin}" />
         <xctk:DoubleUpDown d:IsHidden="True" Value="{Binding AntiDeadZoneY}" FormatString="F2" MinWidth="50" Grid.Row="3" Grid.Column="2" Maximum="1.0" Minimum="0.0" Increment="0.1"
                                                    Margin="{StaticResource spaceMargin}" />
 
-        <Label Content="Max Output:" Grid.Row="4" Grid.Column="0" />
+        <Label Content="{lex:Loc MaxOutput_}" Grid.Row="4" Grid.Column="0" />
         <xctk:DoubleUpDown d:IsHidden="True" Value="{Binding MaxOutputX}" FormatString="F2" MinWidth="50" Grid.Row="4" Grid.Column="1" Maximum="1.0" Minimum="0.0" Increment="0.1"
                                                    Margin="{StaticResource spaceMargin}" />
         <xctk:DoubleUpDown d:IsHidden="True" Value="{Binding MaxOutputY}" FormatString="F2" MinWidth="50" Grid.Row="4" Grid.Column="2" Maximum="1.0" Minimum="0.0" Increment="0.1"

--- a/DS4Windows/DS4Forms/BindingWindow.xaml
+++ b/DS4Windows/DS4Forms/BindingWindow.xaml
@@ -17,49 +17,49 @@
             <StackPanel.Resources>
                 <Thickness x:Key="spaceMargin" Bottom="8" />
             </StackPanel.Resources>
-            <GroupBox Header="Extra" x:Name="extrasGB">
+            <GroupBox Header="{lex:Loc Extra}" x:Name="extrasGB">
                 <StackPanel Orientation="Vertical" Margin="2,0">
                     <StackPanel Orientation="Horizontal" Margin="{StaticResource spaceMargin}">
                         <Label Content="{lex:Loc Rumble}" />
-                        <Button x:Name="testRumbleBtn" Width="60" Content="Test" Click="TestRumbleBtn_Click" />
+                        <Button x:Name="testRumbleBtn" Width="60" Content="{lex:Loc Test}" Click="TestRumbleBtn_Click" />
                     </StackPanel>
 
                     <StackPanel Orientation="Horizontal" Margin="{StaticResource spaceMargin}">
-                        <Label Content="Heavy" Width="50" />
+                        <Label Content="{lex:Loc Heavy}" Width="50" />
                         <xctk:IntegerUpDown Value="{Binding HeavyRumble}" MinWidth="60" Margin="20,0,0,0"
                                             Minimum="0" Maximum="255" />
                     </StackPanel>
 
                     <StackPanel Orientation="Horizontal" Margin="{StaticResource spaceMargin}">
-                        <Label Content="Light" Width="50" />
+                        <Label Content="{lex:Loc Light}" Width="50" />
                         <xctk:IntegerUpDown Value="{Binding LightRumble}" MinWidth="60" Margin="20,0,0,0"
                                             Minimum="0" Maximum="255" />
                     </StackPanel>
 
                     <StackPanel Orientation="Vertical">
-                        <CheckBox Content="Change Light" IsChecked="{Binding UseExtrasColor}" Margin="{StaticResource spaceMargin}" />
+                        <CheckBox Content="{lex:Loc ChangeLight}" IsChecked="{Binding UseExtrasColor}" Margin="{StaticResource spaceMargin}" />
                         <StackPanel Margin="{StaticResource spaceMargin}">
                             <StackPanel Orientation="Horizontal">
-                                <Label Content="R" />
+                                <Label Content="{lex:Loc ColorR}" />
                                 <Slider Value="{Binding ExtrasColorR}" Minimum="0" Maximum="255" ToolTip="{Binding ExtrasColorR}" MinWidth="100" Background="{Binding ExtrasColorRString, FallbackValue=Red}"/>
                             </StackPanel>
                             <StackPanel Orientation="Horizontal">
-                                <Label Content="G" />
+                                <Label Content="{lex:Loc ColorG}" />
                                 <Slider Value="{Binding ExtrasColorG}" MinWidth="100" Minimum="0" Maximum="255" ToolTip="{Binding ExtrasColorG}" Background="{Binding ExtrasColorGString, FallbackValue=Lime}"/>
                             </StackPanel>
                             <StackPanel Orientation="Horizontal">
-                                <Label Content="B" />
+                                <Label Content="{lex:Loc ColorB}" />
                                 <Slider Value="{Binding ExtrasColorB}" MinWidth="100" Minimum="0" Maximum="255" ToolTip="{Binding ExtrasColorB}" Background="{Binding ExtrasColorBString, FallbackValue=Blue}"/>
                             </StackPanel>
                             <Button x:Name="extrasColorChoosebtn" Width="20" Height="20" Background="{Binding ExtrasColorString}" HorizontalAlignment="Right" Margin="0,10,10,0" Click="ExtrasColorChoosebtn_Click" />
                         </StackPanel>
                         <StackPanel Orientation="Horizontal" Margin="{StaticResource spaceMargin}">
-                            <Label Content="Flash Rate"/>
+                            <Label Content="{lex:Loc FlashRate}"/>
                             <xctk:IntegerUpDown MinWidth="50" Value="{Binding FlashRate}"
                                                 Minimum="0" Maximum="20" />
                         </StackPanel>
                         <StackPanel Orientation="Vertical">
-                            <CheckBox Content="Change Mouse Sensitivity" IsChecked="{Binding UseMouseSens}"
+                            <CheckBox Content="{lex:Loc ChangeMouseSensitivity}" IsChecked="{Binding UseMouseSens}"
                                       Margin="{StaticResource spaceMargin}" />
                             <xctk:IntegerUpDown Value="{Binding MouseSens}" MinWidth="50" Height="20"
                                                 Minimum="0" Maximum="255" />
@@ -73,8 +73,8 @@
             <DockPanel x:Name="bottomPanel" DockPanel.Dock="Bottom" Margin="0">
                 <StackPanel x:Name="modePanel" Width="160" DockPanel.Dock="Left" Margin="8,0,0,0">
                     <StackPanel Orientation="Horizontal">
-                        <RadioButton x:Name="regBindRadio" Content="Regular" GroupName="bindModeGroup" IsChecked="True" Click="RegBindRadio_Click" />
-                        <RadioButton x:Name="shiftBindRadio" Content="Shift Modifier" GroupName="bindModeGroup" Margin="10,0,0,0" Click="ShiftBindRadio_Click" />
+                        <RadioButton x:Name="regBindRadio" Content="{lex:Loc Regular}" GroupName="bindModeGroup" IsChecked="True" Click="RegBindRadio_Click" />
+                        <RadioButton x:Name="shiftBindRadio" Content="{lex:Loc ShiftModifier}" GroupName="bindModeGroup" Margin="10,0,0,0" Click="ShiftBindRadio_Click" />
                     </StackPanel>
 
                     <ComboBox x:Name="shiftTriggerCombo" Margin="0,8,0,0" SelectedIndex="{Binding ShiftTrigger,FallbackValue=0}">
@@ -106,10 +106,10 @@
                         <ComboBoxItem Content="Sixaxis Right"/>
                         <ComboBoxItem Content="Finger on Touchpad"/>
                         <ComboBoxItem Content="Mute"/>
-                    </ComboBox>
+                  </ComboBox>
 
                     <Button x:Name="defaultBtn" Content="{Binding DefaultBtnString,FallbackValue=Default}" Background="{Binding DefaultColor,FallbackValue={StaticResource SecondaryColor}}" Margin="0,50,0,0" Click="DefaultBtn_Click" />
-                    <Button x:Name="unboundBtn" Content="Unbound" Background="{Binding UnboundColor,FallbackValue={StaticResource SecondaryColor}}" Margin="0,10,0,0" Click="UnboundBtn_Click" />
+                    <Button x:Name="unboundBtn" Content="{lex:Loc Unbound}" Background="{Binding UnboundColor,FallbackValue={StaticResource SecondaryColor}}" Margin="0,10,0,0" Click="UnboundBtn_Click" />
                 </StackPanel>
 
                 <StackPanel x:Name="outConPanel" Width="630" Orientation="Vertical" DockPanel.Dock="Right" HorizontalAlignment="Center" Margin="0">
@@ -178,7 +178,7 @@
                 </Grid.ColumnDefinitions>
                 <StackPanel Grid.Row="0" Grid.Column="0" HorizontalAlignment="Left">
                     <Label x:Name="macroOnLb"
-                           Content="Macro On, Choose a key to disable, else close this window to save"
+                           Content="{lex:Loc MacroOn}"
                            Visibility="{Binding MacroLbVisible}" />
                 </StackPanel>
                 <StackPanel Grid.Column="1" HorizontalAlignment="Center">
@@ -186,11 +186,11 @@
                 </StackPanel>
                 <StackPanel x:Name="topOptsPanel" Orientation="Horizontal" Grid.Column="2"
                             HorizontalAlignment="Right" VerticalAlignment="Center">
-                    <CheckBox Content="Toggle" IsChecked="{Binding Toggle}" />
-                    <CheckBox Content="Scan Code" IsChecked="{Binding HasScanCode}" Margin="6,0,0,0" />
+                    <CheckBox Content="{lex:Loc Toggle}" IsChecked="{Binding Toggle}" />
+                    <CheckBox Content="{lex:Loc ScanCode}" IsChecked="{Binding HasScanCode}" Margin="6,0,0,0" />
                 </StackPanel>
                 <StackPanel Grid.Column="3" HorizontalAlignment="Right" VerticalAlignment="Center">
-                    <Button x:Name="recordMacroBtn" Content="Record A Macro" Click="RecordMacroBtn_Click" />
+                    <Button x:Name="recordMacroBtn" Content="{lex:Loc RecordMacro}" Click="RecordMacroBtn_Click" />
                 </StackPanel>
             </Grid>
             <Grid DockPanel.Dock="Top">

--- a/DS4Windows/DS4Forms/ControllerReadingsControl.xaml
+++ b/DS4Windows/DS4Forms/ControllerReadingsControl.xaml
@@ -14,7 +14,7 @@
         <StackPanel Orientation="Horizontal" DockPanel.Dock="Top">
             <StackPanel Orientation="Horizontal" Width="200">
                 <Label x:Name="inputContNum" Content="#" FontWeight="Bold"/>
-                <Label x:Name="inputDelayLb" Content="Input Delay: N/A"  Margin="8,0,0,0">
+                <Label x:Name="inputDelayLb" Content="{lex:Loc InputDelayNA}"  Margin="8,0,0,0">
                     <Label.Background>
                         <SolidColorBrush x:Name="inpuDelayBackBrush" Color="Transparent" />
                     </Label.Background>
@@ -24,7 +24,7 @@
                 </Label>
             </StackPanel>
             <StackPanel Orientation="Horizontal" Margin="20,0,0,0">
-                <Label x:Name="batteryLvlLb" Content="Battery: 0%" Margin="8,0,0,0" />
+                <Label x:Name="batteryLvlLb" Content="{lex:Loc Battery0}" Margin="8,0,0,0" />
             </StackPanel>
         </StackPanel>
         <Grid DockPanel.Dock="Top" Width="450" Margin="0,8,0,0">
@@ -49,21 +49,21 @@
                 </Canvas>
                 <StackPanel Orientation="Horizontal">
                     <StackPanel Orientation="Horizontal">
-                        <Label Content="LX (I): " />
+                        <Label Content="{lex:Loc LxInVal}" />
                         <Label x:Name="lxInValLb" Content="" Width="30" Padding="2,5"  />
                     </StackPanel>
                     <StackPanel Orientation="Horizontal">
-                        <Label Content="LX (O): " />
+                        <Label Content="{lex:Loc LxOutVal}" />
                         <Label x:Name="lxOutValLb" Content="" Width="30" Padding="2,5" />
                     </StackPanel>
                 </StackPanel>
                 <StackPanel Orientation="Horizontal">
                     <StackPanel Orientation="Horizontal">
-                        <Label Content="LY (I): "/>
+                        <Label Content="{lex:Loc LyInVal}"/>
                         <Label x:Name="lyInValLb" Content="" Width="30" Padding="2,5" />
                     </StackPanel>
                     <StackPanel Orientation="Horizontal">
-                        <Label Content="LY (O): " />
+                        <Label Content="{lex:Loc LyOutVal}" />
                         <Label x:Name="lyOutValLb" Content="" Width="30" />
                     </StackPanel>
                 </StackPanel>
@@ -85,21 +85,21 @@
                 </Canvas>
                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
                     <StackPanel Orientation="Horizontal">
-                        <Label Content="RX (I): "/>
+                        <Label Content="{lex:Loc RxInVal}"/>
                         <Label x:Name="rxInValLb" Content="" Width="30" />
                     </StackPanel>
                     <StackPanel Orientation="Horizontal">
-                        <Label Content="RX (O): "/>
+                        <Label Content="{lex:Loc RxOutVal}"/>
                         <Label x:Name="rxOutValLb" Content="" Width="30" />
                     </StackPanel>
                 </StackPanel>
                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
                     <StackPanel Orientation="Horizontal">
-                        <Label Content="RY (I): "/>
+                        <Label Content="{lex:Loc RyInVal}"/>
                         <Label x:Name="ryInValLb" Content="" Width="30" />
                     </StackPanel>
                     <StackPanel Orientation="Horizontal">
-                        <Label Content="RY (O): "/>
+                        <Label Content="{lex:Loc RyOutVal}"/>
                         <Label x:Name="ryOutValLb" Content="" Width="30" />
                     </StackPanel>
                 </StackPanel>
@@ -121,21 +121,21 @@
                 </Canvas>
                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
                     <StackPanel Orientation="Horizontal">
-                        <Label Content="X (I): "/>
+                        <Label Content="{lex:Loc XInVal}"/>
                         <Label x:Name="sixAxisXInValLb" Content="" Width="40" />
                     </StackPanel>
                     <StackPanel Orientation="Horizontal">
-                        <Label Content="X (O): "/>
+                        <Label Content="{lex:Loc XOutVal}"/>
                         <Label x:Name="sixAxisXOutValLb" Content="" Width="40" />
                     </StackPanel>
                 </StackPanel>
                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
                     <StackPanel Orientation="Horizontal">
-                        <Label Content="Z (I): "/>
+                        <Label Content="{lex:Loc ZInVal}"/>
                         <Label x:Name="sixAxisZInValLb" Content="" Width="40" />
                     </StackPanel>
                     <StackPanel Orientation="Horizontal">
-                        <Label Content="Z (O): "/>
+                        <Label Content="{lex:Loc ZOutVal}"/>
                         <Label x:Name="sixAxisZOutValLb" Content="" Width="40" />
                     </StackPanel>
                 </StackPanel>
@@ -149,7 +149,7 @@
             <StackPanel Orientation="Horizontal" MinHeight="100" Grid.Column="0" RenderTransformOrigin="0,0" HorizontalAlignment="Center">
                 <StackPanel>
                     <StackPanel Orientation="Horizontal" Margin="0,0,20,0">
-                        <Label x:Name="l2ValLb" Content="L2" Height="16" VerticalAlignment="Top" HorizontalAlignment="Left" RenderTransformOrigin="0.5,1" Padding="0" Margin="0,0,4,0" >
+                        <Label x:Name="l2ValLb" Content="{lex:Loc L2}" Height="16" VerticalAlignment="Top" HorizontalAlignment="Left" RenderTransformOrigin="0.5,1" Padding="0" Margin="0,0,4,0" >
                             <Label.RenderTransform>
                                 <TransformGroup>
                                     <TranslateTransform x:Name="l2ValLbTrans" Y="66" />
@@ -163,11 +163,11 @@
                     </StackPanel>
                     <StackPanel>
                         <StackPanel Orientation="Horizontal">
-                            <Label Content="I: " Width="30" />
+                            <Label Content="{lex:Loc InVal}" Width="30" />
                             <Label x:Name="l2InValLb" Content="" Width="30" />
                         </StackPanel>
                         <StackPanel Orientation="Horizontal">
-                            <Label Content="O: " Width="30" />
+                            <Label Content="{lex:Loc OutVal}" Width="30" />
                             <Label x:Name="l2OutValLb" Content="" Width="30" />
                         </StackPanel>
                     </StackPanel>
@@ -176,7 +176,7 @@
                 <StackPanel>
                     <StackPanel Orientation="Horizontal">
                         <Slider x:Name="r2Slider" Orientation="Vertical" Minimum="0" Maximum="255" Value="0" Height="80" Focusable="False" />
-                        <Label x:Name="r2ValLb" Content="R2" Height="16" VerticalAlignment="Top" HorizontalAlignment="Left" RenderTransformOrigin="0.5,1" Padding="0" Margin="0,0,4,0" >
+                        <Label x:Name="r2ValLb" Content="{lex:Loc R2}" Height="16" VerticalAlignment="Top" HorizontalAlignment="Left" RenderTransformOrigin="0.5,1" Padding="0" Margin="0,0,4,0" >
                             <Label.RenderTransform>
                                 <TransformGroup>
                                     <TranslateTransform x:Name="r2ValLbTrans" Y="66"/>
@@ -190,11 +190,11 @@
 
                     <StackPanel>
                         <StackPanel Orientation="Horizontal">
-                            <Label Content="I: " Width="30" />
+                            <Label Content="{lex:Loc InVal}" Width="30" />
                             <Label x:Name="r2InValLb" Content="" Width="30" />
                         </StackPanel>
                         <StackPanel Orientation="Horizontal">
-                            <Label Content="O: " Width="30" />
+                            <Label Content="{lex:Loc OutVal}" Width="30" />
                             <Label x:Name="r2OutValLb" Content="" Width="30" />
                         </StackPanel>
                     </StackPanel>
@@ -205,30 +205,30 @@
                     <StackPanel Margin="0,0,10,0">
                         <Label Content="{lex:Loc Gyro}" HorizontalAlignment="Center" Padding="0"/>
                         <StackPanel Orientation="Horizontal">
-                            <Label Content="Yaw" Width="40" />
+                            <Label Content="{lex:Loc Yaw}" Width="40" />
                             <Slider x:Name="gyroYawSlider" Width="80" Minimum="-9000" Maximum="9000" Value="0" Focusable="False" Margin="0,8,0,0"/>
                         </StackPanel>
                         <StackPanel Orientation="Horizontal">
-                            <Label Content="Pitch" Width="40" />
+                            <Label Content="{lex:Loc Pitch}" Width="40" />
                             <Slider x:Name="gyroPitchSlider" Width="80" Minimum="-9000" Maximum="9000" Value="0" Focusable="False" Margin="0,4,0,0"/>
                         </StackPanel>
                         <StackPanel Orientation="Horizontal">
-                            <Label Content="Roll" Width="40" />
+                            <Label Content="{lex:Loc Roll}" Width="40" />
                             <Slider x:Name="gyroRollSlider" Width="80" Minimum="-9000" Maximum="9000" Value="0" Focusable="False" Margin="0,4,0,0"/>
                         </StackPanel>
                     </StackPanel>
                     <StackPanel>
                         <Label Content="{lex:Loc Accel}" HorizontalAlignment="Center" Padding="0"/>
                         <StackPanel Orientation="Horizontal">
-                            <Label Content="X" Width="20" />
+                            <Label Content="{lex:Loc AccelX}" Width="20" />
                             <Slider x:Name="accelXSlider" Width="80" Minimum="-128" Maximum="128" Value="0" Focusable="False" Margin="0,8,0,0"/>
                         </StackPanel>
                         <StackPanel Orientation="Horizontal">
-                            <Label Content="Y" Width="20" />
+                            <Label Content="{lex:Loc AccelY}" Width="20" />
                             <Slider x:Name="accelYSlider" Width="80" Minimum="-128" Maximum="128" Value="0" Focusable="False" Margin="0,4,0,0"/>
                         </StackPanel>
                         <StackPanel Orientation="Horizontal">
-                            <Label Content="Z" Width="20" />
+                            <Label Content="{lex:Loc AccelZ}" Width="20" />
                             <Slider x:Name="accelZSlider" Width="80" Minimum="-128" Maximum="128" Value="0" Focusable="False" Margin="0,4,0,0"/>
                         </StackPanel>
                     </StackPanel>

--- a/DS4Windows/DS4Forms/ControllerRegisterOptionsWindow.xaml
+++ b/DS4Windows/DS4Forms/ControllerRegisterOptionsWindow.xaml
@@ -3,6 +3,10 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:lex="http://wpflocalizeextension.codeplex.com"
+        lex:LocalizeDictionary.DesignCulture=""
+        lex:ResxLocalizationProvider.DefaultAssembly="DS4Windows"
+        lex:ResxLocalizationProvider.DefaultDictionary="Strings"
         xmlns:local="clr-namespace:DS4WinWPF.DS4Forms"
         mc:Ignorable="d"
         Title="Controller Type Options" Height="450" Width="800"
@@ -13,14 +17,14 @@
     <DockPanel x:Name="devOptionsDockPanel" Margin="4">
         <DockPanel>
             <StackPanel DockPanel.Dock="Top">
-                <CheckBox Content="DS4 Controller Support" IsChecked="{Binding DS4DeviceOpts.Enabled}" />
-                <CheckBox Content="DualSense Controller Support" IsChecked="{Binding DSDeviceOpts.Enabled}" />
-                <CheckBox Content="Switch Pro Controller Support" IsChecked="{Binding SwitchProDeviceOpts.Enabled}" />
-                <CheckBox Content="JoyCon Controller Support" IsChecked="{Binding JoyConDeviceOpts.Enabled}" />
+                <CheckBox Content="{lex:Loc DS4ControllerSupport}" IsChecked="{Binding DS4DeviceOpts.Enabled}" />
+                <CheckBox Content="{lex:Loc DualSenseControllerSupport}" IsChecked="{Binding DSDeviceOpts.Enabled}" />
+                <CheckBox Content="{lex:Loc SwitchProControllerSupport}" IsChecked="{Binding SwitchProDeviceOpts.Enabled}" />
+                <CheckBox Content="{lex:Loc JoyConControllerSupport}" IsChecked="{Binding JoyConDeviceOpts.Enabled}" />
             </StackPanel>
 
             <DockPanel DockPanel.Dock="Bottom" Margin="0,20,0,0">
-                <Label Content="Detected Controllers" ContentStringFormat="{}{0}:" DockPanel.Dock="Top" FontWeight="Bold" />
+                <Label Content="{lex:Loc DetectedControllers}" ContentStringFormat="{}{0}:" DockPanel.Dock="Top" FontWeight="Bold" />
                 <ListBox x:Name="controllerListBox" ItemsSource="{Binding CurrentInputDevices}" SelectedIndex="{Binding ControllerSelectedIndex}"
                       Margin="0,8,0,0">
                     <ListBox.ItemTemplate>
@@ -30,63 +34,63 @@
                     </ListBox.ItemTemplate>
                 </ListBox>
             </DockPanel>
-            
+
         </DockPanel>
 
         <TabControl x:Name="deviceSettingsTabControl" DockPanel.Dock="Right" SelectedIndex="{Binding CurrentTabSelectedIndex}" Margin="40,4,4,4">
-            <TabItem Header="Blank" Visibility="Collapsed">
+            <TabItem Header="{lex:Loc Blank}" Visibility="Collapsed">
             </TabItem>
 
-            <TabItem x:Name="ds4OptsTabItem" Header="DS4" Visibility="Collapsed">
+            <TabItem x:Name="ds4OptsTabItem" Header="{lex:Loc DS4}" Visibility="Collapsed">
                 <StackPanel Visibility="{Binding Visible, Converter={StaticResource BooleanToVisibilityConverter}}" Margin="4">
-                    <CheckBox Content="Copycat" IsChecked="{Binding Options.IsCopyCat, FallbackValue='False'}" ToolTip="Change some flags used for a non-Sony DS4 controller. It might fix rumble and lightbar support for some third party DS4 clones" />
+                    <CheckBox Content="{lex:Loc Copycat}" IsChecked="{Binding Options.IsCopyCat, FallbackValue='False'}" ToolTip="{lex:Loc CopycatTip}" />
                 </StackPanel>
             </TabItem>
-            
-            <TabItem x:Name="dualSenseOptsTabItem" Header="DualSense" Visibility="Collapsed">
+
+            <TabItem x:Name="dualSenseOptsTabItem" Header="{lex:Loc DualSense}" Visibility="Collapsed">
                 <StackPanel Visibility="{Binding Visible, Converter={StaticResource BooleanToVisibilityConverter}}" Margin="4">
-                    <CheckBox Content="Enable Rumble Emulation" IsChecked="{Binding Options.EnableRumble, FallbackValue='False'}" />
+                    <CheckBox Content="{lex:Loc EnableRumbleEmulation}" IsChecked="{Binding Options.EnableRumble, FallbackValue='False'}" />
                     <StackPanel Orientation="Horizontal" Margin="0,8,0,0" IsEnabled="{Binding Options.EnableRumble}">
-                        <Label Content="Rumble Strength" ContentStringFormat="{}{0}:" />
+                        <Label Content="{lex:Loc RumbleStrength}" ContentStringFormat="{}{0}:" />
                         <ComboBox ItemsSource="{Binding Path=DSHapticOptions}" DisplayMemberPath="DisplayName" SelectedValuePath="ChoiceValue" SelectedValue="{Binding Options.HapticIntensity}" Margin="8,0,0,0" />
                     </StackPanel>
                     <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
-                        <Label Content="Player LED Mode" ContentStringFormat="{}{0}:" />
+                        <Label Content="{lex:Loc PlayerLEDMode}" ContentStringFormat="{}{0}:" />
                         <ComboBox ItemsSource="{Binding Path=DsLEDModes}" DisplayMemberPath="DisplayName" SelectedValuePath="ChoiceValue" SelectedValue="{Binding Options.LedMode}" Margin="8,0,0,0" />
                     </StackPanel>
 
                     <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
-                        <Label Content="Mute LED Mode" ContentStringFormat="{}{0}:" />
+                        <Label Content="{lex:Loc MuteLEDMode}" ContentStringFormat="{}{0}:" />
                         <ComboBox ItemsSource="{Binding Path=DsMuteLEDModes}" DisplayMemberPath="DisplayName" SelectedValuePath="ChoiceValue" SelectedValue="{Binding Options.MuteLedMode}" Margin="8,0,0,0" />
                     </StackPanel>
                 </StackPanel>
             </TabItem>
 
-            <TabItem x:Name="switchProOptsTabItem" Header="Switch Pro" Visibility="Collapsed">
+            <TabItem x:Name="switchProOptsTabItem" Header="{lex:Loc SwitchPro}" Visibility="Collapsed">
                 <StackPanel Visibility="{Binding Visible, Converter={StaticResource BooleanToVisibilityConverter}}" Margin="4">
-                    <CheckBox Content="Enable Home LED" IsChecked="{Binding Options.EnableHomeLED, FallbackValue='False'}" />
+                    <CheckBox Content="{lex:Loc EnableHomeLED}" IsChecked="{Binding Options.EnableHomeLED, FallbackValue='False'}" />
                 </StackPanel>
             </TabItem>
 
-            <TabItem x:Name="joyConOptsTabItem" Header="JoyCon" Visibility="Collapsed">
+            <TabItem x:Name="joyConOptsTabItem" Header="{lex:Loc JoyCon}" Visibility="Collapsed">
                 <StackPanel Visibility="{Binding Visible, Converter={StaticResource BooleanToVisibilityConverter}}" Margin="4">
                     <TextBlock Text="Changes take effect on new device connection" Foreground="#FFDE4343" FontWeight="Bold" />
 
-                    <GroupBox Header="JoyCon Global Options" Margin="0,8,0,0">
+                    <GroupBox Header="{lex:Loc JoyConGlobalOptions}" Margin="0,8,0,0">
                         <StackPanel>
                             <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
-                                <Label Content="Link Mode" ContentStringFormat="{}{0}:" />
+                                <Label Content="{lex:Loc LinkMode}" ContentStringFormat="{}{0}:" />
                                 <ComboBox ItemsSource="{Binding Path=LinkModes}" DisplayMemberPath="DisplayName" SelectedValuePath="ChoiceValue" SelectedValue="{Binding ParentOptions.LinkedMode}" Margin="8,0,0,0" />
                             </StackPanel>
 
                             <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
-                                <Label Content="Joined Gyro Provider" ContentStringFormat="{}{0}:" />
+                                <Label Content="{lex:Loc JoinedGyroProvider}" ContentStringFormat="{}{0}:" />
                                 <ComboBox ItemsSource="{Binding Path=JoinGyroOptions}" DisplayMemberPath="DisplayName" SelectedValuePath="ChoiceValue" SelectedValue="{Binding ParentOptions.JoinGyroProv}" Margin="8,0,0,0" />
                             </StackPanel>
                         </StackPanel>
                     </GroupBox>
 
-                    <CheckBox Content="Enable Home LED" IsChecked="{Binding Options.EnableHomeLED, FallbackValue='False'}"
+                    <CheckBox Content="{lex:Loc EnableHomeLED}" IsChecked="{Binding Options.EnableHomeLED, FallbackValue='False'}"
                               Margin="0,16,0,0" />
                 </StackPanel>
             </TabItem>

--- a/DS4Windows/DS4Forms/DupBox.xaml
+++ b/DS4Windows/DS4Forms/DupBox.xaml
@@ -32,8 +32,8 @@
         </Canvas>
 
         <StackPanel Orientation="Horizontal" DockPanel.Dock="Right" HorizontalAlignment="Right" Margin="0,0,30,0">
-            <Button x:Name="saveBtn" Content="Save" Width="80" Click="SaveBtn_Click" />
-            <Button x:Name="cancelBtn" Content="Cancel" Width="80" Click="CancelBtn_Click" Margin="20,0,0,0" />
+            <Button x:Name="saveBtn" Content="{lex:Loc Save}" Width="80" Click="SaveBtn_Click" />
+            <Button x:Name="cancelBtn" Content="{lex:Loc Cancel}" Width="80" Click="CancelBtn_Click" Margin="20,0,0,0" />
         </StackPanel>
     </DockPanel>
 </UserControl>

--- a/DS4Windows/DS4Forms/LanguagePackControl.xaml
+++ b/DS4Windows/DS4Forms/LanguagePackControl.xaml
@@ -1,13 +1,17 @@
 ﻿<UserControl x:Class="DS4WinWPF.DS4Forms.LanguagePackControl"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:lex="http://wpflocalizeextension.codeplex.com"
+             lex:LocalizeDictionary.DesignCulture=""
+             lex:ResxLocalizationProvider.DefaultAssembly="DS4Windows"
+             lex:ResxLocalizationProvider.DefaultDictionary="Strings"
              xmlns:local="clr-namespace:DS4WinWPF.DS4Forms"
              mc:Ignorable="d" 
              d:DesignHeight="30" d:DesignWidth="340">
     <StackPanel Orientation="Horizontal">
-        <Label x:Name="label1" Content="Use language pack:" />
+        <Label x:Name="label1" Content="{lex:Loc UseLanguagePack_}" />
         <ComboBox x:Name="cbCulture" Width="200" Margin="10,0,0,0"
                   ItemsSource="{Binding LangPackList}" SelectedIndex="{Binding SelectedIndex,FallbackValue=0}" IsEnabled="False">
             <ComboBox.ItemTemplate>

--- a/DS4Windows/DS4Forms/LogMessageDisplay.xaml
+++ b/DS4Windows/DS4Forms/LogMessageDisplay.xaml
@@ -3,13 +3,17 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:lex="http://wpflocalizeextension.codeplex.com"
+        lex:LocalizeDictionary.DesignCulture=""
+        lex:ResxLocalizationProvider.DefaultAssembly="DS4Windows"
+        lex:ResxLocalizationProvider.DefaultDictionary="Strings"
         xmlns:local="clr-namespace:DS4WinWPF.DS4Forms"
         mc:Ignorable="d"
         Title="Log" MinHeight="200" Height="200" Width="600" MinWidth="400" SizeToContent="Height" WindowStartupLocation="CenterScreen"
         Style="{DynamicResource WindowStyle}">
     <DockPanel Margin="4">
         <StackPanel Orientation="Horizontal" DockPanel.Dock="Bottom" HorizontalAlignment="Right">
-            <Button x:Name="okayButton" Content="OK" MinWidth="60" Click="OkayButton_Click" />
+            <Button x:Name="okayButton" Content="{lex:Loc Ok}" MinWidth="60" Click="OkayButton_Click" />
         </StackPanel>
         <RichTextBox x:Name="richMessageBox" DockPanel.Dock="Top" IsReadOnly="True" IsDocumentEnabled="True" BorderBrush="{x:Null}" BorderThickness="0" HorizontalContentAlignment="Stretch" VerticalAlignment="Center"/>
     </DockPanel>

--- a/DS4Windows/DS4Forms/MainWindow.xaml
+++ b/DS4Windows/DS4Forms/MainWindow.xaml
@@ -288,7 +288,7 @@
                         <CheckBox Content="{lex:Loc StartMinimized}" Margin="{StaticResource spaceMargin}"
                               IsChecked="{Binding StartMinimize}" />
                         <CheckBox Content="{lex:Loc MinimizeToTaskbar}"
-                                  ToolTip="{lex:Loc MinimizeToTaskbarInsteadOfSystemTray}"
+                                  ToolTip="{lex:Loc MinimizeToTaskbarTip}"
                                   IsChecked="{Binding MinimizeToTaskbar}" Margin="{StaticResource spaceMargin}" />
                         <CheckBox Content="{lex:Loc CloseMinimizes}" Margin="{StaticResource spaceMargin}"
                               IsChecked="{Binding CloseMinimizes}"

--- a/DS4Windows/DS4Forms/MainWindow.xaml
+++ b/DS4Windows/DS4Forms/MainWindow.xaml
@@ -24,9 +24,9 @@
         <tb:TaskbarIcon x:Name="notifyIcon" IconSource="{Binding IconSource,Mode=OneWay}" ToolTipText="{Binding TooltipText,Mode=OneWay}" MenuActivation="RightClick" TrayRightMouseUp="NotifyIcon_TrayRightMouseUp" TrayMiddleMouseDown="NotifyIcon_TrayMiddleMouseDown" TrayMouseDoubleClick="NotifyIcon_TrayMouseDoubleClick">
             <!--<tb:TaskbarIcon.ContextMenu>
                 <ContextMenu>
-                    <MenuItem Header="Open" />
+                    <MenuItem Header="{lex:Loc Open}" />
                     <Separator />
-                    <MenuItem x:Name="exitMenuItem" Header="Exit" />
+                    <MenuItem x:Name="exitMenuItem" Header="{lex:Loc Exit}" />
                 </ContextMenu>
             </tb:TaskbarIcon.ContextMenu>-->
         </tb:TaskbarIcon>
@@ -60,7 +60,7 @@
                                     </GridViewColumn.CellTemplate>
                                 </GridViewColumn>
 
-                                <GridViewColumn x:Name="idColumn" Header="ID" Width="120">
+                                <GridViewColumn x:Name="idColumn" Header="{lex:Loc ID}" Width="120">
                                     <GridViewColumn.CellTemplate>
                                         <DataTemplate>
                                             <TextBlock x:Name="idColumnTxtB" Text="{Binding IdText, Mode=OneWay}" ToolTip="{Binding TooltipIDText, Mode=OneWay}" ToolTipOpening="IdColumnTxtB_ToolTipOpening" Tag="{Binding DevIndex, Mode=OneTime}"/>
@@ -71,12 +71,12 @@
                                     <GridViewColumn.CellTemplate>
                                         <DataTemplate>
                                             <StackPanel Width="{Binding ElementName=statusColumn, Path=Width}">
-                                                <Image x:Name="contStatusImg" Source="{Binding StatusSource}" Stretch="Uniform" Width="20" Height="20" HorizontalAlignment="Center" ToolTip="Right click to disconnect wireless" MouseRightButtonUp="ContStatusImg_MouseRightButtonUp" Tag="{Binding DevIndex}" />
+                                                <Image x:Name="contStatusImg" Source="{Binding StatusSource}" Stretch="Uniform" Width="20" Height="20" HorizontalAlignment="Center" ToolTip="{lex:Loc ContStatusTip}" MouseRightButtonUp="ContStatusImg_MouseRightButtonUp" Tag="{Binding DevIndex}" />
                                             </StackPanel>
                                         </DataTemplate>
                                     </GridViewColumn.CellTemplate>
                                 </GridViewColumn>
-                                <GridViewColumn x:Name="exclusiveColumn" Header="Ex" Width="50">
+                                <GridViewColumn x:Name="exclusiveColumn" Header="{lex:Loc Ex}" Width="50">
                                     <GridViewColumn.CellTemplate>
                                         <DataTemplate>
                                             <StackPanel Width="{Binding ElementName=exclusiveColumn, Path=Width}">
@@ -96,7 +96,7 @@
                                         </DataTemplate>
                                     </GridViewColumn.CellTemplate>
                                 </GridViewColumn>
-                                <GridViewColumn x:Name="LinkProfColumn" Header="Link Profile/ID" Width="100">
+                                <GridViewColumn x:Name="LinkProfColumn" Header="{lex:Loc LinkProfileOrID}" Width="100">
                                     <GridViewColumn.CellTemplate>
                                         <DataTemplate>
                                             <StackPanel Width="{Binding ElementName=LinkProfColumn, Path=Width}">
@@ -105,7 +105,7 @@
                                         </DataTemplate>
                                     </GridViewColumn.CellTemplate>
                                 </GridViewColumn>
-                                <GridViewColumn x:Name="selectProfileColumn" Header="Selected Profile" Width="130">
+                                <GridViewColumn x:Name="selectProfileColumn" Header="{lex:Loc SelectedProfile}" Width="130">
                                     <GridViewColumn.CellTemplate>
                                         <DataTemplate>
                                             <StackPanel Width="{Binding Path=Width, ElementName=selectProfileColumn, Mode=OneWay}" HorizontalAlignment="Center">
@@ -145,8 +145,8 @@
                                                 <Button x:Name="LightColorBtn" Width="120" Height="20" Background="{Binding LightColor, Mode=OneWay}" Tag="{Binding DevIndex, Mode=OneTime}" Click="LightColorBtn_Click">
                                                     <!--<Button.ContextMenu>
                                                         <ContextMenu>
-                                                            <MenuItem Header="Use Profile Color" IsCheckable="True" />
-                                                            <MenuItem Header="Use Custom Color" IsCheckable="True" />
+                                                            <MenuItem Header="{lex:Loc UseProfileColor}" IsCheckable="True" />
+                                                            <MenuItem Header="{lex:Loc UseCustomColor}" IsCheckable="True" />
                                                         </ContextMenu>
                                                     </Button.ContextMenu>-->
                                                 </Button>
@@ -233,7 +233,7 @@
 
                 </local:AutoProfiles>
             </TabItem>
-            <TabItem Header="Output Slots" IsEnabled="{Binding FullTabsEnabled,Mode=OneWay}">
+            <TabItem Header="{lex:Loc OutputSlots}" IsEnabled="{Binding FullTabsEnabled,Mode=OneWay}">
                 <local:OutputSlotManagerControl x:Name="slotManControl">
 
                 </local:OutputSlotManagerControl>
@@ -244,21 +244,21 @@
                         <WrapPanel.Resources>
                             <Thickness x:Key="spaceMargin" Left="4" Right="0" Bottom="8" Top="0" />
                         </WrapPanel.Resources>
-                        <CheckBox x:Name="hideDS4ContCk" Content="Hide DS4 Controller" x:Uid="hideDS4Checkbox"
+                        <CheckBox x:Name="hideDS4ContCk" Content="{lex:Loc HideDS4Controller}" x:Uid="hideDS4Checkbox"
                               Margin="{StaticResource spaceMargin}" IsChecked="{Binding HideDS4Controller}" Click="HideDS4ContCk_Click" >
                         </CheckBox>
-                        <CheckBox x:Name="swipeTouchCk" Content="Swipe Touchpad To Switch Profiles" Margin="{StaticResource spaceMargin}"
+                        <CheckBox x:Name="swipeTouchCk" Content="{lex:Loc SwipeTouch}" Margin="{StaticResource spaceMargin}"
                               IsChecked="{Binding SwipeTouchSwitchProfile}"
                               ToolTip="{lex:Loc Resources:TwoFingerSwipe}" Click="SwipeTouchCk_Click" />
                         <CheckBox x:Name="runAtStartCk" Content="{lex:Loc RunAtStartup}" Margin="{StaticResource spaceMargin}"
                               IsChecked="{Binding RunAtStartup}"
                               ToolTip="{lex:Loc Resources:RunAtStartup}" Click="RunAtStartCk_Click" />
-                        <GroupBox x:Name="runAsGroupBox" Header="Run As" BorderThickness="2" Visibility="{Binding ShowRunStartPanel}"
+                        <GroupBox x:Name="runAsGroupBox" Header="{lex:Loc RunAs}" BorderThickness="2" Visibility="{Binding ShowRunStartPanel}"
                               Margin="{StaticResource spaceMargin}">
                             <StackPanel Orientation="Horizontal">
                                 <StackPanel>
-                                    <RadioButton Content="Program" GroupName="RunAsOpt" Margin="{StaticResource spaceMargin}" IsChecked="{Binding RunStartProg}" />
-                                    <RadioButton Content="Task" GroupName="RunAsOpt" Margin="{StaticResource spaceMargin}"
+                                    <RadioButton Content="{lex:Loc Program}" GroupName="RunAsOpt" Margin="{StaticResource spaceMargin}" IsChecked="{Binding RunStartProg}" />
+                                    <RadioButton Content="{lex:Loc Task}" GroupName="RunAsOpt" Margin="{StaticResource spaceMargin}"
                                                  IsChecked="{Binding RunStartTask}" IsEnabled="{Binding CanWriteTask}" />
                                 </StackPanel>
                                 <Image x:Name="uacImg" Source="{Binding UACSource, Mode=OneTime}" Width="30" Height="30"
@@ -273,22 +273,22 @@
                                 <ComboBoxItem Content="{lex:Loc All}" />
                             </ComboBox>
                         </StackPanel>
-                        <CheckBox Content="Disconnect from BT when Stopping" Margin="{StaticResource spaceMargin}"
+                        <CheckBox Content="{lex:Loc DisconnectBTStop}" Margin="{StaticResource spaceMargin}"
                               IsChecked="{Binding DisconnectBTStop}" />
                         <StackPanel Orientation="Horizontal" Margin="{StaticResource spaceMargin}">
-                            <CheckBox Content="Flash Lightbar at High Latency" VerticalAlignment="Center"
+                            <CheckBox Content="{lex:Loc FlashHighLatency}" VerticalAlignment="Center"
                                   IsChecked="{Binding FlashHighLatency}" />
                             <StackPanel Orientation="Horizontal" Margin="8,0,0,0"
                                     IsEnabled="{Binding FlashHighLatency,FallbackValue='False'}">
                                 <!--<TextBox Text="20" VerticalContentAlignment="Center" />-->
                                 <xctk:IntegerUpDown d:IsHidden="True" Value="{Binding FlashHighLatencyAt}" MinWidth="30" ButtonSpinnerLocation="Right" Increment="1" Maximum="100" Minimum="10" />
-                                <Label Content="ms" />
+                                <Label Content="{lex:Loc Ms}" />
                             </StackPanel>
                         </StackPanel>
                         <CheckBox Content="{lex:Loc StartMinimized}" Margin="{StaticResource spaceMargin}"
                               IsChecked="{Binding StartMinimize}" />
-                        <CheckBox Content="Minimize to Taskbar"
-                                  ToolTip="Minimize to Taskbar instead of System Tray"
+                        <CheckBox Content="{lex:Loc MinimizeToTaskbar}"
+                                  ToolTip="{lex:Loc MinimizeToTaskbarInsteadOfSystemTray}"
                                   IsChecked="{Binding MinimizeToTaskbar}" Margin="{StaticResource spaceMargin}" />
                         <CheckBox Content="{lex:Loc CloseMinimizes}" Margin="{StaticResource spaceMargin}"
                               IsChecked="{Binding CloseMinimizes}"
@@ -297,7 +297,7 @@
                               IsChecked="{Binding QuickCharge}"
                               ToolTip="{lex:Loc Resources:QuickCharge}" />
                         <StackPanel Orientation="Horizontal" Margin="{StaticResource spaceMargin}">
-                            <Label Content="Icon Choice:" />
+                            <Label Content="{lex:Loc IconChoice}" />
                             <ComboBox x:Name="useIconChoiceCom" SelectedIndex="{Binding IconChoiceIndex,FallbackValue='0'}" Margin="10,0,0,0">
                                 <ComboBoxItem>Default</ComboBoxItem>
                                 <ComboBoxItem>Colored</ComboBoxItem>
@@ -306,7 +306,7 @@
                             </ComboBox>
                         </StackPanel>
                         <StackPanel Orientation="Horizontal" Margin="{StaticResource spaceMargin}">
-                            <Label Content="App Theme:" />
+                            <Label Content="{lex:Loc AppTheme}" />
                             <ComboBox x:Name="appThemeCom" SelectedIndex="{Binding AppChoiceIndex,FallbackValue='0'}" Margin="10,0,0,0">
                                 <ComboBoxItem>Default</ComboBoxItem>
                                 <ComboBoxItem>Dark</ComboBoxItem>
@@ -317,7 +317,7 @@
                               IsChecked="{Binding CheckForUpdates}" />
                         <StackPanel x:Name="checkEveryOptionsStack" Orientation="Horizontal" Margin="{StaticResource spaceMargin}"
                                 IsEnabled="{Binding CheckForUpdates}">
-                            <Label Content="Check every " />
+                            <Label Content="{lex:Loc CheckEvery}" />
                             <!--<TextBox Text="0" VerticalAlignment="Center" />-->
                             <xctk:IntegerUpDown d:IsHidden="True" Value="{Binding CheckEvery}" MinWidth="30" Margin="8,0,0,0"
                                             ButtonSpinnerLocation="Right" Increment="1" Maximum="30" Minimum="0" />
@@ -329,27 +329,27 @@
                                 <ComboBoxItem Content="Days" />
                             </ComboBox>
                         </StackPanel>
-                        <GroupBox Header="UDP Server" Padding="0,10,0,0" Margin="{StaticResource spaceMargin}">
+                        <GroupBox Header="{lex:Loc UDPServer}" Padding="0,10,0,0" Margin="{StaticResource spaceMargin}">
                             <StackPanel>
                                 <StackPanel Orientation="Horizontal" MinHeight="20">
-                                    <CheckBox x:Name="useUdpServerCk" Content="Enable Server" IsChecked="{Binding UseUDPServer}" Click="UseUdpServerCk_Click" />
+                                    <CheckBox x:Name="useUdpServerCk" Content="{lex:Loc EnableServer}" IsChecked="{Binding UseUDPServer}" Click="UseUdpServerCk_Click" />
                                     <TextBox x:Name="udpServerTxt" IsEnabled="{Binding UseUDPServer,Mode=OneWay}" Text="{Binding UdpIpAddress, UpdateSourceTrigger=LostFocus,FallbackValue='127.0.0.1'}"
                                  Margin="8,0,0,0" />
-                                    <Label Content="Port" Padding="0" Margin="20,0,0,0" />
+                                    <Label Content="{lex:Loc Port}" Padding="0" Margin="20,0,0,0" />
                                     <!--<TextBox x:Name="updPortNum" IsEnabled="{Binding UseUDPServer}" Text="{Binding UdpPort, UpdateSourceTrigger=LostFocus,FallbackValue='26760'}" />-->
                                     <xctk:IntegerUpDown d:IsHidden="True" x:Name="updPortNum" IsEnabled="{Binding UseUDPServer}" MinWidth="20" Margin="8,0,0,0"
                                             Value="{Binding UdpPort, UpdateSourceTrigger=LostFocus,FallbackValue='26760'}" ButtonSpinnerLocation="Right" Increment="1" Maximum="65535" Minimum="0" />
                                 </StackPanel>
 
-                                <CheckBox Content="Use Smoothing" IsChecked="{Binding UseUdpSmoothing,FallbackValue='False'}" IsEnabled="{Binding UseUDPServer,Mode=OneWay}" Margin="0,4,0,10" />
+                                <CheckBox Content="{lex:Loc UseSmoothing}" IsChecked="{Binding UseUdpSmoothing,FallbackValue='False'}" IsEnabled="{Binding UseUDPServer,Mode=OneWay}" Margin="0,4,0,10" />
                                 <StackPanel x:Name="udpEuroPanel" Orientation="Horizontal" Margin="{StaticResource spaceMargin}" Visibility="{Binding UdpServerOneEuroPanelVisibility,FallbackValue='Collapsed'}">
                                     <StackPanel Orientation="Horizontal">
-                                        <Label Content="1&#x20ac; MinCutoff" />
+                                        <Label Content="{lex:Loc OneEuroMinCutoff}" />
                                         <xctk:DoubleUpDown d:IsHidden="True" FormatString="F5" Value="{Binding UdpSmoothMinCutoff,FallbackValue=1.0,UpdateSourceTrigger=LostFocus}"
                                                            Minimum="0.00001" Maximum="100.0" Increment="0.1" MinWidth="60" />
                                     </StackPanel>
                                     <StackPanel Orientation="Horizontal" Margin="30,0,0,0">
-                                        <Label Content="1&#x20ac; Beta" />
+                                        <Label Content="{lex:Loc OneEuroBeta}" />
                                         <xctk:DoubleUpDown  d:IsHidden="True" FormatString="F5" Value="{Binding UdpSmoothBeta,FallbackValue=0.0,UpdateSourceTrigger=LostFocus}"
                                                            Minimum="0.0" Maximum="1.0" Increment="0.1" MinWidth="60" />
                                     </StackPanel>
@@ -359,14 +359,14 @@
                         </GroupBox>
 
                         <!--<StackPanel Orientation="Horizontal">
-                        <Label Content="Use language pack" />
+                        <Label Content="{lex:Loc UseLanguagePack}" />
                         <ComboBox x:Name="langPackCombo" MinWidth="100" IsEnabled="False">
                         </ComboBox>
                     </StackPanel>
                     -->
                         <local:LanguagePackControl Margin="{StaticResource spaceMargin}" />
                         <StackPanel Margin="{StaticResource spaceMargin}">
-                            <CheckBox x:Name="customSteamCk" Content="Use custom Steam Folder" Margin="{StaticResource spaceMargin}"
+                            <CheckBox x:Name="customSteamCk" Content="{lex:Loc UseCustomSteamFolder}" Margin="{StaticResource spaceMargin}"
                                   IsChecked="{Binding UseCustomSteamFolder}" />
                             <TextBox x:Name="customSteamTxt" Text="{Binding CustomSteamFolder, UpdateSourceTrigger=LostFocus}"
                                  IsEnabled="{Binding UseCustomSteamFolder}" />
@@ -380,7 +380,7 @@
                             <TextBox x:Name="fakeExeNameTxt" Text="{Binding FakeExeName, UpdateSourceTrigger=LostFocus}" MinWidth="200" />
                         </DockPanel>
 
-                        <GroupBox Header="Utils" BorderThickness="2" Margin="{StaticResource spaceMargin}"
+                        <GroupBox Header="{lex:Loc Utils}" BorderThickness="2" Margin="{StaticResource spaceMargin}"
                               Padding="8" HorizontalAlignment="Left">
                             <WrapPanel HorizontalAlignment="Left" Orientation="Vertical">
                                 <Button x:Name="profFolderBtn" BorderThickness="0" Margin="0,0,4,4" Background="{x:Null}" BorderBrush="{x:Null}"
@@ -420,7 +420,7 @@
                             </WrapPanel>
                         </GroupBox>
 
-                        <Button x:Name="deviceOptionSettingsBtn" MaxWidth="100" HorizontalAlignment="Left" Content="Device Options" Click="DeviceOptionSettingsBtn_Click" />
+                        <Button x:Name="deviceOptionSettingsBtn" MaxWidth="100" HorizontalAlignment="Left" Content="{lex:Loc DeviceOptions}" Click="DeviceOptionSettingsBtn_Click" />
                     </WrapPanel>
                 </ScrollViewer>
 
@@ -428,20 +428,20 @@
             <TabItem Header="{lex:Loc Log}">
                 <DockPanel>
                     <DockPanel Height="20" DockPanel.Dock="Bottom" Margin="4,8">
-                        <Button x:Name="exportLogBtn" Content="Export" HorizontalAlignment="Left" Padding="20,1" Click="ExportLogBtn_Click" />
+                        <Button x:Name="exportLogBtn" Content="{lex:Loc Export}" HorizontalAlignment="Left" Padding="20,1" Click="ExportLogBtn_Click" />
                         <Button x:Name="clearLogBtn" Content="{lex:Loc Clear}" DockPanel.Dock="Right" Padding="20,1" Margin="100,0,0,0" Click="ClearLogBtn_Click" />
                     </DockPanel>
                     <ListView x:Name="logListView" DockPanel.Dock="Top" ItemsSource="{Binding LogItems}" MouseDoubleClick="LogListView_MouseDoubleClick" Margin="0">
                         <ListView.View>
                             <GridView AllowsColumnReorder="False">
-                                <GridViewColumn Header="Time" Width="150">
+                                <GridViewColumn Header="{lex:Loc Time}" Width="150">
                                     <GridViewColumn.CellTemplate>
                                         <DataTemplate>
                                             <TextBlock Text="{Binding Path=Datetime, StringFormat=\{0:G\}}"/>
                                         </DataTemplate>
                                     </GridViewColumn.CellTemplate>
                                 </GridViewColumn>
-                                <GridViewColumn Header="Data" Width="800">
+                                <GridViewColumn Header="{lex:Loc Data}" Width="800">
                                     <GridViewColumn.CellTemplate>
                                         <DataTemplate>
                                             <TextBlock Text="{Binding Path=Message}"/>

--- a/DS4Windows/DS4Forms/OutputSlotManagerControl.xaml
+++ b/DS4Windows/DS4Forms/OutputSlotManagerControl.xaml
@@ -1,15 +1,19 @@
 ﻿<UserControl x:Class="DS4WinWPF.DS4Forms.OutputSlotManagerControl"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:lex="http://wpflocalizeextension.codeplex.com"
+             lex:LocalizeDictionary.DesignCulture=""
+             lex:ResxLocalizationProvider.DefaultAssembly="DS4Windows"
+             lex:ResxLocalizationProvider.DefaultDictionary="Strings"
              xmlns:local="clr-namespace:DS4WinWPF.DS4Forms"
              mc:Ignorable="d" 
              d:DesignHeight="200" d:DesignWidth="800">
     <DockPanel Margin="4,8">
         <StackPanel x:Name="plugDevStackPanel" Orientation="Horizontal" DockPanel.Dock="Bottom" Height="30" Margin="0,20,0,0">
-            <Button x:Name="pluginBtn" MinWidth="60" Content="Plug" IsEnabled="{Binding PluginEnabled}" Click="PluginBtn_Click" />
-            <Button x:Name="unplugBtn" MinWidth="60" Content="Unplug" IsEnabled="{Binding UnpluginEnabled}" Click="UnplugBtn_Click" Margin="30,0,0,0" />
+            <Button x:Name="pluginBtn" MinWidth="60" Content="{lex:Loc Plug}" IsEnabled="{Binding PluginEnabled}" Click="PluginBtn_Click" />
+            <Button x:Name="unplugBtn" MinWidth="60" Content="{lex:Loc Unplug}" IsEnabled="{Binding UnpluginEnabled}" Click="UnplugBtn_Click" Margin="30,0,0,0" />
         </StackPanel>
 
         <DockPanel>
@@ -20,28 +24,28 @@
                         <ComboBoxItem Tag="1" Content="Permanent" />
                     </ComboBox>
 
-                    <Button x:Name="slotChangeAcceptBtn" Content="Accept" IsEnabled="{Binding Dirty,FallbackValue=False}"
+                    <Button x:Name="slotChangeAcceptBtn" Content="{lex:Loc Accept}" IsEnabled="{Binding Dirty,FallbackValue=False}"
                             Click="SlotChangeAcceptBtn_Click" Margin="0,8,0,0" />
                 </StackPanel>
             </StackPanel>
             <ListView x:Name="currentOutDevLV" ItemsSource="{Binding SlotDeviceEntries}" SelectedIndex="{Binding SelectedIndex,Mode=OneWayToSource}" DockPanel.Dock="Top">
                 <ListView.View>
                     <GridView>
-                        <GridViewColumn Width="200" Header="Current">
+                        <GridViewColumn Width="200" Header="{lex:Loc Current}">
                             <GridViewColumn.CellTemplate>
                                 <DataTemplate>
                                     <TextBlock Text="{Binding CurrentType}" />
                                 </DataTemplate>
                             </GridViewColumn.CellTemplate>
                         </GridViewColumn>
-                        <GridViewColumn Width="200" Header="Requested">
+                        <GridViewColumn Width="200" Header="{lex:Loc Requested}">
                             <GridViewColumn.CellTemplate>
                                 <DataTemplate>
                                     <TextBlock Text="{Binding DesiredType}" />
                                 </DataTemplate>
                             </GridViewColumn.CellTemplate>
                         </GridViewColumn>
-                        <GridViewColumn Width="60" Header="Active">
+                        <GridViewColumn Width="60" Header="{lex:Loc Active}">
                             <GridViewColumn.CellTemplate>
                                 <DataTemplate>
                                     <CheckBox IsChecked="{Binding BoundInput,Mode=OneWay}" IsEnabled="False" />

--- a/DS4Windows/DS4Forms/PluginOutDevWindow.xaml
+++ b/DS4Windows/DS4Forms/PluginOutDevWindow.xaml
@@ -3,6 +3,10 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:lex="http://wpflocalizeextension.codeplex.com"
+        lex:LocalizeDictionary.DesignCulture=""
+        lex:ResxLocalizationProvider.DefaultAssembly="DS4Windows"
+        lex:ResxLocalizationProvider.DefaultDictionary="Strings"
         xmlns:local="clr-namespace:DS4WinWPF.DS4Forms"
         mc:Ignorable="d"
         Title="PluginOutDevWindow" Height="200" Width="400"
@@ -10,8 +14,8 @@
     <DockPanel LastChildFill="False">
         <TextBlock Text="Device type" DockPanel.Dock="Top" />
         <StackPanel Orientation="Horizontal" DockPanel.Dock="Bottom" Height="40" HorizontalAlignment="Right">
-            <Button x:Name="acceptBtn" Content="Accept" Click="AcceptBtn_Click" />
-            <Button x:Name="cancelBtn" Content="Cancel" Click="CancelBtn_Click" Margin="20,0,0,0" />
+            <Button x:Name="acceptBtn" Content="{lex:Loc Accept}" Click="AcceptBtn_Click" />
+            <Button x:Name="cancelBtn" Content="{lex:Loc Cancel}" Click="CancelBtn_Click" Margin="20,0,0,0" />
         </StackPanel>
 
         <ComboBox x:Name="devTypeCombo" SelectedIndex="0" DockPanel.Dock="Top">

--- a/DS4Windows/DS4Forms/PresetOptionWindow.xaml
+++ b/DS4Windows/DS4Forms/PresetOptionWindow.xaml
@@ -17,18 +17,18 @@
     </Window.Resources>
     <DockPanel>
         <TabControl x:Name="screensTabControl" BorderBrush="{x:Null}">
-            <TabItem x:Name="IntroTab" Header="Intro">
+            <TabItem x:Name="IntroTab" Header="{lex:Loc Intro}">
                 <DockPanel Margin="4,0,4,8">
                     <StackPanel Orientation="Horizontal" DockPanel.Dock="Bottom" HorizontalAlignment="Right">
-                        <Button x:Name="noPresetBtn" Content="No" MinWidth="60" Margin="0,0,20,0" TabIndex="0" Click="NoPresetBtn_Click" />
-                        <Button x:Name="yesPresetBtn" Content="Yes" MinWidth="60" TabIndex="1" Click="YesPresetBtn_Click" />
+                        <Button x:Name="noPresetBtn" Content="{lex:Loc No}" MinWidth="60" Margin="0,0,20,0" TabIndex="0" Click="NoPresetBtn_Click" />
+                        <Button x:Name="yesPresetBtn" Content="{lex:Loc Yes}" MinWidth="60" TabIndex="1" Click="YesPresetBtn_Click" />
                     </StackPanel>
                     <StackPanel>
                         <TextBlock Text="{lex:Loc PresetIntrotext}" TextWrapping="Wrap" />
                     </StackPanel>
                 </DockPanel>
             </TabItem>
-            <TabItem x:Name="PresetListTab" Header="Preset Menu">
+            <TabItem x:Name="PresetListTab" Header="{lex:Loc PresetMenu}">
                 <DockPanel Margin="4,0,4,8">
                     <StackPanel Orientation="Horizontal" DockPanel.Dock="Top">
                         <Label Content="{lex:Loc Presets}" />
@@ -41,7 +41,7 @@
                         </ComboBox>
                     </StackPanel>
                     <StackPanel x:Name="outputContStackPanel" Orientation="Horizontal" DockPanel.Dock="Top" Visibility="{Binding PresetDisplayOutputCont, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}" Margin="0,10,0,10">
-                        <Label Content="Output Controller:" />
+                        <Label Content="{lex:Loc OutputController}" />
                         <ComboBox ItemsSource="{Binding OutputChoices}" DisplayMemberPath="DisplayName" SelectedValuePath="ChoiceValue" SelectedValue="{Binding ControllerChoice}" Margin="8,0,0,0" />
                     </StackPanel>
                     <StackPanel Orientation="Horizontal" DockPanel.Dock="Bottom" HorizontalAlignment="Right">

--- a/DS4Windows/DS4Forms/ProfileEditor.xaml
+++ b/DS4Windows/DS4Forms/ProfileEditor.xaml
@@ -21,7 +21,7 @@
             <Button x:Name="saveBtn" Content="{lex:Loc SaveProfile}" Margin="10,0,0,0" Click="SaveBtn_Click" />
             <Button x:Name="cancelBtn" Content="{lex:Loc Cancel}" Margin="10,0,0,0" Click="CancelBtn_Click" />
             <Button x:Name="applyBtn" Content="{lex:Loc Apply}" Margin="10,0,0,0" Click="ApplyBtn_Click" IsEnabled="False" />
-            <Button x:Name="presetBtn" Content="Select Preset" Margin="10,0,0,0" Click="PresetBtn_Click" />
+            <Button x:Name="presetBtn" Content="{lex:Loc SelectPreset}" Margin="10,0,0,0" Click="PresetBtn_Click" />
             <Button x:Name="keepSizeBtn" Margin="10,0,0,0" Click="KeepSizeBtn_Click">
                 <StackPanel Orientation="Horizontal" Margin="0">
                     <Image x:Name="sizeImage" Source="/DS4Windows;component/Resources/size.png" Width="20" Height="20"/>
@@ -31,7 +31,7 @@
             </Button>
         </StackPanel>
         <TabControl x:Name="sidebarTabControl" Width="460" DockPanel.Dock="Left" SelectionChanged="SidebarTabControl_SelectionChanged">
-            <TabItem Header="Controls">
+            <TabItem Header="{lex:Loc Controls}">
                 <DockPanel Width="440" LastChildFill="False">
                     <DockPanel.Background>
                         <SolidColorBrush Color="DimGray"/>
@@ -39,57 +39,57 @@
                     <Canvas x:Name="conCanvas" Width="440" Height="240" Margin="0,10,0,0" DockPanel.Dock="Top" >
                         <Canvas.Resources>
                             <ContextMenu x:Key="presetMenu">
-                                <MenuItem x:Name="controlNameItem" Header="Name" IsEnabled="False" />
+                                <MenuItem x:Name="controlNameItem" Header="{lex:Loc Name}" IsEnabled="False" />
                                 <Separator />
-                                <MenuItem Header="Default" Tag="0" Click="PresetMenuItem_Click" />
-                                <MenuItem Header="DPad">
-                                    <MenuItem Header="Normal" Tag="1" CommandParameter="0" Click="PresetMenuItem_Click" />
-                                    <MenuItem Header="Inverted" Tag="1" CommandParameter="1" Click="PresetMenuItem_Click" />
-                                    <MenuItem Header="Inverted X" Tag="1" CommandParameter="2" Click="PresetMenuItem_Click" />
-                                    <MenuItem Header="Inverted Y" Tag="1" CommandParameter="3" Click="PresetMenuItem_Click" />
-                                    <MenuItem Header="Rotate 90&#xb0;" Tag="1" CommandParameter="4" Click="PresetMenuItem_Click" />
-                                    <MenuItem Header="Rotate -90&#xb0;" Tag="1" CommandParameter="5" Click="PresetMenuItem_Click" />
+                                <MenuItem Header="{lex:Loc Default}" Tag="0" Click="PresetMenuItem_Click" />
+                                <MenuItem Header="{lex:Loc DPad}">
+                                    <MenuItem Header="{lex:Loc Normal}" Tag="1" CommandParameter="0" Click="PresetMenuItem_Click" />
+                                    <MenuItem Header="{lex:Loc Inverted}" Tag="1" CommandParameter="1" Click="PresetMenuItem_Click" />
+                                    <MenuItem Header="{lex:Loc InvertedX}" Tag="1" CommandParameter="2" Click="PresetMenuItem_Click" />
+                                    <MenuItem Header="{lex:Loc InvertedY}" Tag="1" CommandParameter="3" Click="PresetMenuItem_Click" />
+                                    <MenuItem Header="{lex:Loc Rotate90}" Tag="1" CommandParameter="4" Click="PresetMenuItem_Click" />
+                                    <MenuItem Header="{lex:Loc Rotate-90}" Tag="1" CommandParameter="5" Click="PresetMenuItem_Click" />
                                 </MenuItem>
-                                <MenuItem Header="Left Stick">
-                                    <MenuItem Header="Normal" Tag="2" CommandParameter="0" Click="PresetMenuItem_Click" />
-                                    <MenuItem Header="Inverted" Tag="2" CommandParameter="1" Click="PresetMenuItem_Click" />
-                                    <MenuItem Header="Inverted X" Tag="2" CommandParameter="2" Click="PresetMenuItem_Click" />
-                                    <MenuItem Header="Inverted Y" Tag="2" CommandParameter="3" Click="PresetMenuItem_Click" />
-                                    <MenuItem Header="Rotate 90&#xb0;" Tag="2" CommandParameter="4" Click="PresetMenuItem_Click" />
-                                    <MenuItem Header="Rotate -90&#xb0;" Tag="2" CommandParameter="5" Click="PresetMenuItem_Click" />
+                                <MenuItem Header="{lex:Loc LeftStick}">
+                                    <MenuItem Header="{lex:Loc Normal}" Tag="2" CommandParameter="0" Click="PresetMenuItem_Click" />
+                                    <MenuItem Header="{lex:Loc Inverted}" Tag="2" CommandParameter="1" Click="PresetMenuItem_Click" />
+                                    <MenuItem Header="{lex:Loc InvertedX}" Tag="2" CommandParameter="2" Click="PresetMenuItem_Click" />
+                                    <MenuItem Header="{lex:Loc InvertedY}" Tag="2" CommandParameter="3" Click="PresetMenuItem_Click" />
+                                    <MenuItem Header="{lex:Loc Rotate90}" Tag="2" CommandParameter="4" Click="PresetMenuItem_Click" />
+                                    <MenuItem Header="{lex:Loc Rotate-90}" Tag="2" CommandParameter="5" Click="PresetMenuItem_Click" />
                                 </MenuItem>
-                                <MenuItem Header="Right Stick">
-                                    <MenuItem Header="Normal" Tag="3" CommandParameter="0" Click="PresetMenuItem_Click" />
-                                    <MenuItem Header="Inverted" Tag="3" CommandParameter="1" Click="PresetMenuItem_Click" />
-                                    <MenuItem Header="Inverted X" Tag="3" CommandParameter="2" Click="PresetMenuItem_Click" />
-                                    <MenuItem Header="Inverted Y" Tag="3" CommandParameter="3" Click="PresetMenuItem_Click" />
-                                    <MenuItem Header="Rotate 90&#xb0;" Tag="3" CommandParameter="4" Click="PresetMenuItem_Click" />
-                                    <MenuItem Header="Rotate -90&#xb0;" Tag="3" CommandParameter="5" Click="PresetMenuItem_Click" />
+                                <MenuItem Header="{lex:Loc RightStick}">
+                                    <MenuItem Header="{lex:Loc Normal}" Tag="3" CommandParameter="0" Click="PresetMenuItem_Click" />
+                                    <MenuItem Header="{lex:Loc Inverted}" Tag="3" CommandParameter="1" Click="PresetMenuItem_Click" />
+                                    <MenuItem Header="{lex:Loc InvertedX}" Tag="3" CommandParameter="2" Click="PresetMenuItem_Click" />
+                                    <MenuItem Header="{lex:Loc InvertedY}" Tag="3" CommandParameter="3" Click="PresetMenuItem_Click" />
+                                    <MenuItem Header="{lex:Loc Rotate90}" Tag="3" CommandParameter="4" Click="PresetMenuItem_Click" />
+                                    <MenuItem Header="{lex:Loc Rotate-90}" Tag="3" CommandParameter="5" Click="PresetMenuItem_Click" />
                                 </MenuItem>
-                                <MenuItem Header="Face Buttons">
-                                    <MenuItem Header="Normal" Tag="4" CommandParameter="0" Click="PresetMenuItem_Click" />
-                                    <MenuItem Header="Rotate 90&#xb0;" Tag="4" CommandParameter="1" Click="PresetMenuItem_Click" />
-                                    <MenuItem Header="Rotate -90&#xb0;" Tag="4" CommandParameter="2" Click="PresetMenuItem_Click" />
+                                <MenuItem Header="{lex:Loc FaceButtons}">
+                                    <MenuItem Header="{lex:Loc Normal}" Tag="4" CommandParameter="0" Click="PresetMenuItem_Click" />
+                                    <MenuItem Header="{lex:Loc Rotate90}" Tag="4" CommandParameter="1" Click="PresetMenuItem_Click" />
+                                    <MenuItem Header="{lex:Loc Rotate-90}" Tag="4" CommandParameter="2" Click="PresetMenuItem_Click" />
                                 </MenuItem>
-                                <MenuItem Header="WASD">
-                                    <MenuItem Header="Normal" Tag="5" CommandParameter="0" Click="PresetMenuItem_Click" />
-                                    <MenuItem Header="Rotate 90&#xb0;" Tag="5" CommandParameter="1" Click="PresetMenuItem_Click" />
-                                    <MenuItem Header="Rotate -90&#xb0;" Tag="5" CommandParameter="2" Click="PresetMenuItem_Click" />
+                                <MenuItem Header="{lex:Loc WASD}">
+                                    <MenuItem Header="{lex:Loc Normal}" Tag="5" CommandParameter="0" Click="PresetMenuItem_Click" />
+                                    <MenuItem Header="{lex:Loc Rotate90}" Tag="5" CommandParameter="1" Click="PresetMenuItem_Click" />
+                                    <MenuItem Header="{lex:Loc Rotate-90}" Tag="5" CommandParameter="2" Click="PresetMenuItem_Click" />
                                 </MenuItem>
-                                <MenuItem Header="Arrow Keys">
-                                    <MenuItem Header="Normal" Tag="6" CommandParameter="0" Click="PresetMenuItem_Click" />
-                                    <MenuItem Header="Rotate 90&#xb0;" Tag="6" CommandParameter="1" Click="PresetMenuItem_Click" />
-                                    <MenuItem Header="Rotate -90&#xb0;" Tag="6" CommandParameter="2" Click="PresetMenuItem_Click" />
+                                <MenuItem Header="{lex:Loc ArrowKeys}">
+                                    <MenuItem Header="{lex:Loc Normal}" Tag="6" CommandParameter="0" Click="PresetMenuItem_Click" />
+                                    <MenuItem Header="{lex:Loc Rotate90}" Tag="6" CommandParameter="1" Click="PresetMenuItem_Click" />
+                                    <MenuItem Header="{lex:Loc Rotate-90}" Tag="6" CommandParameter="2" Click="PresetMenuItem_Click" />
                                 </MenuItem>
-                                <MenuItem Header="Mouse">
-                                    <MenuItem Header="Normal" Tag="7" CommandParameter="0" Click="PresetMenuItem_Click" />
-                                    <MenuItem Header="Inverted" Tag="7" CommandParameter="1" Click="PresetMenuItem_Click" />
-                                    <MenuItem Header="Inverted X" Tag="7" CommandParameter="2" Click="PresetMenuItem_Click" />
-                                    <MenuItem Header="Inverted Y" Tag="7" CommandParameter="3" Click="PresetMenuItem_Click" />
-                                    <MenuItem Header="Rotate 90&#xb0;" Tag="7" CommandParameter="4" Click="PresetMenuItem_Click" />
-                                    <MenuItem Header="Rotate -90&#xb0;" Tag="7" CommandParameter="5" Click="PresetMenuItem_Click" />
+                                <MenuItem Header="{lex:Loc Mouse}">
+                                    <MenuItem Header="{lex:Loc Normal}" Tag="7" CommandParameter="0" Click="PresetMenuItem_Click" />
+                                    <MenuItem Header="{lex:Loc Inverted}" Tag="7" CommandParameter="1" Click="PresetMenuItem_Click" />
+                                    <MenuItem Header="{lex:Loc InvertedX}" Tag="7" CommandParameter="2" Click="PresetMenuItem_Click" />
+                                    <MenuItem Header="{lex:Loc InvertedY}" Tag="7" CommandParameter="3" Click="PresetMenuItem_Click" />
+                                    <MenuItem Header="{lex:Loc Rotate90}" Tag="7" CommandParameter="4" Click="PresetMenuItem_Click" />
+                                    <MenuItem Header="{lex:Loc Rotate-90}" Tag="7" CommandParameter="5" Click="PresetMenuItem_Click" />
                                 </MenuItem>
-                                <MenuItem Header="Unbound" Tag="8" Click="PresetMenuItem_Click" />
+                                <MenuItem Header="{lex:Loc Unbound}" Tag="8" Click="PresetMenuItem_Click" />
                             </ContextMenu>
                         </Canvas.Resources>
 
@@ -126,55 +126,55 @@
                         <Image x:Name="picBoxHover" IsEnabled="False" Source="/DS4Windows;component/Resources/DS4-Config_RS.png" Height="48" Width="48" Canvas.Left="447" Canvas.Top="5" />
                         <Image x:Name="picBoxHover2" IsEnabled="False" Source="/DS4Windows;component/Resources/DS4-Config_RS.png" Height="48" Width="48" Canvas.Left="0" Canvas.Top="0" Stretch="Fill" />
 
-                        <Button Content="Cross" x:Name="crossConBtn" Canvas.Left="330" Canvas.Top="125" Width="26" Height="26" Click="HoverConBtn_Click" Style="{StaticResource NoBGHoverBtn}" MouseEnter="ContBtn_MouseEnter" MouseLeave="ContBtn_MouseLeave" MouseRightButtonUp="ConBtn_MouseRightButtonUp" />
-                        <Button Content="Circle" x:Name="circleConBtn" Canvas.Left="357" Canvas.Top="99" Width="26" Height="26" Style="{StaticResource NoBGHoverBtn}" Click="HoverConBtn_Click" MouseEnter="ContBtn_MouseEnter" MouseLeave="ContBtn_MouseLeave" MouseRightButtonUp="ConBtn_MouseRightButtonUp" />
-                        <Button Content="Square" x:Name="squareConBtn" Canvas.Left="300" Canvas.Top="98" Width="26" Height="26" Style="{StaticResource NoBGHoverBtn}" Click="HoverConBtn_Click" MouseEnter="ContBtn_MouseEnter" MouseLeave="ContBtn_MouseLeave" MouseRightButtonUp="ConBtn_MouseRightButtonUp" />
-                        <Button Content="Triangle" x:Name="triangleConBtn" Canvas.Left="330" Canvas.Top="74" Width="26" Height="26" Style="{StaticResource NoBGHoverBtn}" Click="HoverConBtn_Click" MouseEnter="ContBtn_MouseEnter" MouseLeave="ContBtn_MouseLeave" MouseRightButtonUp="ConBtn_MouseRightButtonUp" />
+                        <Button Content="{lex:Loc Cross}" x:Name="crossConBtn" Canvas.Left="330" Canvas.Top="125" Width="26" Height="26" Click="HoverConBtn_Click" Style="{StaticResource NoBGHoverBtn}" MouseEnter="ContBtn_MouseEnter" MouseLeave="ContBtn_MouseLeave" MouseRightButtonUp="ConBtn_MouseRightButtonUp" />
+                        <Button Content="{lex:Loc Circle}" x:Name="circleConBtn" Canvas.Left="357" Canvas.Top="99" Width="26" Height="26" Style="{StaticResource NoBGHoverBtn}" Click="HoverConBtn_Click" MouseEnter="ContBtn_MouseEnter" MouseLeave="ContBtn_MouseLeave" MouseRightButtonUp="ConBtn_MouseRightButtonUp" />
+                        <Button Content="{lex:Loc Square}" x:Name="squareConBtn" Canvas.Left="300" Canvas.Top="98" Width="26" Height="26" Style="{StaticResource NoBGHoverBtn}" Click="HoverConBtn_Click" MouseEnter="ContBtn_MouseEnter" MouseLeave="ContBtn_MouseLeave" MouseRightButtonUp="ConBtn_MouseRightButtonUp" />
+                        <Button Content="{lex:Loc Triangle}" x:Name="triangleConBtn" Canvas.Left="330" Canvas.Top="74" Width="26" Height="26" Style="{StaticResource NoBGHoverBtn}" Click="HoverConBtn_Click" MouseEnter="ContBtn_MouseEnter" MouseLeave="ContBtn_MouseLeave" MouseRightButtonUp="ConBtn_MouseRightButtonUp" />
 
-                        <Button Content="L1" x:Name="l1ConBtn" Canvas.Left="75" Canvas.Top="22" Width="50" Height="18" Style="{StaticResource NoBGHoverBtn}" Click="HoverConBtn_Click" MouseEnter="ContBtn_MouseEnter" MouseLeave="ContBtn_MouseLeave" />
-                        <Button Content="R1" x:Name="r1ConBtn" Canvas.Left="317" Canvas.Top="22" Width="50" Height="18" Style="{StaticResource NoBGHoverBtn}" Click="HoverConBtn_Click" MouseEnter="ContBtn_MouseEnter" MouseLeave="ContBtn_MouseLeave" />
-                        <Button Content="L2" x:Name="l2ConBtn" Canvas.Left="78" Canvas.Top="0" Width="46" Height="20" Style="{StaticResource NoBGHoverBtn}" Click="HoverConBtn_Click" MouseEnter="ContBtn_MouseEnter" MouseLeave="ContBtn_MouseLeave" />
-                        <Button Content="R2" x:Name="r2ConBtn" Canvas.Left="316" Canvas.Top="0" Width="46" Height="20" Style="{StaticResource NoBGHoverBtn}" Click="HoverConBtn_Click" MouseEnter="ContBtn_MouseEnter" MouseLeave="ContBtn_MouseLeave" />
+                        <Button Content="{lex:Loc L1}" x:Name="l1ConBtn" Canvas.Left="75" Canvas.Top="22" Width="50" Height="18" Style="{StaticResource NoBGHoverBtn}" Click="HoverConBtn_Click" MouseEnter="ContBtn_MouseEnter" MouseLeave="ContBtn_MouseLeave" />
+                        <Button Content="{lex:Loc R1}" x:Name="r1ConBtn" Canvas.Left="317" Canvas.Top="22" Width="50" Height="18" Style="{StaticResource NoBGHoverBtn}" Click="HoverConBtn_Click" MouseEnter="ContBtn_MouseEnter" MouseLeave="ContBtn_MouseLeave" />
+                        <Button Content="{lex:Loc L2}" x:Name="l2ConBtn" Canvas.Left="78" Canvas.Top="0" Width="46" Height="20" Style="{StaticResource NoBGHoverBtn}" Click="HoverConBtn_Click" MouseEnter="ContBtn_MouseEnter" MouseLeave="ContBtn_MouseLeave" />
+                        <Button Content="{lex:Loc R2}" x:Name="r2ConBtn" Canvas.Left="316" Canvas.Top="0" Width="46" Height="20" Style="{StaticResource NoBGHoverBtn}" Click="HoverConBtn_Click" MouseEnter="ContBtn_MouseEnter" MouseLeave="ContBtn_MouseLeave" />
 
-                        <Button Content="Share" x:Name="shareConBtn" Canvas.Left="134" Canvas.Top="63" Width="16" Height="24" Style="{StaticResource NoBGHoverBtn}" Click="HoverConBtn_Click" MouseEnter="ContBtn_MouseEnter" MouseLeave="ContBtn_MouseLeave" />
-                        <Button Content="Options" x:Name="optionsConBtn" Canvas.Left="291" Canvas.Top="63" Width="16" Height="24" Style="{StaticResource NoBGHoverBtn}" Click="HoverConBtn_Click" MouseEnter="ContBtn_MouseEnter" MouseLeave="ContBtn_MouseLeave" />
-                        <Button Content="Guide" x:Name="guideConBtn" Canvas.Left="211" Canvas.Top="144" Width="20" Height="20" Style="{StaticResource NoBGHoverBtn}" Click="HoverConBtn_Click" MouseEnter="ContBtn_MouseEnter" MouseLeave="ContBtn_MouseLeave" />
-                        <Button Content="Mute" x:Name="muteConBtn" Canvas.Left="0" Canvas.Top="0" Width="0" Height="0" Style="{StaticResource NoBGHoverBtn}" Visibility="Collapsed" />
+                        <Button Content="{lex:Loc Share}" x:Name="shareConBtn" Canvas.Left="134" Canvas.Top="63" Width="16" Height="24" Style="{StaticResource NoBGHoverBtn}" Click="HoverConBtn_Click" MouseEnter="ContBtn_MouseEnter" MouseLeave="ContBtn_MouseLeave" />
+                        <Button Content="{lex:Loc Options}" x:Name="optionsConBtn" Canvas.Left="291" Canvas.Top="63" Width="16" Height="24" Style="{StaticResource NoBGHoverBtn}" Click="HoverConBtn_Click" MouseEnter="ContBtn_MouseEnter" MouseLeave="ContBtn_MouseLeave" />
+                        <Button Content="{lex:Loc Guide}" x:Name="guideConBtn" Canvas.Left="211" Canvas.Top="144" Width="20" Height="20" Style="{StaticResource NoBGHoverBtn}" Click="HoverConBtn_Click" MouseEnter="ContBtn_MouseEnter" MouseLeave="ContBtn_MouseLeave" />
+                        <Button Content="{lex:Loc Mute}" x:Name="muteConBtn" Canvas.Left="0" Canvas.Top="0" Width="0" Height="0" Style="{StaticResource NoBGHoverBtn}" Visibility="Collapsed" />
 
-                        <Button Content="Left Touch" x:Name="leftTouchConBtn" Canvas.Left="158" Canvas.Top="69" Width="37" Height="51" Style="{StaticResource NoBGHoverBtn}" Click="HoverConBtn_Click" MouseEnter="ContBtn_MouseEnter" MouseLeave="ContBtn_MouseLeave" />
-                        <Button Content="Multi Touch" x:Name="multiTouchConBtn" Canvas.Left="199" Canvas.Top="74" Width="41" Height="45" Style="{StaticResource NoBGHoverBtn}" Click="HoverConBtn_Click" MouseEnter="ContBtn_MouseEnter" MouseLeave="ContBtn_MouseLeave" />
-                        <Button Content="Right Touch" x:Name="rightTouchConBtn" Canvas.Left="251" Canvas.Top="70" Width="32" Height="53" Style="{StaticResource NoBGHoverBtn}" Click="HoverConBtn_Click" MouseEnter="ContBtn_MouseEnter" MouseLeave="ContBtn_MouseLeave" />
-                        <Button Content="Top Touch" x:Name="topTouchConBtn" Canvas.Left="157" Canvas.Top="46" Width="125" Height="23" Style="{StaticResource NoBGHoverBtn}" Click="HoverConBtn_Click" MouseEnter="ContBtn_MouseEnter" MouseLeave="ContBtn_MouseLeave" />
+                        <Button Content="{lex:Loc LeftTouch}" x:Name="leftTouchConBtn" Canvas.Left="158" Canvas.Top="69" Width="37" Height="51" Style="{StaticResource NoBGHoverBtn}" Click="HoverConBtn_Click" MouseEnter="ContBtn_MouseEnter" MouseLeave="ContBtn_MouseLeave" />
+                        <Button Content="{lex:Loc Multi_Touch}" x:Name="multiTouchConBtn" Canvas.Left="199" Canvas.Top="74" Width="41" Height="45" Style="{StaticResource NoBGHoverBtn}" Click="HoverConBtn_Click" MouseEnter="ContBtn_MouseEnter" MouseLeave="ContBtn_MouseLeave" />
+                        <Button Content="{lex:Loc RightTouch}" x:Name="rightTouchConBtn" Canvas.Left="251" Canvas.Top="70" Width="32" Height="53" Style="{StaticResource NoBGHoverBtn}" Click="HoverConBtn_Click" MouseEnter="ContBtn_MouseEnter" MouseLeave="ContBtn_MouseLeave" />
+                        <Button Content="{lex:Loc TopTouch}" x:Name="topTouchConBtn" Canvas.Left="157" Canvas.Top="46" Width="125" Height="23" Style="{StaticResource NoBGHoverBtn}" Click="HoverConBtn_Click" MouseEnter="ContBtn_MouseEnter" MouseLeave="ContBtn_MouseLeave" />
 
-                        <Button Content="L3" x:Name="l3ConBtn" Canvas.Left="138" Canvas.Top="147" Width="42" Height="42" Style="{StaticResource NoBGHoverBtn}" Click="HoverConBtn_Click" MouseEnter="ContBtn_MouseEnter" MouseLeave="ContBtn_MouseLeave"
+                        <Button Content="{lex:Loc L3}" x:Name="l3ConBtn" Canvas.Left="138" Canvas.Top="147" Width="42" Height="42" Style="{StaticResource NoBGHoverBtn}" Click="HoverConBtn_Click" MouseEnter="ContBtn_MouseEnter" MouseLeave="ContBtn_MouseLeave"
                                 MouseRightButtonUp="ConBtn_MouseRightButtonUp" />
-                        <Button Content="LSU" x:Name="lsuConBtn" Canvas.Left="150" Canvas.Top="140" Width="17" Height="15" Style="{StaticResource NoBGHoverBtn}" Click="HoverConBtn_Click" MouseEnter="ContBtn_MouseEnter" MouseLeave="ContBtn_MouseLeave"
+                        <Button Content="{lex:Loc LSU}" x:Name="lsuConBtn" Canvas.Left="150" Canvas.Top="140" Width="17" Height="15" Style="{StaticResource NoBGHoverBtn}" Click="HoverConBtn_Click" MouseEnter="ContBtn_MouseEnter" MouseLeave="ContBtn_MouseLeave"
                                 MouseRightButtonUp="ConBtn_MouseRightButtonUp" />
-                        <Button Content="LSR" x:Name="lsrConBtn" Canvas.Left="172" Canvas.Top="162" Width="17" Height="15" Style="{StaticResource NoBGHoverBtn}" Click="HoverConBtn_Click" MouseEnter="ContBtn_MouseEnter" MouseLeave="ContBtn_MouseLeave"
+                        <Button Content="{lex:Loc LSR}" x:Name="lsrConBtn" Canvas.Left="172" Canvas.Top="162" Width="17" Height="15" Style="{StaticResource NoBGHoverBtn}" Click="HoverConBtn_Click" MouseEnter="ContBtn_MouseEnter" MouseLeave="ContBtn_MouseLeave"
                                 MouseRightButtonUp="ConBtn_MouseRightButtonUp" />
-                        <Button Content="LSD" x:Name="lsdConBtn" Canvas.Left="150" Canvas.Top="180" Width="17" Height="15" Style="{StaticResource NoBGHoverBtn}" Click="HoverConBtn_Click" MouseEnter="ContBtn_MouseEnter" MouseLeave="ContBtn_MouseLeave"
+                        <Button Content="{lex:Loc LSD}" x:Name="lsdConBtn" Canvas.Left="150" Canvas.Top="180" Width="17" Height="15" Style="{StaticResource NoBGHoverBtn}" Click="HoverConBtn_Click" MouseEnter="ContBtn_MouseEnter" MouseLeave="ContBtn_MouseLeave"
                                 MouseRightButtonUp="ConBtn_MouseRightButtonUp" />
-                        <Button Content="LSL" x:Name="lslConBtn" Canvas.Left="126" Canvas.Top="162" Width="17" Height="15" Style="{StaticResource NoBGHoverBtn}" Click="HoverConBtn_Click" MouseEnter="ContBtn_MouseEnter" MouseLeave="ContBtn_MouseLeave"
-                                MouseRightButtonUp="ConBtn_MouseRightButtonUp" />
-
-                        <Button Content="R3" x:Name="r3ConBtn" Canvas.Left="262" Canvas.Top="149" Width="42" Height="42" Style="{StaticResource NoBGHoverBtn}" Click="HoverConBtn_Click" MouseEnter="ContBtn_MouseEnter" MouseLeave="ContBtn_MouseLeave"
-                                MouseRightButtonUp="ConBtn_MouseRightButtonUp" />
-                        <Button Content="RSU" x:Name="rsuConBtn" Canvas.Left="275" Canvas.Top="142" Width="17" Height="15" Style="{StaticResource NoBGHoverBtn}" Click="HoverConBtn_Click" MouseEnter="ContBtn_MouseEnter" MouseLeave="ContBtn_MouseLeave"
-                                MouseRightButtonUp="ConBtn_MouseRightButtonUp" />
-                        <Button Content="RSR" x:Name="rsrConBtn" Canvas.Left="298" Canvas.Top="162" Width="17" Height="15" Style="{StaticResource NoBGHoverBtn}" Click="HoverConBtn_Click" MouseEnter="ContBtn_MouseEnter" MouseLeave="ContBtn_MouseLeave"
-                                MouseRightButtonUp="ConBtn_MouseRightButtonUp" />
-                        <Button Content="RSD" x:Name="rsdConBtn" Canvas.Left="275" Canvas.Top="180" Width="17" Height="15" Style="{StaticResource NoBGHoverBtn}" Click="HoverConBtn_Click" MouseEnter="ContBtn_MouseEnter" MouseLeave="ContBtn_MouseLeave"
-                                MouseRightButtonUp="ConBtn_MouseRightButtonUp" />
-                        <Button Content="RSL" x:Name="rslConBtn" Canvas.Left="248" Canvas.Top="162" Width="17" Height="15" Style="{StaticResource NoBGHoverBtn}" Click="HoverConBtn_Click" MouseEnter="ContBtn_MouseEnter" MouseLeave="ContBtn_MouseLeave"
+                        <Button Content="{lex:Loc LSL}" x:Name="lslConBtn" Canvas.Left="126" Canvas.Top="162" Width="17" Height="15" Style="{StaticResource NoBGHoverBtn}" Click="HoverConBtn_Click" MouseEnter="ContBtn_MouseEnter" MouseLeave="ContBtn_MouseLeave"
                                 MouseRightButtonUp="ConBtn_MouseRightButtonUp" />
 
-                        <Button Content="Up" x:Name="upConBtn" Canvas.Left="88" Canvas.Top="74" Width="20" Height="35" Style="{StaticResource NoBGHoverBtn}" Click="HoverConBtn_Click" MouseEnter="ContBtn_MouseEnter" MouseLeave="ContBtn_MouseLeave"
+                        <Button Content="{lex:Loc R3}" x:Name="r3ConBtn" Canvas.Left="262" Canvas.Top="149" Width="42" Height="42" Style="{StaticResource NoBGHoverBtn}" Click="HoverConBtn_Click" MouseEnter="ContBtn_MouseEnter" MouseLeave="ContBtn_MouseLeave"
                                 MouseRightButtonUp="ConBtn_MouseRightButtonUp" />
-                        <Button Content="Right" x:Name="rightConBtn" Canvas.Left="103" Canvas.Top="103" Width="35" Height="20" Style="{StaticResource NoBGHoverBtn}" Click="HoverConBtn_Click" MouseEnter="ContBtn_MouseEnter" MouseLeave="ContBtn_MouseLeave"
+                        <Button Content="{lex:Loc RSU}" x:Name="rsuConBtn" Canvas.Left="275" Canvas.Top="142" Width="17" Height="15" Style="{StaticResource NoBGHoverBtn}" Click="HoverConBtn_Click" MouseEnter="ContBtn_MouseEnter" MouseLeave="ContBtn_MouseLeave"
                                 MouseRightButtonUp="ConBtn_MouseRightButtonUp" />
-                        <Button Content="Down" x:Name="downConBtn" Canvas.Left="88" Canvas.Top="114" Width="20" Height="35" Style="{StaticResource NoBGHoverBtn}" Click="HoverConBtn_Click" MouseEnter="ContBtn_MouseEnter" MouseLeave="ContBtn_MouseLeave"
+                        <Button Content="{lex:Loc RSR}" x:Name="rsrConBtn" Canvas.Left="298" Canvas.Top="162" Width="17" Height="15" Style="{StaticResource NoBGHoverBtn}" Click="HoverConBtn_Click" MouseEnter="ContBtn_MouseEnter" MouseLeave="ContBtn_MouseLeave"
                                 MouseRightButtonUp="ConBtn_MouseRightButtonUp" />
-                        <Button Content="Left" x:Name="leftConBtn" Canvas.Left="56" Canvas.Top="103" Width="35" Height="20" Style="{StaticResource NoBGHoverBtn}" Click="HoverConBtn_Click" MouseEnter="ContBtn_MouseEnter" MouseLeave="ContBtn_MouseLeave"
+                        <Button Content="{lex:Loc RSD}" x:Name="rsdConBtn" Canvas.Left="275" Canvas.Top="180" Width="17" Height="15" Style="{StaticResource NoBGHoverBtn}" Click="HoverConBtn_Click" MouseEnter="ContBtn_MouseEnter" MouseLeave="ContBtn_MouseLeave"
+                                MouseRightButtonUp="ConBtn_MouseRightButtonUp" />
+                        <Button Content="{lex:Loc RSL}" x:Name="rslConBtn" Canvas.Left="248" Canvas.Top="162" Width="17" Height="15" Style="{StaticResource NoBGHoverBtn}" Click="HoverConBtn_Click" MouseEnter="ContBtn_MouseEnter" MouseLeave="ContBtn_MouseLeave"
+                                MouseRightButtonUp="ConBtn_MouseRightButtonUp" />
+
+                        <Button Content="{lex:Loc Up}" x:Name="upConBtn" Canvas.Left="88" Canvas.Top="74" Width="20" Height="35" Style="{StaticResource NoBGHoverBtn}" Click="HoverConBtn_Click" MouseEnter="ContBtn_MouseEnter" MouseLeave="ContBtn_MouseLeave"
+                                MouseRightButtonUp="ConBtn_MouseRightButtonUp" />
+                        <Button Content="{lex:Loc Right}" x:Name="rightConBtn" Canvas.Left="103" Canvas.Top="103" Width="35" Height="20" Style="{StaticResource NoBGHoverBtn}" Click="HoverConBtn_Click" MouseEnter="ContBtn_MouseEnter" MouseLeave="ContBtn_MouseLeave"
+                                MouseRightButtonUp="ConBtn_MouseRightButtonUp" />
+                        <Button Content="{lex:Loc Down}" x:Name="downConBtn" Canvas.Left="88" Canvas.Top="114" Width="20" Height="35" Style="{StaticResource NoBGHoverBtn}" Click="HoverConBtn_Click" MouseEnter="ContBtn_MouseEnter" MouseLeave="ContBtn_MouseLeave"
+                                MouseRightButtonUp="ConBtn_MouseRightButtonUp" />
+                        <Button Content="{lex:Loc Left}" x:Name="leftConBtn" Canvas.Left="56" Canvas.Top="103" Width="35" Height="20" Style="{StaticResource NoBGHoverBtn}" Click="HoverConBtn_Click" MouseEnter="ContBtn_MouseEnter" MouseLeave="ContBtn_MouseLeave"
                                 MouseRightButtonUp="ConBtn_MouseRightButtonUp" />
 
                         <Label x:Name="highlightControlDisplayLb" Content="" Canvas.Left="150" Canvas.Top="208" MinWidth="150"
@@ -199,7 +199,7 @@
                     </ListBox>
                 </DockPanel>
             </TabItem>
-            <TabItem x:Name="specialActionsTab" Header="Special Actions">
+            <TabItem x:Name="specialActionsTab" Header="{lex:Loc SpecialActions}">
                 <DockPanel x:Name="specialActionDockPanel">
                     <DockPanel x:Name="baseSpeActPanel" DockPanel.Dock="Top">
                         <UniformGrid Rows="1" Columns="3" DockPanel.Dock="Top">
@@ -229,7 +229,7 @@
                     </DockPanel>
                 </DockPanel>
             </TabItem>
-            <TabItem x:Name="contReadingsTab" Header="Controller Readings" IsEnabled="False">
+            <TabItem x:Name="contReadingsTab" Header="{lex:Loc ControllerReadings}" IsEnabled="False">
                 <local:ControllerReadingsControl x:Name="conReadingsUserCon" />
             </TabItem>
         </TabControl>
@@ -239,7 +239,7 @@
                 <Thickness x:Key="spaceMargin" Bottom="8" />
             </TabControl.Resources>
 
-            <TabItem Header="Axis Config">
+            <TabItem Header="{lex:Loc AxisConfig}">
                 <TabItem.Resources>
                     <Thickness x:Key="spaceMargin" Left="10" Bottom="6" />
                     <Style x:Key="gridRowHeight" TargetType="{x:Type RowDefinition}">
@@ -248,10 +248,10 @@
                 </TabItem.Resources>
                 <ScrollViewer>
                     <StackPanel>
-                        <GroupBox Header="LS">
+                        <GroupBox Header="{lex:Loc LS}">
                             <StackPanel>
                                 <StackPanel Orientation="Horizontal">
-                                    <Label Content="Output Mode" />
+                                    <Label Content="{lex:Loc OutputMode}" />
                                     <ComboBox MinWidth="160" SelectedIndex="{Binding LSOutputIndex,FallbackValue='0'}" VerticalContentAlignment="Center" Margin="10,0,0,0">
                                         <ComboBoxItem Content="None" />
                                         <ComboBoxItem Content="Controls" />
@@ -260,11 +260,11 @@
                                 </StackPanel>
 
                                 <TabControl SelectedIndex="{Binding LSOutputIndex,Mode=OneWay,FallbackValue='0'}" BorderBrush="{x:Null}" Padding="0" Margin="0,10,0,0">
-                                    <TabItem Header="None"  Visibility="Collapsed" />
-                                    <TabItem Header="Controls" Visibility="Collapsed">
+                                    <TabItem Header="{lex:Loc None}"  Visibility="Collapsed" />
+                                    <TabItem Header="{lex:Loc Controls}" Visibility="Collapsed">
                                         <DockPanel>
                                             <StackPanel Orientation="Horizontal" DockPanel.Dock="Top">
-                                                <Label Content="Dead Zone Type" />
+                                                <Label Content="{lex:Loc DeadZoneType}" />
                                                 <ComboBox MinWidth="160" SelectedIndex="{Binding LSDeadTypeIndex,FallbackValue='0'}" VerticalContentAlignment="Center" Margin="10,0,0,0">
                                                     <ComboBoxItem Content="Radial" />
                                                     <ComboBoxItem Content="Axial" />
@@ -272,7 +272,7 @@
                                             </StackPanel>
 
                                             <TabControl DockPanel.Dock="Top" SelectedIndex="{Binding LSDeadTypeIndex,Mode=OneWay,FallbackValue='0'}" BorderBrush="{x:Null}" Padding="0" Margin="0,8,0,8">
-                                                <TabItem Header="Radial" Visibility="Collapsed">
+                                                <TabItem Header="{lex:Loc Radial}" Visibility="Collapsed">
                                                     <Grid>
                                                         <Grid.ColumnDefinitions>
                                                             <ColumnDefinition/>
@@ -287,34 +287,34 @@
                                                             <RowDefinition Style="{StaticResource gridRowHeight}" />
                                                         </Grid.RowDefinitions>
 
-                                                        <Label Content="Dead Zone:" Grid.Row="0" Grid.Column="0" />
+                                                        <Label Content="{lex:Loc DeadZone_}" Grid.Row="0" Grid.Column="0" />
                                                         <xctk:DoubleUpDown d:IsHidden="True" Value="{Binding LSDeadZone,UpdateSourceTrigger=LostFocus}" FormatString="F2" MinWidth="50" Grid.Row="0" Grid.Column="1" Maximum="1.0" Minimum="0.0" Increment="0.1"
                                                    Margin="{StaticResource spaceMargin}" />
 
-                                                        <Label Content="Max Zone:" Grid.Row="1" Grid.Column="0" />
+                                                        <Label Content="{lex:Loc MaxZone_}" Grid.Row="1" Grid.Column="0" />
                                                         <xctk:DoubleUpDown d:IsHidden="True" Value="{Binding LSMaxZone}" FormatString="F2" MinWidth="50" Grid.Row="1" Grid.Column="1" Maximum="1.0" Minimum="0.0" Increment="0.1"
                                                    Margin="{StaticResource spaceMargin}" />
 
-                                                        <Label Content="Anti-dead Zone:" Grid.Row="2" Grid.Column="0" />
+                                                        <Label Content="{lex:Loc AntiDeadZone}" Grid.Row="2" Grid.Column="0" />
                                                         <xctk:DoubleUpDown d:IsHidden="True" Value="{Binding LSAntiDeadZone}" FormatString="F2" MinWidth="50" Grid.Row="2" Grid.Column="1" Maximum="1.0" Minimum="0.0" Increment="0.1"
                                                    Margin="{StaticResource spaceMargin}" />
 
-                                                        <Label Content="Max Output:" Grid.Row="3" Grid.Column="0" />
+                                                        <Label Content="{lex:Loc MaxOutput_}" Grid.Row="3" Grid.Column="0" />
                                                         <xctk:DoubleUpDown d:IsHidden="True" Value="{Binding LSMaxOutput}" FormatString="F2" MinWidth="50" Grid.Row="3" Grid.Column="1" Maximum="1.0" Minimum="0.0" Increment="0.1"
                                                    Margin="{StaticResource spaceMargin}" />
 
-                                                        <Label Content="Vertical Scale:" Grid.Row="4" Grid.Column="0" />
+                                                        <Label Content="{lex:Loc VerticalScale_}" Grid.Row="4" Grid.Column="0" />
                                                         <xctk:DoubleUpDown d:IsHidden="True" Value="{Binding LSVerticalScale}" FormatString="F2" MinWidth="50" Grid.Row="4" Grid.Column="1" Maximum="2.0" Minimum="0.0" Increment="0.1"
                                                    Margin="{StaticResource spaceMargin}" />
 
-                                                        <Label Content="Sensitivity:" Grid.Row="5" Grid.Column="0" />
+                                                        <Label Content="{lex:Loc Sensitivity}" Grid.Row="5" Grid.Column="0" />
                                                         <xctk:DoubleUpDown d:IsHidden="True" FormatString="F2" Value="{Binding LSSens}" MinWidth="50" Grid.Row="5" Grid.Column="1" Maximum="5.0" Minimum="0.5" Increment="0.1"
                                                    Margin="{StaticResource spaceMargin}" />
 
                                                     </Grid>
                                                 </TabItem>
 
-                                                <TabItem Header="Axial" Visibility="Collapsed">
+                                                <TabItem Header="{lex:Loc Axial}" Visibility="Collapsed">
                                                     <local:AxialStickUserControl x:Name="axialLSStickControl" />
                                                 </TabItem>
                                             </TabControl>
@@ -334,8 +334,8 @@
                                                     <RowDefinition Style="{StaticResource gridRowHeight}" />
                                                     <RowDefinition Style="{StaticResource gridRowHeight}" />
                                                 </Grid.RowDefinitions>
-                                                
-                                                <Label Content="Output Curve:" Grid.Row="0" Grid.Column="0" />
+
+                                                <Label Content="{lex:Loc OutputCurve}" Grid.Row="0" Grid.Column="0" />
                                                 <ComboBox Grid.Row="0" Grid.Column="1" SelectedIndex="{Binding LSOutputCurveIndex}"
                                           Margin="{StaticResource spaceMargin}">
                                                     <ComboBoxItem Content="Linear" />
@@ -348,13 +348,13 @@
                                                 </ComboBox>
 
                                                 <DockPanel Grid.Row="1" Grid.Column="1" IsEnabled="{Binding LSCustomCurveSelected}">
-                                                    <Button x:Name="lsCustomEditorBtn" Content="..." Tag="LS" Width="20" DockPanel.Dock="Right" Click="CustomEditorBtn_Click"
+                                                    <Button x:Name="lsCustomEditorBtn" Content="{lex:Loc ...}" Tag="LS" Width="20" DockPanel.Dock="Right" Click="CustomEditorBtn_Click"
                                             Margin="{StaticResource spaceMargin}" />
                                                     <TextBox Text="{Binding LSCustomCurve,UpdateSourceTrigger=LostFocus,FallbackValue='0.00, 0.00, 1.00, 1.00'}" DockPanel.Dock="Left"
                                              Margin="{StaticResource spaceMargin}" />
                                                 </DockPanel>
 
-                                                <Label Content="Square Stick:" Grid.Row="2" Grid.Column="0" />
+                                                <Label Content="{lex:Loc SquareStick}" Grid.Row="2" Grid.Column="0" />
                                                 <StackPanel Orientation="Horizontal" Grid.Row="2" Grid.Column="1" HorizontalAlignment="Right">
                                                     <CheckBox IsChecked="{Binding LSSquareStick}" Margin="{StaticResource spaceMargin}" VerticalAlignment="Center" />
                                                     <xctk:DoubleUpDown d:IsHidden="True" FormatString="F1" Value="{Binding LSSquareRoundness,FallbackValue=5}"
@@ -362,14 +362,14 @@
                                                        Margin="{StaticResource spaceMargin}" />
                                                 </StackPanel>
 
-                                                <Label Content="Curve (Input):" Grid.Row="3" Grid.Column="0" />
+                                                <Label Content="{lex:Loc CurveInput}" Grid.Row="3" Grid.Column="0" />
                                                 <StackPanel Orientation="Horizontal" Grid.Row="3" Grid.Column="1" HorizontalAlignment="Right">
                                                     <xctk:DoubleUpDown d:IsHidden="True" MinWidth="100" Value="{Binding LSCurve}" Minimum="0" Maximum="100"
                                                        Margin="{StaticResource spaceMargin}" />
                                                     <Label Content="%" />
                                                 </StackPanel>
 
-                                                <Label Content="Rotation:" Grid.Row="4" Grid.Column="0" />
+                                                <Label Content="{lex:Loc Rotation_}" Grid.Row="4" Grid.Column="0" />
                                                 <DockPanel Grid.Row="4" Grid.Column="1">
                                                     <TextBlock Text="&#xb0;" DockPanel.Dock="Right" FontSize="18" Margin="{StaticResource spaceMargin}" />
                                                     <xctk:IntegerUpDown d:IsHidden="True" Value="{Binding LSRotation}"
@@ -377,7 +377,7 @@
                                                     Margin="{StaticResource spaceMargin}" />
                                                 </DockPanel>
 
-                                                <Label Content="Fuzz:" Grid.Row="5" Grid.Column="0" />
+                                                <Label Content="{lex:Loc Fuzz}" Grid.Row="5" Grid.Column="0" />
                                                 <DockPanel Grid.Row="5" Grid.Column="1">
                                                     <TextBlock Text="units" DockPanel.Dock="Right" FontSize="10" Margin="{StaticResource spaceMargin}" VerticalAlignment="Center" />
                                                     <xctk:IntegerUpDown d:IsHidden="True" Value="{Binding LSFuzz}"
@@ -385,7 +385,7 @@
                                                     Margin="{StaticResource spaceMargin}" />
                                                 </DockPanel>
 
-                                                <Label Content="Anti Snapback:" Grid.Row="6" Grid.Column="0" />
+                                                <Label Content="{lex:Loc AntiSnapback}" Grid.Row="6" Grid.Column="0" />
                                                 <StackPanel Orientation="Horizontal" Grid.Row="6" Grid.Column="1" HorizontalAlignment="Right">
                                                     <CheckBox IsChecked="{Binding LSAntiSnapback}" Margin="{StaticResource spaceMargin}" VerticalAlignment="Center" />
                                                     <xctk:DoubleUpDown d:IsHidden="True" FormatString="F1" Value="{Binding LSAntiSnapbackDelta, FallbackValue=135}"
@@ -394,7 +394,7 @@
                                                     <TextBlock Text="units" DockPanel.Dock="Right" FontSize="10" Margin="{StaticResource spaceMargin}" VerticalAlignment="Center" />
                                                 </StackPanel>
 
-                                                <Label Content="Anti Snapback timing:" Grid.Row="7" Grid.Column="0" />
+                                                <Label Content="{lex:Loc AntiSnapbackTiming}" Grid.Row="7" Grid.Column="0" />
                                                 <StackPanel Orientation="Horizontal" Grid.Row="7" Grid.Column="1" HorizontalAlignment="Right">
                                                     <xctk:IntegerUpDown d:IsHidden="True" FormatString="F1" Value="{Binding LSAntiSnapbackTimeout}"
                                                        MinWidth="100" Minimum="0" Maximum="1000" Increment="1" IsEnabled="{Binding LSAntiSnapback}"
@@ -404,7 +404,7 @@
                                             </Grid>
                                         </DockPanel>
                                     </TabItem>
-                                    <TabItem Header="FlickStick" Visibility="Collapsed">
+                                    <TabItem Header="{lex:Loc FlickStick}" Visibility="Collapsed">
                                         <Grid>
                                             <Grid.ColumnDefinitions>
                                                 <ColumnDefinition/>
@@ -438,19 +438,19 @@
                                                 <xctk:DoubleUpDown d:IsHidden="True" Value="{Binding LSMinAngleThreshold,UpdateSourceTrigger=LostFocus}" FormatString="F2" MinWidth="50" Maximum="180.0" Minimum="0.0" Increment="0.5"
                                                    Margin="{StaticResource spaceMargin}" />
                                             </DockPanel>
-                                            
+
                                         </Grid>
                                     </TabItem>
                                 </TabControl>
                             </StackPanel>
-                            
-                            
+
+
                         </GroupBox>
 
-                        <GroupBox Header="RS">
+                        <GroupBox Header="{lex:Loc RS}">
                             <StackPanel>
                                 <StackPanel Orientation="Horizontal">
-                                    <Label Content="Output Mode" />
+                                    <Label Content="{lex:Loc OutputMode}" />
                                     <ComboBox MinWidth="160" SelectedIndex="{Binding RSOutputIndex,FallbackValue='0'}" VerticalContentAlignment="Center" Margin="10,0,0,0">
                                         <ComboBoxItem Content="None" />
                                         <ComboBoxItem Content="Controls" />
@@ -460,11 +460,11 @@
 
 
                                 <TabControl SelectedIndex="{Binding RSOutputIndex,Mode=OneWay,FallbackValue='0'}" BorderBrush="{x:Null}">
-                                    <TabItem Header="None"  Visibility="Collapsed" />
-                                    <TabItem Header="Controls" Visibility="Collapsed">
+                                    <TabItem Header="{lex:Loc None}"  Visibility="Collapsed" />
+                                    <TabItem Header="{lex:Loc Controls}" Visibility="Collapsed">
                                         <DockPanel>
                                             <StackPanel Orientation="Horizontal" DockPanel.Dock="Top">
-                                                <Label Content="Dead Zone Type" />
+                                                <Label Content="{lex:Loc DeadZoneType}" />
                                                 <ComboBox MinWidth="160" SelectedIndex="{Binding RSDeadTypeIndex,FallbackValue='0'}" VerticalContentAlignment="Center" Margin="10,0,0,0">
                                                     <ComboBoxItem Content="Radial" />
                                                     <ComboBoxItem Content="Axial" />
@@ -472,7 +472,7 @@
                                             </StackPanel>
 
                                             <TabControl DockPanel.Dock="Top" SelectedIndex="{Binding RSDeadTypeIndex,Mode=OneWay,FallbackValue='0'}" BorderBrush="{x:Null}" Padding="0" Margin="0,8,0,8">
-                                                <TabItem Header="Radial" Visibility="Collapsed">
+                                                <TabItem Header="{lex:Loc Radial}" Visibility="Collapsed">
                                                     <Grid>
                                                         <Grid.ColumnDefinitions>
                                                             <ColumnDefinition/>
@@ -487,32 +487,32 @@
                                                             <RowDefinition Style="{StaticResource gridRowHeight}" />
                                                         </Grid.RowDefinitions>
 
-                                                        <Label Content="Dead Zone:" Grid.Row="0" Grid.Column="0" />
+                                                        <Label Content="{lex:Loc DeadZone_}" Grid.Row="0" Grid.Column="0" />
                                                         <xctk:DoubleUpDown d:IsHidden="True" Value="{Binding RSDeadZone,UpdateSourceTrigger=LostFocus}" FormatString="F2" MinWidth="50" Grid.Row="0" Grid.Column="1" Maximum="1.0" Minimum="0.0" Increment="0.1"
                                                    Margin="{StaticResource spaceMargin}" />
 
-                                                        <Label Content="Max Zone:" Grid.Row="1" Grid.Column="0" />
+                                                        <Label Content="{lex:Loc MaxZone_}" Grid.Row="1" Grid.Column="0" />
                                                         <xctk:DoubleUpDown d:IsHidden="True" Value="{Binding RSMaxZone}" FormatString="F2" MinWidth="50" Grid.Row="1" Grid.Column="1" Maximum="1.0" Minimum="0.0" Increment="0.1"
                                                    Margin="{StaticResource spaceMargin}" />
 
-                                                        <Label Content="Anti-dead Zone:" Grid.Row="2" Grid.Column="0" />
+                                                        <Label Content="{lex:Loc AntiDeadZone}" Grid.Row="2" Grid.Column="0" />
                                                         <xctk:DoubleUpDown d:IsHidden="True" Value="{Binding RSAntiDeadZone}" FormatString="F2" MinWidth="50" Grid.Row="2" Grid.Column="1" Maximum="1.0" Minimum="0.0" Increment="0.1"
                                                    Margin="{StaticResource spaceMargin}" />
 
-                                                        <Label Content="Max Output:" Grid.Row="3" Grid.Column="0" />
+                                                        <Label Content="{lex:Loc MaxOutput_}" Grid.Row="3" Grid.Column="0" />
                                                         <xctk:DoubleUpDown d:IsHidden="True" Value="{Binding RSMaxOutput}" FormatString="F2" MinWidth="50" Grid.Row="3" Grid.Column="1" Maximum="1.0" Minimum="0.0" Increment="0.1"
                                                    Margin="{StaticResource spaceMargin}" />
 
-                                                        <Label Content="Vertical Scale:" Grid.Row="4" Grid.Column="0" />
+                                                        <Label Content="{lex:Loc VerticalScale_}" Grid.Row="4" Grid.Column="0" />
                                                         <xctk:DoubleUpDown d:IsHidden="True" Value="{Binding RSVerticalScale}" FormatString="F2" MinWidth="50" Grid.Row="4" Grid.Column="1" Maximum="2.0" Minimum="0.0" Increment="0.1"
                                                    Margin="{StaticResource spaceMargin}" />
 
-                                                        <Label Content="Sensitivity:" Grid.Row="5" Grid.Column="0" />
+                                                        <Label Content="{lex:Loc Sensitivity}" Grid.Row="5" Grid.Column="0" />
                                                         <xctk:DoubleUpDown d:IsHidden="True" FormatString="F2" Value="{Binding RSSens}" MinWidth="50" Grid.Row="5" Grid.Column="1" Maximum="5.0" Minimum="0.5" Increment="0.1"
                                                    Margin="{StaticResource spaceMargin}" />
                                                     </Grid>
                                                 </TabItem>
-                                                <TabItem Header="Axial" Visibility="Collapsed">
+                                                <TabItem Header="{lex:Loc Axial}" Visibility="Collapsed">
                                                     <local:AxialStickUserControl x:Name="axialRSStickControl" />
                                                 </TabItem>
                                             </TabControl>
@@ -533,7 +533,7 @@
                                                     <RowDefinition Style="{StaticResource gridRowHeight}" />
                                                 </Grid.RowDefinitions>
 
-                                                <Label Content="Output Curve:" Grid.Row="0" Grid.Column="0" />
+                                                <Label Content="{lex:Loc OutputCurve}" Grid.Row="0" Grid.Column="0" />
                                                 <ComboBox Grid.Row="0" Grid.Column="1" SelectedIndex="{Binding RSOutputCurveIndex}"
                                           Margin="{StaticResource spaceMargin}">
                                                     <ComboBoxItem Content="Linear" />
@@ -546,13 +546,13 @@
                                                 </ComboBox>
 
                                                 <DockPanel Grid.Row="1" Grid.Column="1" IsEnabled="{Binding RSCustomCurveSelected}">
-                                                    <Button x:Name="rsCustomEditorBtn" Content="..." Tag="RS" Width="20" DockPanel.Dock="Right" Click="CustomEditorBtn_Click"
+                                                    <Button x:Name="rsCustomEditorBtn" Content="{lex:Loc ...}" Tag="RS" Width="20" DockPanel.Dock="Right" Click="CustomEditorBtn_Click"
                                             Margin="{StaticResource spaceMargin}" />
                                                     <TextBox Text="{Binding RSCustomCurve,UpdateSourceTrigger=LostFocus,FallbackValue='0.00, 0.00, 1.00, 1.00'}" DockPanel.Dock="Left"
                                              Margin="{StaticResource spaceMargin}" />
                                                 </DockPanel>
 
-                                                <Label Content="Square Stick:" Grid.Row="2" Grid.Column="0" />
+                                                <Label Content="{lex:Loc SquareStick}" Grid.Row="2" Grid.Column="0" />
                                                 <StackPanel Orientation="Horizontal" Grid.Row="2" Grid.Column="1" HorizontalAlignment="Right">
                                                     <CheckBox IsChecked="{Binding RSSquareStick}" Margin="{StaticResource spaceMargin}" VerticalAlignment="Center" />
                                                     <xctk:DoubleUpDown d:IsHidden="True" FormatString="F1" Value="{Binding RSSquareRoundness,FallbackValue=5}"
@@ -560,14 +560,14 @@
                                                        Margin="{StaticResource spaceMargin}" />
                                                 </StackPanel>
 
-                                                <Label Content="Curve (Input):" Grid.Row="3" Grid.Column="0" />
+                                                <Label Content="{lex:Loc CurveInput}" Grid.Row="3" Grid.Column="0" />
                                                 <StackPanel Orientation="Horizontal" Grid.Row="3" Grid.Column="1" HorizontalAlignment="Right">
                                                     <xctk:DoubleUpDown d:IsHidden="True" MinWidth="100" Value="{Binding RSCurve}" Minimum="0" Maximum="100"
                                                        Margin="{StaticResource spaceMargin}"/>
                                                     <Label Content="%" />
                                                 </StackPanel>
 
-                                                <Label Content="Rotation:" Grid.Row="4" Grid.Column="0" />
+                                                <Label Content="{lex:Loc Rotation_}" Grid.Row="4" Grid.Column="0" />
                                                 <DockPanel Grid.Row="4" Grid.Column="1">
                                                     <TextBlock Text="&#xb0;" DockPanel.Dock="Right" FontSize="18" Margin="{StaticResource spaceMargin}" />
                                                     <xctk:IntegerUpDown d:IsHidden="True" Value="{Binding RSRotation}"
@@ -575,7 +575,7 @@
                                                     Margin="{StaticResource spaceMargin}" />
                                                 </DockPanel>
 
-                                                <Label Content="Fuzz:" Grid.Row="5" Grid.Column="0" />
+                                                <Label Content="{lex:Loc Fuzz}" Grid.Row="5" Grid.Column="0" />
                                                 <DockPanel Grid.Row="5" Grid.Column="1">
                                                     <TextBlock Text="units" DockPanel.Dock="Right" FontSize="10" Margin="{StaticResource spaceMargin}" VerticalAlignment="Center" />
                                                     <xctk:IntegerUpDown d:IsHidden="True" Value="{Binding RSFuzz}"
@@ -583,7 +583,7 @@
                                                     Margin="{StaticResource spaceMargin}" />
                                                 </DockPanel>
 
-                                                <Label Content="Anti Snapback:" Grid.Row="6" Grid.Column="0" />
+                                                <Label Content="{lex:Loc AntiSnapback}" Grid.Row="6" Grid.Column="0" />
                                                 <StackPanel Orientation="Horizontal" Grid.Row="6" Grid.Column="1" HorizontalAlignment="Right">
                                                     <CheckBox IsChecked="{Binding RSAntiSnapback}" Margin="{StaticResource spaceMargin}" VerticalAlignment="Center" />
                                                     <xctk:DoubleUpDown d:IsHidden="True" FormatString="F1" Value="{Binding RSAntiSnapbackDelta, FallbackValue=135}"
@@ -592,7 +592,7 @@
                                                     <TextBlock Text="units" DockPanel.Dock="Right" FontSize="10" Margin="{StaticResource spaceMargin}" VerticalAlignment="Center" />
                                                 </StackPanel>
 
-                                                <Label Content="Anti Snapback timing:" Grid.Row="7" Grid.Column="0" />
+                                                <Label Content="{lex:Loc AntiSnapbackTiming}" Grid.Row="7" Grid.Column="0" />
                                                 <StackPanel Orientation="Horizontal" Grid.Row="7" Grid.Column="1" HorizontalAlignment="Right">
                                                     <xctk:IntegerUpDown d:IsHidden="True" FormatString="F1" Value="{Binding RSAntiSnapbackTimeout}"
                                                        MinWidth="100" Minimum="0" Maximum="1000" Increment="1" IsEnabled="{Binding RSAntiSnapback}"
@@ -603,7 +603,7 @@
                                         </DockPanel>
 
                                     </TabItem>
-                                    <TabItem Header="FlickStick" Visibility="Collapsed">
+                                    <TabItem Header="{lex:Loc FlickStick}" Visibility="Collapsed">
                                         <Grid>
                                             <Grid.ColumnDefinitions>
                                                 <ColumnDefinition/>
@@ -641,11 +641,11 @@
                                     </TabItem>
                                 </TabControl>
                             </StackPanel>
-                            
-                            
+
+
                         </GroupBox>
 
-                        <GroupBox Header="L2 &amp; R2">
+                        <GroupBox Header="{lex:Loc L2AndR2}">
                             <Grid>
                                 <Grid.RowDefinitions>
                                     <RowDefinition></RowDefinition>
@@ -671,37 +671,37 @@
                                 <TextBlock Text="L2" Grid.Column="1" FontWeight="Bold" HorizontalAlignment="Center" Margin="0,0,0,8" />
                                 <TextBlock Text="R2" Grid.Column="2" FontWeight="Bold" HorizontalAlignment="Center" Margin="0,0,0,8" />
 
-                                <Label Content="Dead Zone:" Grid.Row="1" Grid.Column="0" />
+                                <Label Content="{lex:Loc DeadZone_}" Grid.Row="1" Grid.Column="0" />
                                 <xctk:DoubleUpDown d:IsHidden="True" FormatString="F2" Value="{Binding L2DeadZone}" MinWidth="50" Grid.Row="1" Grid.Column="1" Maximum="1.0" Minimum="0.0" Increment="0.1"
                                                    Margin="{StaticResource spaceMargin}" />
                                 <xctk:DoubleUpDown d:IsHidden="True" FormatString="F2" Value="{Binding R2DeadZone}" MinWidth="50" Grid.Row="1" Grid.Column="2" Maximum="1.0" Minimum="0.0" Increment="0.1"
                                                    Margin="{StaticResource spaceMargin}" />
 
-                                <Label Content="Max Zone:" Grid.Row="2" Grid.Column="0" />
+                                <Label Content="{lex:Loc MaxZone_}" Grid.Row="2" Grid.Column="0" />
                                 <xctk:DoubleUpDown d:IsHidden="True" FormatString="F2" Value="{Binding L2MaxZone}" MinWidth="50" Grid.Row="2" Grid.Column="1" Maximum="1.0" Minimum="0.0" Increment="0.1"
                                                    Margin="{StaticResource spaceMargin}" />
                                 <xctk:DoubleUpDown d:IsHidden="True" FormatString="F2" Value="{Binding R2MaxZone}" MinWidth="50" Grid.Row="2" Grid.Column="2" Maximum="1.0" Minimum="0.0" Increment="0.1"
                                                    Margin="{StaticResource spaceMargin}" />
 
-                                <Label Content="Anti-dead Zone:" Grid.Row="3" Grid.Column="0" />
+                                <Label Content="{lex:Loc AntiDeadZone}" Grid.Row="3" Grid.Column="0" />
                                 <xctk:DoubleUpDown d:IsHidden="True" FormatString="F2" Value="{Binding L2AntiDeadZone}" MinWidth="50" Grid.Row="3" Grid.Column="1" Maximum="1.0" Minimum="0.0" Increment="0.1"
                                                    Margin="{StaticResource spaceMargin}" />
                                 <xctk:DoubleUpDown d:IsHidden="True" FormatString="F2" Value="{Binding R2AntiDeadZone}" MinWidth="50" Grid.Row="3" Grid.Column="2" Maximum="1.0" Minimum="0.0" Increment="0.1"
                                                    Margin="{StaticResource spaceMargin}" />
 
-                                <Label Content="Max Output:" Grid.Row="4" Grid.Column="0" />
+                                <Label Content="{lex:Loc MaxOutput_}" Grid.Row="4" Grid.Column="0" />
                                 <xctk:DoubleUpDown d:IsHidden="True" FormatString="F2" Value="{Binding L2MaxOutput}" MinWidth="50" Grid.Row="4" Grid.Column="1" Maximum="1.0" Minimum="0.0" Increment="0.1"
                                                    Margin="{StaticResource spaceMargin}" />
                                 <xctk:DoubleUpDown d:IsHidden="True" FormatString="F2" Value="{Binding R2MaxOutput}" MinWidth="50" Grid.Row="4" Grid.Column="2" Maximum="1.0" Minimum="0.0" Increment="0.1"
                                                    Margin="{StaticResource spaceMargin}" />
 
-                                <Label Content="Sensitivity:" Grid.Row="5" Grid.Column="0" />
+                                <Label Content="{lex:Loc Sensitivity}" Grid.Row="5" Grid.Column="0" />
                                 <xctk:DoubleUpDown d:IsHidden="True" FormatString="F2" Value="{Binding L2Sens}" MinWidth="50" Grid.Row="5" Grid.Column="1" Maximum="10.0" Minimum="0.1" Increment="0.1"
                                                    Margin="{StaticResource spaceMargin}" />
                                 <xctk:DoubleUpDown d:IsHidden="True" FormatString="F2" Value="{Binding R2Sens}" MinWidth="50" Grid.Row="5" Grid.Column="2" Maximum="10.0" Minimum="0.1" Increment="0.1"
                                                    Margin="{StaticResource spaceMargin}" />
 
-                                <Label Content="Output Curve:" Grid.Row="6" Grid.Column="0" />
+                                <Label Content="{lex:Loc OutputCurve}" Grid.Row="6" Grid.Column="0" />
                                 <ComboBox Grid.Row="6" Grid.Column="1" SelectedIndex="{Binding L2OutputCurveIndex}"
                                           Margin="{StaticResource spaceMargin}">
                                     <ComboBoxItem Content="Linear" />
@@ -724,53 +724,53 @@
                                 </ComboBox>
 
                                 <DockPanel Grid.Row="7" Grid.Column="1" IsEnabled="{Binding L2CustomCurveSelected}">
-                                    <Button x:Name="l2CustomEditorBtn" Content="..." Tag="L2" Width="20" DockPanel.Dock="Right" Click="CustomEditorBtn_Click"
+                                    <Button x:Name="l2CustomEditorBtn" Content="{lex:Loc ProfileEditor0727}" Tag="L2" Width="20" DockPanel.Dock="Right" Click="CustomEditorBtn_Click"
                                             Margin="{StaticResource spaceMargin}" />
                                     <TextBox Text="{Binding L2CustomCurve,FallbackValue='0.00, 0.00, 1.00, 1.00'}" DockPanel.Dock="Left"
                                              Margin="{StaticResource spaceMargin}" />
                                 </DockPanel>
                                 <DockPanel Grid.Row="7" Grid.Column="2"  IsEnabled="{Binding R2CustomCurveSelected}">
-                                    <Button x:Name="r2CustomEditorBtn" Content="..." Tag="R2" Width="20" DockPanel.Dock="Right" Click="CustomEditorBtn_Click"
+                                    <Button x:Name="r2CustomEditorBtn" Content="{lex:Loc ProfileEditor0733}" Tag="R2" Width="20" DockPanel.Dock="Right" Click="CustomEditorBtn_Click"
                                             Margin="{StaticResource spaceMargin}" />
                                     <TextBox Text="{Binding R2CustomCurve,FallbackValue='0.00, 0.00, 1.00, 1.00'}" DockPanel.Dock="Left"
                                              Margin="{StaticResource spaceMargin}" />
                                 </DockPanel>
 
-                                <Label Content="Two Stage Mode:" Grid.Row="8" Grid.Column="0" />
+                                <Label Content="{lex:Loc TwoStageMode}" Grid.Row="8" Grid.Column="0" />
                                 <ComboBox Grid.Row="8" Grid.Column="1" ItemsSource="{Binding Path=TwoStageModeChoices}"
                                           DisplayMemberPath="DisplayName" SelectedValuePath="Mode" SelectedValue="{Binding L2TriggerMode}" Margin="{StaticResource spaceMargin}" />
 
                                 <ComboBox Grid.Row="8" Grid.Column="2" ItemsSource="{Binding Path=TwoStageModeChoices}"
                                           DisplayMemberPath="DisplayName" SelectedValuePath="Mode" SelectedValue="{Binding R2TriggerMode}" Margin="{StaticResource spaceMargin}" />
 
-                                <Label Content="Full Pull Btn:" Grid.Row="9" Grid.Column="0" />
+                                <Label Content="{lex:Loc FullPullBtn}" Grid.Row="9" Grid.Column="0" />
                                 <DockPanel Grid.Row="9" Grid.Column="1">
-                                    <Button Content="Full" MinWidth="40" Tag="{Binding L2FullPull, Source={StaticResource controlIndexCheck}}" Click="TriggerFullPullBtn_Click"
+                                    <Button Content="{lex:Loc FullPull}" MinWidth="40" Tag="{Binding L2FullPull, Source={StaticResource controlIndexCheck}}" Click="TriggerFullPullBtn_Click"
                                             Margin="{StaticResource spaceMargin}" DockPanel.Dock="Top" />
                                     <Label x:Name="l2FullPullLb" Content="{Binding MappingName,FallbackValue=Unassigned}"
                                            Margin="{StaticResource spaceMargin}" HorizontalAlignment="Center" DockPanel.Dock="Top"/>
                                 </DockPanel>
                                 <DockPanel Grid.Row="9" Grid.Column="2">
-                                    <Button Content="Full" MinWidth="40" Tag="{Binding R2FullPull, Source={StaticResource controlIndexCheck}}" Click="TriggerFullPullBtn_Click"
+                                    <Button Content="{lex:Loc FullPull}" MinWidth="40" Tag="{Binding R2FullPull, Source={StaticResource controlIndexCheck}}" Click="TriggerFullPullBtn_Click"
                                             Margin="{StaticResource spaceMargin}" DockPanel.Dock="Top" />
                                     <Label x:Name="r2FullPullLb" Content="{Binding MappingName,FallbackValue=Unassigned}"
                                            Margin="{StaticResource spaceMargin}" HorizontalAlignment="Center" DockPanel.Dock="Top" />
                                 </DockPanel>
 
-                                <Label Content="Hip Fire Delay:" Grid.Row="10" Grid.Column="0" />
+                                <Label Content="{lex:Loc HipFireDelay}" Grid.Row="10" Grid.Column="0" />
                                 <DockPanel Grid.Row="10" Grid.Column="1">
-                                    <Label Content="ms" DockPanel.Dock="Right" />
+                                    <Label Content="{lex:Loc Ms}" DockPanel.Dock="Right" />
                                     <xctk:IntegerUpDown d:IsHidden="True" Value="{Binding L2HipFireTime}" MinWidth="50" Maximum="5000" Minimum="0" Increment="10"
                                                    Margin="{StaticResource spaceMargin}" />
                                 </DockPanel>
 
                                 <DockPanel Grid.Row="10" Grid.Column="2">
-                                    <Label Content="ms" DockPanel.Dock="Right" />
+                                    <Label Content="{lex:Loc Ms}" DockPanel.Dock="Right" />
                                     <xctk:IntegerUpDown d:IsHidden="True" Value="{Binding R2HipFireTime}" MinWidth="50" Maximum="5000" Minimum="0" Increment="10"
                                                    Margin="{StaticResource spaceMargin}" />
                                 </DockPanel>
 
-                                <Label Content="Trigger Effect:" Grid.Row="11" Grid.Column="0" />
+                                <Label Content="{lex:Loc TriggerEffect}" Grid.Row="11" Grid.Column="0" />
 
                                 <ComboBox Grid.Row="11" Grid.Column="1" ItemsSource="{Binding Path=TriggerEffectChoices}"
                                           DisplayMemberPath="DisplayName" SelectedValuePath="Mode" SelectedValue="{Binding L2TriggerEffect}" Margin="{StaticResource spaceMargin}" />
@@ -779,7 +779,7 @@
                             </Grid>
                         </GroupBox>
 
-                        <GroupBox Header="SixAxis">
+                        <GroupBox Header="{lex:Loc SixAxis}">
                             <Grid>
                                 <Grid.RowDefinitions>
                                     <RowDefinition></RowDefinition>
@@ -800,31 +800,31 @@
                                 <TextBlock Text="X" Grid.Column="1" FontWeight="Bold" HorizontalAlignment="Center" Margin="0,0,0,8" />
                                 <TextBlock Text="Z" Grid.Column="2"  FontWeight="Bold" HorizontalAlignment="Center" Margin="0,0,0,8" />
 
-                                <Label Content="Dead Zone:" Grid.Row="1" Grid.Column="0" />
+                                <Label Content="{lex:Loc DeadZone_}" Grid.Row="1" Grid.Column="0" />
                                 <xctk:DoubleUpDown d:IsHidden="True" FormatString="F2" Value="{Binding SXDeadZone}" MinWidth="50" Grid.Row="1" Grid.Column="1" Maximum="1.0" Minimum="0.0" Increment="0.1"
                                                    Margin="{StaticResource spaceMargin}" />
                                 <xctk:DoubleUpDown d:IsHidden="True" FormatString="F2" Value="{Binding SZDeadZone}" MinWidth="50" Grid.Row="1" Grid.Column="2" Maximum="1.0" Minimum="0.0" Increment="0.1"
                                                    Margin="{StaticResource spaceMargin}" />
 
-                                <Label Content="Max Zone:" Grid.Row="2" Grid.Column="0" />
+                                <Label Content="{lex:Loc MaxZone_}" Grid.Row="2" Grid.Column="0" />
                                 <xctk:DoubleUpDown d:IsHidden="True" FormatString="F2" Value="{Binding SXMaxZone}" MinWidth="50" Grid.Row="2" Grid.Column="1" Maximum="1.0" Minimum="0.0" Increment="0.1"
                                                    Margin="{StaticResource spaceMargin}" />
                                 <xctk:DoubleUpDown d:IsHidden="True" FormatString="F2" Value="{Binding SZMaxZone}" MinWidth="50" Grid.Row="2" Grid.Column="2" Maximum="1.0" Minimum="0.0" Increment="0.1"
                                                    Margin="{StaticResource spaceMargin}" />
 
-                                <Label Content="Anti-dead Zone:" Grid.Row="3" Grid.Column="0" />
+                                <Label Content="{lex:Loc AntiDeadZone}" Grid.Row="3" Grid.Column="0" />
                                 <xctk:DoubleUpDown d:IsHidden="True" FormatString="F2" Value="{Binding SXAntiDeadZone}" MinWidth="50" Grid.Row="3" Grid.Column="1" Maximum="1.0" Minimum="0.0" Increment="0.1"
                                                    Margin="{StaticResource spaceMargin}" />
                                 <xctk:DoubleUpDown d:IsHidden="True" FormatString="F2" Value="{Binding SZAntiDeadZone}" MinWidth="50" Grid.Row="3" Grid.Column="2" Maximum="1.0" Minimum="0.0" Increment="0.1"
                                                    Margin="{StaticResource spaceMargin}" />
 
-                                <Label Content="Sensitivity:" Grid.Row="4" Grid.Column="0" />
+                                <Label Content="{lex:Loc Sensitivity}" Grid.Row="4" Grid.Column="0" />
                                 <xctk:DoubleUpDown d:IsHidden="True" FormatString="F2" Value="{Binding SXSens}" MinWidth="50" Grid.Row="4" Grid.Column="1" Maximum="5.0" Minimum="0.5" Increment="0.1"
                                                    Margin="{StaticResource spaceMargin}" />
                                 <xctk:DoubleUpDown d:IsHidden="True" FormatString="F2" Value="{Binding SZSens}" MinWidth="50" Grid.Row="4" Grid.Column="2" Maximum="5.0" Minimum="0.5" Increment="0.1"
                                                    Margin="{StaticResource spaceMargin}" />
 
-                                <Label Content="Output Curve:" Grid.Row="5" Grid.Column="0" />
+                                <Label Content="{lex:Loc OutputCurve}" Grid.Row="5" Grid.Column="0" />
                                 <ComboBox Grid.Row="5" Grid.Column="1" SelectedIndex="{Binding SXOutputCurveIndex}"
                                           Margin="{StaticResource spaceMargin}">
                                     <ComboBoxItem Content="Linear" />
@@ -847,13 +847,13 @@
                                 </ComboBox>
 
                                 <DockPanel Grid.Row="6" Grid.Column="1" IsEnabled="{Binding SXCustomCurveSelected}">
-                                    <Button x:Name="sxCustomEditorBtn" Content="..." Tag="SX" Width="20" DockPanel.Dock="Right" Click="CustomEditorBtn_Click"
+                                    <Button x:Name="sxCustomEditorBtn" Content="{lex:Loc ...}" Tag="SX" Width="20" DockPanel.Dock="Right" Click="CustomEditorBtn_Click"
                                             Margin="{StaticResource spaceMargin}" />
                                     <TextBox Text="{Binding SXCustomCurve,FallbackValue='0.00, 0.00, 1.00, 1.00'}" DockPanel.Dock="Left"
                                              Margin="{StaticResource spaceMargin}" />
                                 </DockPanel>
                                 <DockPanel Grid.Row="6" Grid.Column="2" IsEnabled="{Binding SZCustomCurveSelected}">
-                                    <Button x:Name="szCustomEditorBtn" Content="..." Tag="SZ" Width="20" DockPanel.Dock="Right" Click="CustomEditorBtn_Click"
+                                    <Button x:Name="szCustomEditorBtn" Content="{lex:Loc ...}" Tag="SZ" Width="20" DockPanel.Dock="Right" Click="CustomEditorBtn_Click"
                                            Margin="{StaticResource spaceMargin}" />
                                     <TextBox Text="{Binding SZCustomCurve,FallbackValue='0.00, 0.00, 1.00, 1.00'}" DockPanel.Dock="Left"
                                              Margin="{StaticResource spaceMargin}" />
@@ -864,10 +864,10 @@
                 </ScrollViewer>
             </TabItem>
 
-            <TabItem Header="Lightbar">
+            <TabItem Header="{lex:Loc Lightbar}">
                 <StackPanel>
                     <StackPanel Orientation="Horizontal">
-                        <Label Content="Mode:" />
+                        <Label Content="{lex:Loc Mode}" />
                         <ComboBox x:Name="lightbarModeCombo" Width="160" SelectedIndex="{Binding LightbarModeIndex, FallbackValue=0}"
                                   VerticalContentAlignment="Center" Margin="10,0,0,0">
                             <ComboBoxItem Content="Normal" />
@@ -879,33 +879,33 @@
                             <GroupBox x:Name="colorGB" Header="{lex:Loc Color}" Padding="4">
                                 <StackPanel>
                                     <StackPanel Orientation="Horizontal">
-                                        <Label Content="R" />
+                                        <Label Content="{lex:Loc ColorR}" />
                                         <Slider Value="{Binding MainColorR}" Minimum="0" Maximum="255" ToolTip="{Binding MainColorR}" MinWidth="100" Background="{Binding MainColorRString, FallbackValue=Red}"/>
                                     </StackPanel>
                                     <StackPanel Orientation="Horizontal">
-                                        <Label Content="G" />
+                                        <Label Content="{lex:Loc ColorG}" />
                                         <Slider Value="{Binding MainColorG}" MinWidth="100" Minimum="0" Maximum="255" ToolTip="{Binding MainColorG}" Background="{Binding MainColorGString, FallbackValue=Lime}"/>
                                     </StackPanel>
                                     <StackPanel Orientation="Horizontal">
-                                        <Label Content="B" />
+                                        <Label Content="{lex:Loc ColorB}" />
                                         <Slider Value="{Binding MainColorB}" MinWidth="100" Minimum="0" Maximum="255" ToolTip="{Binding MainColorB}" Background="{Binding MainColorBString, FallbackValue=Blue}"/>
                                     </StackPanel>
                                 </StackPanel>
                             </GroupBox>
 
-                            <GroupBox x:Name="emptyColorGB" Header="Empty" Padding="4">
+                            <GroupBox x:Name="emptyColorGB" Header="{lex:Loc Empty}" Padding="4">
                                 <StackPanel>
 
                                     <StackPanel Orientation="Horizontal">
-                                        <Label Content="R" />
+                                        <Label Content="{lex:Loc ColorR}" />
                                         <Slider Value="{Binding LowColorR}" MinWidth="100" Minimum="0" Maximum="255" ToolTip="{Binding LowColorR}" Background="{Binding LowColorRString, FallbackValue=Red}"/>
                                     </StackPanel>
                                     <StackPanel Orientation="Horizontal">
-                                        <Label Content="G" />
+                                        <Label Content="{lex:Loc ColorG}" />
                                         <Slider Value="{Binding LowColorG}" MinWidth="100" Minimum="0" Maximum="255" ToolTip="{Binding LowColorG}" Background="{Binding LowColorGString, FallbackValue=Lime}"/>
                                     </StackPanel>
                                     <StackPanel Orientation="Horizontal">
-                                        <Label Content="B" />
+                                        <Label Content="{lex:Loc ColorB}" />
                                         <Slider Value="{Binding LowColorB}" MinWidth="100" Minimum="0" Maximum="255" ToolTip="{Binding LowColorB}" Background="{Binding LowColorBString, FallbackValue=Blue}"/>
                                     </StackPanel>
 
@@ -926,7 +926,7 @@
                         </StackPanel>
 
                         <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
-                            <Label Content="While Charging:"/>
+                            <Label Content="{lex:Loc WhileCharging}"/>
                             <ComboBox Margin="8,0,0,0" SelectedIndex="{Binding ChargingType,FallbackValue=0}">
                                 <ComboBoxItem Content="Normal" />
                                 <ComboBoxItem Content="Pulse" />
@@ -937,7 +937,7 @@
                                 Visibility="{Binding ChargingColorVisible}" Click="ChargingColorBtn_Click" Margin="20,0,0,0" />
                         </StackPanel>
 
-                        <CheckBox x:Name="colorByBatteryPerCk" Content="Color by Battery %" IsChecked="{Binding ColorBatteryPercent}"
+                        <CheckBox x:Name="colorByBatteryPerCk" Content="{lex:Loc ColorByBatteryPercent}" IsChecked="{Binding ColorBatteryPercent}"
                               ToolTip="{lex:Loc Resources:LightByBatteryTip}" Click="ColorByBatteryPerCk_Click" Margin="0,10,0,0" />
 
                         <StackPanel Orientation="Horizontal" Height="60" Margin="0,10,0,0">
@@ -949,7 +949,7 @@
                             </Button>
                             <xctk:IntegerUpDown MinWidth="30" Height="30" Minimum="0" Maximum="60" Increment="1" Margin="8,0,0,0"
                                             Value="{Binding Rainbow,FallbackValue=5}" IsEnabled="{Binding RainbowExists}" />
-                            <Label Content="secs/cycle" Padding="0" Margin="8,0,0,0" VerticalContentAlignment="Center" />
+                            <Label Content="{lex:Loc SecsPerCycle}" Padding="0" Margin="8,0,0,0" VerticalContentAlignment="Center" />
                             <StackPanel Margin="8,0,0,0" VerticalAlignment="Center">
                                 <TextBlock Text="{Binding MaxSatRainbow,FallbackValue=100,StringFormat=Max Sat. {0:N2}%}" Margin="0,0,0,5" />
                                 <Slider Value="{Binding MaxSatRainbow,FallbackValue=100}" Minimum="0" Maximum="100" Width="100" IsEnabled="{Binding RainbowExists}" />
@@ -959,14 +959,14 @@
                 </StackPanel>
             </TabItem>
 
-            <TabItem Header="Touchpad">
+            <TabItem Header="{lex:Loc Touchpad}">
                 <TabItem.Resources>
                     <Thickness x:Key="spaceMargin" Bottom="8" />
                 </TabItem.Resources>
 
                 <StackPanel Margin="4">
                     <StackPanel Orientation="Horizontal" Margin="{StaticResource spaceMargin}">
-                        <Label Content="Output Mode" />
+                        <Label Content="{lex:Loc OutputMode}" />
                         <ComboBox x:Name="touchpadOutModeCombo" Width="160" SelectedIndex="{Binding TouchpadOutputIndex, FallbackValue='0'}" VerticalContentAlignment="Center" Margin="10,0,0,0">
                             <ComboBoxItem Content="Mouse" />
                             <ComboBoxItem Content="Controls" />
@@ -976,7 +976,7 @@
                     </StackPanel>
 
                     <TabControl x:Name="touchOutputTabControl" SelectedIndex="{Binding TouchpadOutputIndex, FallbackValue='0'}" BorderBrush="{x:Null}" Margin="{StaticResource spaceMargin}">
-                        <TabItem Header="Mouse" Visibility="Collapsed">
+                        <TabItem Header="{lex:Loc Mouse}" Visibility="Collapsed">
                             <StackPanel>
                                 <Grid>
                                     <Grid.RowDefinitions>
@@ -995,7 +995,7 @@
                                         <xctk:IntegerUpDown d:IsHidden="True" MinWidth="80" Height="20" Maximum="500" Value="{Binding TouchSens}" IsEnabled="{Binding TouchSenExists}" Margin="8,0,0,0" />
                                     </StackPanel>
 
-                                    <CheckBox Content="Jitter Compensation" Grid.Row="0" Grid.Column="1" IsChecked="{Binding TouchJitter}" VerticalAlignment="Center"
+                                    <CheckBox Content="{lex:Loc JitterCompensation}" Grid.Row="0" Grid.Column="1" IsChecked="{Binding TouchJitter}" VerticalAlignment="Center"
                                                           ToolTip="{lex:Loc Resources:Jitter}" />
 
                                     <StackPanel Orientation="Horizontal" Grid.Row="1" Grid.Column="0" Margin="{StaticResource spaceMargin}">
@@ -1003,7 +1003,7 @@
                                         <xctk:IntegerUpDown Value="{Binding TouchTap}" d:IsHidden="True" MinWidth="80" Height="20" IsEnabled="{Binding TouchTapExists}" Margin="8,0,0,0" />
                                     </StackPanel>
 
-                                    <CheckBox Content="Double Tap" Grid.Row="1" Grid.Column="1" IsChecked="{Binding TouchDoubleTap}" VerticalAlignment="Center"
+                                    <CheckBox Content="{lex:Loc DoubleTap}" Grid.Row="1" Grid.Column="1" IsChecked="{Binding TouchDoubleTap}" VerticalAlignment="Center"
                                                           ToolTip="{lex:Loc Resources:TapAndHold}" />
 
                                     <StackPanel Orientation="Horizontal" Grid.Row="2" Grid.Column="0" Margin="{StaticResource spaceMargin}">
@@ -1011,35 +1011,35 @@
                                         <xctk:IntegerUpDown Value="{Binding TouchScroll}" d:IsHidden="True" MinWidth="80" Height="20" IsEnabled="{Binding TouchScrollExists}" Margin="8,0,0,0" />
                                     </StackPanel>
 
-                                    <CheckBox Content="Lower Right as RMB" Grid.Row="2" Grid.Column="1" IsChecked="{Binding LowerRightTouchRMB}" VerticalAlignment="Center"
+                                    <CheckBox Content="{lex:Loc LowerRightAsRMB}" Grid.Row="2" Grid.Column="1" IsChecked="{Binding LowerRightTouchRMB}" VerticalAlignment="Center"
                                                           ToolTip="{lex:Loc Resources:BestUsedRightSide}" />
 
-                                    <CheckBox Content="Passthru Click Action (DS4 mode)" Grid.Row="3" Grid.Column="0" IsChecked="{Binding TouchpadClickPassthru}" VerticalAlignment="Center" />
+                                    <CheckBox Content="{lex:Loc PassthruClickAction}" Grid.Row="3" Grid.Column="0" IsChecked="{Binding TouchpadClickPassthru}" VerticalAlignment="Center" />
                                 </Grid>
 
-                                <CheckBox Content="Start with Slide/Scroll Off" IsChecked="{Binding StartTouchpadOff}" VerticalAlignment="Center"
+                                <CheckBox Content="{lex:Loc StartTouchpadOff}" IsChecked="{Binding StartTouchpadOff}" VerticalAlignment="Center"
                                                     ToolTip="{lex:Loc Resources:TouchpadOffTip}" Margin="0,10,0,0" />
 
                                 <StackPanel Orientation="Horizontal" Margin="{StaticResource spaceMargin}">
-                                    <Label Content="Rotation" ContentStringFormat="{}{0}:" />
+                                    <Label Content="{lex:Loc Rotation}" ContentStringFormat="{}{0}:" />
                                     <xctk:DoubleUpDown d:IsHidden="True" MinWidth="80" Height="20" Minimum="-180" Maximum="180" Increment="1" FormatString="F0" Value="{Binding TouchRelMouseRotation,FallbackValue='0'}" Margin="8,0,0,0" />
                                     <TextBlock Text="&#xb0;" FontSize="18" Margin="{StaticResource spaceMargin}" />
                                 </StackPanel>
 
                                 <StackPanel Orientation="Horizontal" Margin="{StaticResource spaceMargin}">
-                                    <Label Content="Min Threshold" ContentStringFormat="{}{0}:" />
+                                    <Label Content="{lex:Loc MinThreshold}" ContentStringFormat="{}{0}:" />
                                     <xctk:DoubleUpDown d:IsHidden="True" MinWidth="80" Height="20" Minimum="1.0" Maximum="40.0" Increment="1.0" FormatString="F1" Value="{Binding TouchRelMouseMinThreshold,FallbackValue='1.0'}" Margin="8,0,0,0" />
                                 </StackPanel>
 
                                 <StackPanel Orientation="Horizontal" Height="20" Margin="{StaticResource spaceMargin}">
-                                    <CheckBox Content="Trackball" IsChecked="{Binding TouchTrackball}" VerticalAlignment="Center" />
-                                    <Label Content="Friction:" Padding="0" Margin="20,0,5,0" VerticalAlignment="Center"/>
+                                    <CheckBox Content="{lex:Loc Trackball}" IsChecked="{Binding TouchTrackball}" VerticalAlignment="Center" />
+                                    <Label Content="{lex:Loc Friction}" Padding="0" Margin="20,0,5,0" VerticalAlignment="Center"/>
                                     <xctk:DoubleUpDown x:Name="frictionUD" d:IsHidden="True" MinWidth="80" IsEnabled="{Binding TouchTrackball}" Minimum="0.1" Maximum="20.0"
                                                                Value="{Binding TouchTrackballFriction,FallbackValue='10'}" ValueChanged="FrictionUD_ValueChanged" Margin="8,0,0,0" />
                                 </StackPanel>
 
                                 <StackPanel Orientation="Horizontal" Margin="{StaticResource spaceMargin}">
-                                    <Label Content="Invert" Padding="0" HorizontalAlignment="Center" />
+                                    <Label Content="{lex:Loc Invert}" Padding="0" HorizontalAlignment="Center" />
                                     <ComboBox MinWidth="160" SelectedIndex="{Binding TouchInvertIndex}" Margin="20,0,0,0">
                                         <ComboBoxItem Content="None" />
                                         <ComboBoxItem Content="X" />
@@ -1049,31 +1049,31 @@
                                 </StackPanel>
 
                                 <StackPanel Orientation="Horizontal" Margin="{StaticResource spaceMargin}">
-                                    <Label Content="Disable Invert" Padding="0" HorizontalAlignment="Center" />
+                                    <Label Content="{lex:Loc DisableInvert}" Padding="0" HorizontalAlignment="Center" />
                                     <Button x:Name="touchDisInvertBtn" MinWidth="160"  Height="22" Content="{Binding TouchDisInvertString,FallbackValue=None}" Click="TouchDisInvertBtn_Click" Margin="20,0,0,0">
                                         <Button.ContextMenu>
                                             <ContextMenu>
-                                                <MenuItem Header="Cross" IsCheckable="True" Click="TouchDisInvertMenuItem_Click" />
-                                                <MenuItem Header="Circle" IsCheckable="True" Click="TouchDisInvertMenuItem_Click" />
-                                                <MenuItem Header="Square" IsCheckable="True" Click="TouchDisInvertMenuItem_Click" />
-                                                <MenuItem Header="Triangle" IsCheckable="True" Click="TouchDisInvertMenuItem_Click" />
-                                                <MenuItem Header="L1" IsCheckable="True" Click="TouchDisInvertMenuItem_Click" />
-                                                <MenuItem Header="L2" IsCheckable="True" Click="TouchDisInvertMenuItem_Click" />
-                                                <MenuItem Header="R1" IsCheckable="True" Click="TouchDisInvertMenuItem_Click" />
-                                                <MenuItem Header="R2" IsCheckable="True" Click="TouchDisInvertMenuItem_Click" />
-                                                <MenuItem Header="Up" IsCheckable="True" Click="TouchDisInvertMenuItem_Click" />
-                                                <MenuItem Header="Down" IsCheckable="True" Click="TouchDisInvertMenuItem_Click" />
-                                                <MenuItem Header="Left" IsCheckable="True" Click="TouchDisInvertMenuItem_Click" />
-                                                <MenuItem Header="Right" IsCheckable="True" Click="TouchDisInvertMenuItem_Click" />
-                                                <MenuItem Header="L3" IsCheckable="True" Click="TouchDisInvertMenuItem_Click" />
-                                                <MenuItem Header="R3" IsCheckable="True" Click="TouchDisInvertMenuItem_Click" />
-                                                <MenuItem Header="Finger on Touchpad" IsCheckable="True" Click="TouchDisInvertMenuItem_Click" />
-                                                <MenuItem Header="2 Fingers on Touchpad" IsCheckable="True" Click="TouchDisInvertMenuItem_Click" />
-                                                <MenuItem Header="Options" IsCheckable="True" Click="TouchDisInvertMenuItem_Click" />
-                                                <MenuItem Header="Share" IsCheckable="True" Click="TouchDisInvertMenuItem_Click" />
-                                                <MenuItem Header="PS" IsCheckable="True" Click="TouchDisInvertMenuItem_Click" />
-                                                <MenuItem Header="Touchpad Click" IsCheckable="True" Click="TouchDisInvertMenuItem_Click" />
-                                                <MenuItem Header="Mute" IsCheckable="True" Click="TouchDisInvertMenuItem_Click" />
+                                                <MenuItem Header="{lex:Loc Cross}" IsCheckable="True" Click="TouchDisInvertMenuItem_Click" />
+                                                <MenuItem Header="{lex:Loc Circle}" IsCheckable="True" Click="TouchDisInvertMenuItem_Click" />
+                                                <MenuItem Header="{lex:Loc Square}" IsCheckable="True" Click="TouchDisInvertMenuItem_Click" />
+                                                <MenuItem Header="{lex:Loc Triangle}" IsCheckable="True" Click="TouchDisInvertMenuItem_Click" />
+                                                <MenuItem Header="{lex:Loc L1}" IsCheckable="True" Click="TouchDisInvertMenuItem_Click" />
+                                                <MenuItem Header="{lex:Loc L2}" IsCheckable="True" Click="TouchDisInvertMenuItem_Click" />
+                                                <MenuItem Header="{lex:Loc R1}" IsCheckable="True" Click="TouchDisInvertMenuItem_Click" />
+                                                <MenuItem Header="{lex:Loc R2}" IsCheckable="True" Click="TouchDisInvertMenuItem_Click" />
+                                                <MenuItem Header="{lex:Loc Up}" IsCheckable="True" Click="TouchDisInvertMenuItem_Click" />
+                                                <MenuItem Header="{lex:Loc Down}" IsCheckable="True" Click="TouchDisInvertMenuItem_Click" />
+                                                <MenuItem Header="{lex:Loc Left}" IsCheckable="True" Click="TouchDisInvertMenuItem_Click" />
+                                                <MenuItem Header="{lex:Loc Right}" IsCheckable="True" Click="TouchDisInvertMenuItem_Click" />
+                                                <MenuItem Header="{lex:Loc L3}" IsCheckable="True" Click="TouchDisInvertMenuItem_Click" />
+                                                <MenuItem Header="{lex:Loc R3}" IsCheckable="True" Click="TouchDisInvertMenuItem_Click" />
+                                                <MenuItem Header="{lex:Loc FingerOnTouchpad}" IsCheckable="True" Click="TouchDisInvertMenuItem_Click" />
+                                                <MenuItem Header="{lex:Loc TwoFingersOnTouchpad}" IsCheckable="True" Click="TouchDisInvertMenuItem_Click" />
+                                                <MenuItem Header="{lex:Loc Options}" IsCheckable="True" Click="TouchDisInvertMenuItem_Click" />
+                                                <MenuItem Header="{lex:Loc Share}" IsCheckable="True" Click="TouchDisInvertMenuItem_Click" />
+                                                <MenuItem Header="{lex:Loc PS}" IsCheckable="True" Click="TouchDisInvertMenuItem_Click" />
+                                                <MenuItem Header="{lex:Loc TouchpadClick}" IsCheckable="True" Click="TouchDisInvertMenuItem_Click" />
+                                                <MenuItem Header="{lex:Loc Mute}" IsCheckable="True" Click="TouchDisInvertMenuItem_Click" />
                                             </ContextMenu>
                                         </Button.ContextMenu>
                                     </Button>
@@ -1082,55 +1082,55 @@
                             </StackPanel>
                         </TabItem>
 
-                        <TabItem Header="Controls" Visibility="Collapsed">
+                        <TabItem Header="{lex:Loc Controls}" Visibility="Collapsed">
                             <StackPanel>
                                 <StackPanel Orientation="Horizontal" Margin="5,0,0,0">
-                                    <Button x:Name="swipeUpBtn" Content="Swipe Up" MinWidth="100" Tag="{Binding SwipeUp, Source={StaticResource controlIndexCheck}}" Click="SwipeControlsButton_Click" />
+                                    <Button x:Name="swipeUpBtn" Content="{lex:Loc SwipeUp}" MinWidth="100" Tag="{Binding SwipeUp, Source={StaticResource controlIndexCheck}}" Click="SwipeControlsButton_Click" />
                                     <Label x:Name="swipeUpLb" Content="{Binding MappingName,FallbackValue=Unassigned}"  Margin="10,0,0,0"/>
                                 </StackPanel>
                                 <StackPanel Orientation="Horizontal" Margin="5,8,0,0">
-                                    <Button x:Name="swipeDownBtn" Content="Swipe Down" MinWidth="100" Tag="{Binding SwipeDown, Source={StaticResource controlIndexCheck}}" Click="SwipeControlsButton_Click" />
+                                    <Button x:Name="swipeDownBtn" Content="{lex:Loc SwipeDown}" MinWidth="100" Tag="{Binding SwipeDown, Source={StaticResource controlIndexCheck}}" Click="SwipeControlsButton_Click" />
                                     <Label x:Name="swipeDownLb" Content="{Binding MappingName,FallbackValue=Unassigned}"  Margin="10,0,0,0"/>
                                 </StackPanel>
                                 <StackPanel Orientation="Horizontal" Margin="5,8,0,0">
-                                    <Button x:Name="swipeLeftBtn" Content="Swipe Left" MinWidth="100" Tag="{Binding SwipeLeft, Source={StaticResource controlIndexCheck}}" Click="SwipeControlsButton_Click" />
+                                    <Button x:Name="swipeLeftBtn" Content="{lex:Loc SwipeLeft}" MinWidth="100" Tag="{Binding SwipeLeft, Source={StaticResource controlIndexCheck}}" Click="SwipeControlsButton_Click" />
                                     <Label x:Name="swipeLeftLb" Content="{Binding MappingName,FallbackValue=Unassigned}"  Margin="10,0,0,0"/>
                                 </StackPanel>
                                 <StackPanel Orientation="Horizontal" Margin="5,8,0,10">
-                                    <Button x:Name="swipeRightBtn" Content="Swipe Right" MinWidth="100" Tag="{Binding SwipeRight, Source={StaticResource controlIndexCheck}}" Click="SwipeControlsButton_Click" />
+                                    <Button x:Name="swipeRightBtn" Content="{lex:Loc SwipeRight}" MinWidth="100" Tag="{Binding SwipeRight, Source={StaticResource controlIndexCheck}}" Click="SwipeControlsButton_Click" />
                                     <Label x:Name="swipeRightLb" Content="{Binding MappingName,FallbackValue=Unassigned}"  Margin="10,0,0,0"/>
                                 </StackPanel>
 
-                                <CheckBox Content="Passthru Click Action (DS4 mode)" IsChecked="{Binding TouchpadClickPassthru}" VerticalAlignment="Center"
+                                <CheckBox Content="{lex:Loc PassthruClickAction}" IsChecked="{Binding TouchpadClickPassthru}" VerticalAlignment="Center"
                                                           Margin="5,8,0,0" />
                             </StackPanel>
                         </TabItem>
-                        <TabItem Header="Absolute Mouse" Visibility="Collapsed">
+                        <TabItem Header="{lex:Loc AbsoluteMouse}" Visibility="Collapsed">
                             <StackPanel>
                                 <StackPanel Orientation="Horizontal" Margin="{StaticResource spaceMargin}">
-                                    <Label Content="Max Zone X:" />
+                                    <Label Content="{lex:Loc MaxZoneX_}" />
                                     <xctk:IntegerUpDown d:IsHidden="True" MinWidth="80" Height="20" Minimum="0" Maximum="100" Value="{Binding TouchAbsMouseMaxZoneX}" Margin="8,0,0,0" />
                                 </StackPanel>
                                 <StackPanel Orientation="Horizontal" Margin="{StaticResource spaceMargin}">
-                                    <Label Content="Max Zone Y:" />
+                                    <Label Content="{lex:Loc MaxZoneY_}" />
                                     <xctk:IntegerUpDown d:IsHidden="True" MinWidth="80" Height="20" Minimum="0" Maximum="100" Value="{Binding TouchAbsMouseMaxZoneY}" Margin="8,0,0,0" />
                                 </StackPanel>
                                 <StackPanel Orientation="Horizontal" Margin="{StaticResource spaceMargin}">
-                                    <Label Content="Snap To Center on Release:" />
+                                    <Label Content="{lex:Loc SnapToCenterOnRelease}" />
                                     <CheckBox IsChecked="{Binding TouchAbsMouseSnapCenter}" VerticalAlignment="Center" Margin="8,0,0,0" />
                                 </StackPanel>
                             </StackPanel>
                         </TabItem>
-                        <TabItem Header="Passthru" Visibility="Collapsed" />
+                        <TabItem Header="{lex:Loc Passthru}" Visibility="Collapsed" />
                     </TabControl>
                 </StackPanel>
             </TabItem>
 
-            <TabItem Header="Gyro">
+            <TabItem Header="{lex:Loc Gyro}">
                 <ScrollViewer VerticalScrollBarVisibility="Auto">
                     <StackPanel>
                         <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
-                            <Label Content="Output Mode" />
+                            <Label Content="{lex:Loc OutputMode}" />
                             <ComboBox x:Name="gyroOutModeCombo" Width="160" SelectedIndex="{Binding GyroOutModeIndex, FallbackValue=0}" VerticalContentAlignment="Center" Margin="10,0,0,0">
                                 <ComboBoxItem Content="Controls" />
                                 <ComboBoxItem Content="Mouse" />
@@ -1142,75 +1142,75 @@
 
                         <StackPanel x:Name="gyroControlsPanel" Visibility="Visible">
                             <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
-                                <Button x:Name="gyroZNBtn" Content="Tilt Up" Width="100" Tag="{Binding TiltUp, Source={StaticResource controlIndexCheck}}" Click="TiltControlsButton_Click" />
+                                <Button x:Name="gyroZNBtn" Content="{lex:Loc TiltUp}" Width="100" Tag="{Binding TiltUp, Source={StaticResource controlIndexCheck}}" Click="TiltControlsButton_Click" />
                                 <Label x:Name="gyroZNLb" Content="{Binding MappingName,FallbackValue=Unassigned}" />
                             </StackPanel>
 
                             <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
-                                <Button x:Name="gyroZPBtn" Content="Tilt Down" Width="100" Tag="{Binding TiltDown, Source={StaticResource controlIndexCheck}}" Click="TiltControlsButton_Click" />
+                                <Button x:Name="gyroZPBtn" Content="{lex:Loc TiltDown}" Width="100" Tag="{Binding TiltDown, Source={StaticResource controlIndexCheck}}" Click="TiltControlsButton_Click" />
                                 <Label x:Name="gyroZPLb" Content="{Binding MappingName,FallbackValue=Unassigned}" />
                             </StackPanel>
 
                             <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
-                                <Button x:Name="gyroXPBtn" Content="Tilt Left" Width="100" Tag="{Binding TiltLeft, Source={StaticResource controlIndexCheck}}" Click="TiltControlsButton_Click" />
+                                <Button x:Name="gyroXPBtn" Content="{lex:Loc TiltLeft}" Width="100" Tag="{Binding TiltLeft, Source={StaticResource controlIndexCheck}}" Click="TiltControlsButton_Click" />
                                 <Label x:Name="gyroXLb" Content="{Binding MappingName,FallbackValue=Unassigned}" />
                             </StackPanel>
 
                             <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
-                                <Button x:Name="gyroXNBtn" Content="Tilt Right" Width="100" Tag="{Binding TiltRight, Source={StaticResource controlIndexCheck}}" Click="TiltControlsButton_Click" />
+                                <Button x:Name="gyroXNBtn" Content="{lex:Loc TiltRight}" Width="100" Tag="{Binding TiltRight, Source={StaticResource controlIndexCheck}}" Click="TiltControlsButton_Click" />
                                 <Label x:Name="gyroXNLb" Content="{Binding MappingName,FallbackValue=Unassigned}" />
                             </StackPanel>
 
                             <StackPanel Orientation="Horizontal" Margin="0,16,0,0">
-                                <Label Content="Triggers" />
+                                <Label Content="{lex:Loc Triggers}" />
                                 <Button x:Name="gyroControlsTrigBtn" Content="{Binding GyroControlsTrigDisplay,FallbackValue='Always On'}" MinWidth="160" Click="GyroControlsTrigBtn_Click" >
                                     <Button.ContextMenu>
                                         <ContextMenu>
-                                            <MenuItem Header="Cross" IsCheckable="True" Click="GyroControlsMenuItem_Click" />
-                                            <MenuItem Header="Circle" IsCheckable="True" Click="GyroControlsMenuItem_Click" />
-                                            <MenuItem Header="Square" IsCheckable="True" Click="GyroControlsMenuItem_Click" />
-                                            <MenuItem Header="Triangle" IsCheckable="True" Click="GyroControlsMenuItem_Click" />
-                                            <MenuItem Header="L1" IsCheckable="True" Click="GyroControlsMenuItem_Click" />
-                                            <MenuItem Header="L2" IsCheckable="True" Click="GyroControlsMenuItem_Click" />
-                                            <MenuItem Header="R1" IsCheckable="True" Click="GyroControlsMenuItem_Click" />
-                                            <MenuItem Header="R2" IsCheckable="True" Click="GyroControlsMenuItem_Click" />
-                                            <MenuItem Header="Up" IsCheckable="True" Click="GyroControlsMenuItem_Click" />
-                                            <MenuItem Header="Down" IsCheckable="True" Click="GyroControlsMenuItem_Click" />
-                                            <MenuItem Header="Left" IsCheckable="True" Click="GyroControlsMenuItem_Click" />
-                                            <MenuItem Header="Right" IsCheckable="True" Click="GyroControlsMenuItem_Click" />
-                                            <MenuItem Header="L3" IsCheckable="True" Click="GyroControlsMenuItem_Click" />
-                                            <MenuItem Header="R3" IsCheckable="True" Click="GyroControlsMenuItem_Click" />
-                                            <MenuItem Header="Finger on Touchpad" IsCheckable="True" Click="GyroControlsMenuItem_Click" />
-                                            <MenuItem Header="2 Fingers on Touchpad" IsCheckable="True" Click="GyroControlsMenuItem_Click" />
-                                            <MenuItem Header="Options" IsCheckable="True" Click="GyroControlsMenuItem_Click" />
-                                            <MenuItem Header="Share" IsCheckable="True" Click="GyroControlsMenuItem_Click" />
-                                            <MenuItem Header="PS" IsCheckable="True" Click="GyroControlsMenuItem_Click" />
-                                            <MenuItem Header="Touchpad Click" IsCheckable="True" Click="GyroControlsMenuItem_Click" />
-                                            <MenuItem Header="Mute" IsCheckable="True" Click="GyroControlsMenuItem_Click" />
-                                            <MenuItem Header="Always On" IsCheckable="True" Click="GyroControlsMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc Cross}" IsCheckable="True" Click="GyroControlsMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc Circle}" IsCheckable="True" Click="GyroControlsMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc Square}" IsCheckable="True" Click="GyroControlsMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc Triangle}" IsCheckable="True" Click="GyroControlsMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc L1}" IsCheckable="True" Click="GyroControlsMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc L2}" IsCheckable="True" Click="GyroControlsMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc R1}" IsCheckable="True" Click="GyroControlsMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc R2}" IsCheckable="True" Click="GyroControlsMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc Up}" IsCheckable="True" Click="GyroControlsMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc Down}" IsCheckable="True" Click="GyroControlsMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc Left}" IsCheckable="True" Click="GyroControlsMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc Right}" IsCheckable="True" Click="GyroControlsMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc L3}" IsCheckable="True" Click="GyroControlsMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc R3}" IsCheckable="True" Click="GyroControlsMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc FingerOnTouchpad}" IsCheckable="True" Click="GyroControlsMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc TwoFingersOnTouchpad}" IsCheckable="True" Click="GyroControlsMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc Options}" IsCheckable="True" Click="GyroControlsMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc Share}" IsCheckable="True" Click="GyroControlsMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc PS}" IsCheckable="True" Click="GyroControlsMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc TouchpadClick}" IsCheckable="True" Click="GyroControlsMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc Mute}" IsCheckable="True" Click="GyroControlsMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc AlwaysOn}" IsCheckable="True" Click="GyroControlsMenuItem_Click" />
                                         </ContextMenu>
                                     </Button.ContextMenu>
                                 </Button>
                             </StackPanel>
 
                             <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
-                                <CheckBox Content="Turn Behavior - Turns Gyro"
+                                <CheckBox Content="{lex:Loc TurnBehaviorTurnsGyro}"
                                   IsChecked="{Binding GyroControlsTurns}" ToolTip="{lex:Loc Resources:GyroTriggerBehavior}" />
-                                <CheckBox Content="Toggle" IsChecked="{Binding GyroControlsToggle}" Margin="20,0,0,0" />
+                                <CheckBox Content="{lex:Loc Toggle}" IsChecked="{Binding GyroControlsToggle}" Margin="20,0,0,0" />
                             </StackPanel>
 
                             <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
-                                <Label Content="Eval Cond." />
+                                <Label Content="{lex:Loc EvalCond}" />
                                 <ComboBox SelectedIndex="{Binding GyroControlsEvalCondIndex,FallbackValue=0}" Margin="8,0,0,0">
                                     <ComboBoxItem Content="And" />
                                     <ComboBoxItem Content="Or" />
                                 </ComboBox>
                             </StackPanel>
 
-                            <GroupBox Header="360 Steering Wheel" Margin="0,16,0,0" Padding="2,4">
+                            <GroupBox Header="{lex:Loc 360SteeringWheel}" Margin="0,16,0,0" Padding="2,4">
                                 <StackPanel>
                                     <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
-                                        <Label Content="Steering wheel axis" />
+                                        <Label Content="{lex:Loc SteeringWheelAxis}" />
                                         <ComboBox Width="160" Margin="8,0,0,0" SelectedIndex="{Binding SASteeringWheelEmulationAxisIndex,FallbackValue=0}">
                                             <ComboBoxItem Content="None" />
                                             <ComboBoxItem Content="Left X-Axis" />
@@ -1228,7 +1228,7 @@
                                     </StackPanel>
 
                                     <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
-                                        <Label Content="Steering wheel range" />
+                                        <Label Content="{lex:Loc SteeringWheelRange}" />
                                         <ComboBox Margin="8,0,0,0" SelectedIndex="{Binding SASteeringWheelEmulationRangeIndex,FallbackValue=0}">
                                             <ComboBoxItem Content="90" />
                                             <ComboBoxItem Content="180" />
@@ -1240,12 +1240,12 @@
                                             <ComboBoxItem Content="1080" />
                                             <ComboBoxItem Content="1440" />
                                         </ComboBox>
-                                        <Button x:Name="steeringWheelEmulationCalibrateBtn" Content="Calibrate" Margin="8,0,0,0"
+                                        <Button x:Name="steeringWheelEmulationCalibrateBtn" Content="{lex:Loc Calibrate}" Margin="8,0,0,0"
                                         Click="SteeringWheelEmulationCalibrateBtn_Click" />
                                     </StackPanel>
 
                                     <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
-                                        <Label Content="Fuzz:" />
+                                        <Label Content="{lex:Loc Fuzz}" />
                                         <xctk:IntegerUpDown d:IsHidden="True" Value="{Binding SASteeringWheelFuzz}"
                                                     Minimum="0" Maximum="100"
                                                     Margin="{StaticResource spaceMargin}" />
@@ -1253,18 +1253,18 @@
                                     </StackPanel>
 
                                     <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
-                                        <CheckBox Content="Use Smoothing" IsChecked="{Binding SASteeringWheelUseSmoothing}" />
+                                        <CheckBox Content="{lex:Loc UseSmoothing}" IsChecked="{Binding SASteeringWheelUseSmoothing}" />
                                     </StackPanel>
 
                                     <StackPanel x:Name="euroFilterOptionsPanel" IsEnabled="{Binding SASteeringWheelUseSmoothing,FallbackValue=False}"
                                             Orientation="Horizontal" Margin="0,0,0,8">
                                         <StackPanel Orientation="Horizontal">
-                                            <Label Content="1&#x20ac; MinCutoff" />
+                                            <Label Content="{lex:Loc OneEuroMinCutoff}" />
                                             <xctk:DoubleUpDown x:Name="euroMinCutoff" d:IsHidden="True" FormatString="F5" Value="{Binding SASteeringWheelSmoothMinCutoff,FallbackValue=1.0,UpdateSourceTrigger=LostFocus}"
                                                            Minimum="0.00001" Maximum="1000.0" Increment="0.1" MinWidth="60" />
                                         </StackPanel>
                                         <StackPanel Orientation="Horizontal" Margin="30,0,0,0">
-                                            <Label Content="1&#x20ac; Beta" />
+                                            <Label Content="{lex:Loc OneEuroBeta}" />
                                             <xctk:DoubleUpDown x:Name="euroBeta" d:IsHidden="True" FormatString="F5" Value="{Binding SASteeringWheelSmoothBeta,FallbackValue=0.0,UpdateSourceTrigger=LostFocus}"
                                                            Minimum="0.0" Maximum="1.0" MinWidth="60" />
                                         </StackPanel>
@@ -1273,53 +1273,53 @@
                             </GroupBox>
 
                             <StackPanel Orientation="Horizontal" Margin="0,8,0,8">
-                                <Button x:Name="gyroCalBtn" Content="Gyro Calibration" Width="100"  Click="GyroCalibration_Click" />
+                                <Button x:Name="gyroCalBtn" Content="{lex:Loc GyroCalibration}" Width="100"  Click="GyroCalibration_Click" />
                             </StackPanel>
                         </StackPanel>
 
                         <StackPanel x:Name="gyroMousePanel" Visibility="Collapsed" Margin="{StaticResource spaceMargin}">
                             <StackPanel Orientation="Horizontal" Margin="{StaticResource spaceMargin}">
-                                <Label Content="Triggers" />
+                                <Label Content="{lex:Loc Triggers}" />
                                 <Button x:Name="gyroMouseTrigBtn" Content="{Binding GyroMouseTrigDisplay,FallbackValue=Always On}" MinWidth="160" Click="GyroMouseTrigBtn_Click" >
                                     <Button.ContextMenu>
                                         <ContextMenu>
-                                            <MenuItem Header="Cross" IsCheckable="True" Click="GyroMouseTrigMenuItem_Click" />
-                                            <MenuItem Header="Circle" IsCheckable="True" Click="GyroMouseTrigMenuItem_Click" />
-                                            <MenuItem Header="Square" IsCheckable="True" Click="GyroMouseTrigMenuItem_Click" />
-                                            <MenuItem Header="Triangle" IsCheckable="True" Click="GyroMouseTrigMenuItem_Click" />
-                                            <MenuItem Header="L1" IsCheckable="True" Click="GyroMouseTrigMenuItem_Click" />
-                                            <MenuItem Header="L2" IsCheckable="True" Click="GyroMouseTrigMenuItem_Click" />
-                                            <MenuItem Header="R1" IsCheckable="True" Click="GyroMouseTrigMenuItem_Click" />
-                                            <MenuItem Header="R2" IsCheckable="True" Click="GyroMouseTrigMenuItem_Click" />
-                                            <MenuItem Header="Up" IsCheckable="True" Click="GyroMouseTrigMenuItem_Click" />
-                                            <MenuItem Header="Down" IsCheckable="True" Click="GyroMouseTrigMenuItem_Click" />
-                                            <MenuItem Header="Left" IsCheckable="True" Click="GyroMouseTrigMenuItem_Click" />
-                                            <MenuItem Header="Right" IsCheckable="True" Click="GyroMouseTrigMenuItem_Click" />
-                                            <MenuItem Header="L3" IsCheckable="True" Click="GyroMouseTrigMenuItem_Click" />
-                                            <MenuItem Header="R3" IsCheckable="True" Click="GyroMouseTrigMenuItem_Click" />
-                                            <MenuItem Header="Finger on Touchpad" IsCheckable="True" Click="GyroMouseTrigMenuItem_Click" />
-                                            <MenuItem Header="2 Fingers on Touchpad" IsCheckable="True" Click="GyroMouseTrigMenuItem_Click" />
-                                            <MenuItem Header="Options" IsCheckable="True" Click="GyroMouseTrigMenuItem_Click" />
-                                            <MenuItem Header="Share" IsCheckable="True" Click="GyroMouseTrigMenuItem_Click" />
-                                            <MenuItem Header="PS" IsCheckable="True" Click="GyroMouseTrigMenuItem_Click" />
-                                            <MenuItem Header="Touchpad Click" IsCheckable="True" Click="GyroMouseTrigMenuItem_Click" />
-                                            <MenuItem Header="Mute" IsCheckable="True" Click="GyroMouseTrigMenuItem_Click" />
-                                            <MenuItem Header="Always On" IsCheckable="True" Click="GyroMouseTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc Cross}" IsCheckable="True" Click="GyroMouseTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc Circle}" IsCheckable="True" Click="GyroMouseTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc Square}" IsCheckable="True" Click="GyroMouseTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc Triangle}" IsCheckable="True" Click="GyroMouseTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc L1}" IsCheckable="True" Click="GyroMouseTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc L2}" IsCheckable="True" Click="GyroMouseTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc R1}" IsCheckable="True" Click="GyroMouseTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc R2}" IsCheckable="True" Click="GyroMouseTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc Up}" IsCheckable="True" Click="GyroMouseTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc Down}" IsCheckable="True" Click="GyroMouseTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc Left}" IsCheckable="True" Click="GyroMouseTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc Right}" IsCheckable="True" Click="GyroMouseTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc L3}" IsCheckable="True" Click="GyroMouseTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc R3}" IsCheckable="True" Click="GyroMouseTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc FingerOnTouchpad}" IsCheckable="True" Click="GyroMouseTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc TwoFingersOnTouchpad}" IsCheckable="True" Click="GyroMouseTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc Options}" IsCheckable="True" Click="GyroMouseTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc Share}" IsCheckable="True" Click="GyroMouseTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc PS}" IsCheckable="True" Click="GyroMouseTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc TouchpadClick}" IsCheckable="True" Click="GyroMouseTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc Mute}" IsCheckable="True" Click="GyroMouseTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc AlwaysOn}" IsCheckable="True" Click="GyroMouseTrigMenuItem_Click" />
                                         </ContextMenu>
                                     </Button.ContextMenu>
                                 </Button>
                             </StackPanel>
 
-                            <CheckBox Content="Turn Behavior - Turns Gyro" Margin="{StaticResource spaceMargin}"
+                            <CheckBox Content="{lex:Loc TurnBehaviorTurnsGyro}" Margin="{StaticResource spaceMargin}"
                                   IsChecked="{Binding GyroMouseTurns}" ToolTip="{lex:Loc Resources:GyroTriggerBehavior}" />
                             <StackPanel Orientation="Horizontal" Margin="{StaticResource spaceMargin}">
-                                <Label Content="Gyro Sensitivity:" />
+                                <Label Content="{lex:Loc GyroSensitivity}" />
                                 <xctk:IntegerUpDown d:IsHidden="True" MinWidth="50" Margin="8,0,0,0" Value="{Binding GyroSensitivity}"
                                                 Minimum="0" Maximum="500" />
                             </StackPanel>
 
                             <StackPanel Orientation="Horizontal" Margin="{StaticResource spaceMargin}">
-                                <Label Content="Vertical Scale:" />
+                                <Label Content="{lex:Loc VerticalScale_}" />
                                 <xctk:IntegerUpDown d:IsHidden="True" MinWidth="50" Margin="8,0,0,0" Value="{Binding GyroVertScale}"
                                                 Minimum="0" Maximum="400" Increment="10" />
                                 <Label Content="%" />
@@ -1327,7 +1327,7 @@
 
                             <StackPanel Orientation="Horizontal" Margin="{StaticResource spaceMargin}">
                                 <StackPanel>
-                                    <Label Content="Eval Cond." Margin="{StaticResource spaceMargin}" />
+                                    <Label Content="{lex:Loc EvalCond}" Margin="{StaticResource spaceMargin}" />
                                     <ComboBox SelectedIndex="{Binding GyroMouseEvalCondIndex,FallbackValue=0}">
                                         <ComboBoxItem Content="And" />
                                         <ComboBoxItem Content="Or" />
@@ -1335,7 +1335,7 @@
                                 </StackPanel>
 
                                 <StackPanel Margin="20,0,0,0">
-                                    <Label Content="X Axis" Margin="{StaticResource spaceMargin}" />
+                                    <Label Content="{lex:Loc XAxis}" Margin="{StaticResource spaceMargin}" />
                                     <ComboBox SelectedIndex="{Binding GyroMouseXAxis,FallbackValue=0}">
                                         <ComboBoxItem Content="Yaw" />
                                         <ComboBoxItem Content="Roll" />
@@ -1344,26 +1344,26 @@
                             </StackPanel>
 
                             <StackPanel Orientation="Horizontal" Margin="{StaticResource spaceMargin}">
-                                <Label Content="Invert" Padding="0"/>
-                                <CheckBox Content="X" Margin="8,0,0,0" IsChecked="{Binding GyroMouseInvertX}" />
-                                <CheckBox Content="Y" Margin="8,0,0,0" IsChecked="{Binding GyroMouseInvertY}" />
+                                <Label Content="{lex:Loc Invert}" Padding="0"/>
+                                <CheckBox Content="{lex:Loc GyroMouseInvertX}" Margin="8,0,0,0" IsChecked="{Binding GyroMouseInvertX}" />
+                                <CheckBox Content="{lex:Loc GyroMouseInvertY}" Margin="8,0,0,0" IsChecked="{Binding GyroMouseInvertY}" />
                             </StackPanel>
 
                             <StackPanel Orientation="Horizontal" Margin="{StaticResource spaceMargin}">
-                                <Label Content="Deadzone" />
+                                <Label Content="{lex:Loc Deadzone}" />
                                 <xctk:IntegerUpDown d:IsHidden="True" MinWidth="60" Margin="8,0,0,0"
                                                 Value="{Binding GyroMouseDeadZone}" Minimum="0" Maximum="1000" />
                             </StackPanel>
 
                             <StackPanel Orientation="Horizontal" Margin="{StaticResource spaceMargin}">
-                                <Label Content="Min Threshold" ContentStringFormat="{}{0}:" />
+                                <Label Content="{lex:Loc MinThreshold}" ContentStringFormat="{}{0}:" />
                                 <xctk:DoubleUpDown d:IsHidden="True" MinWidth="80" Height="20" Minimum="1.0" Maximum="40.0" Increment="1.0" FormatString="F1" Value="{Binding GyroMouseMinThreshold,FallbackValue='1.0'}" Margin="8,0,0,0" />
                             </StackPanel>
 
-                            <CheckBox Content="Toggle" IsChecked="{Binding GyroMouseToggle}" Margin="{StaticResource spaceMargin}" />
+                            <CheckBox Content="{lex:Loc Toggle}" IsChecked="{Binding GyroMouseToggle}" Margin="{StaticResource spaceMargin}" />
 
-                            <CheckBox Content="Smoothing" IsChecked="{Binding GyroMouseSmooth,FallbackValue='False'}"  Margin="{StaticResource spaceMargin}" />
-                            <GroupBox Header="Smoothing Options" IsEnabled="{Binding GyroMouseSmooth,FallbackValue='False'}" Margin="{StaticResource spaceMargin}">
+                            <CheckBox Content="{lex:Loc Smoothing}" IsChecked="{Binding GyroMouseSmooth,FallbackValue='False'}"  Margin="{StaticResource spaceMargin}" />
+                            <GroupBox Header="{lex:Loc ProfileEditor1366}" IsEnabled="{Binding GyroMouseSmooth,FallbackValue='False'}" Margin="{StaticResource spaceMargin}">
                                 <StackPanel>
                                     <ComboBox x:Name="gyroMouseSmoothMethodCombo" Margin="{StaticResource spaceMargin}" SelectedIndex="{Binding GyroMouseSmoothMethodIndex,FallbackValue='0'}">
                                         <ComboBoxItem Content="1&#x20ac; Filter" />
@@ -1372,19 +1372,19 @@
 
                                     <StackPanel x:Name="gyroMouseOneEuroPanel" Orientation="Horizontal" Margin="{StaticResource spaceMargin}" Visibility="{Binding GyroMouseOneEuroPanelVisibility,FallbackValue='Visible'}">
                                         <StackPanel Orientation="Horizontal">
-                                            <Label Content="1&#x20ac; MinCutoff" />
+                                            <Label Content="{lex:Loc OneEuroMinCutoff}" />
                                             <xctk:DoubleUpDown d:IsHidden="True" FormatString="F5" Value="{Binding GyroMouseOneEuroMinCutoff,FallbackValue=1.0,UpdateSourceTrigger=LostFocus}"
                                                            Minimum="0.00001" Maximum="100.0" Increment="0.1" MinWidth="60" />
                                         </StackPanel>
                                         <StackPanel Orientation="Horizontal" Margin="30,0,0,0">
-                                            <Label Content="1&#x20ac; Beta" />
+                                            <Label Content="{lex:Loc OneEuroBeta}" />
                                             <xctk:DoubleUpDown  d:IsHidden="True" FormatString="F5" Value="{Binding GyroMouseOneEuroBeta,FallbackValue=0.0,UpdateSourceTrigger=LostFocus}"
                                                            Minimum="0.0" Maximum="1.0" Increment="0.1" MinWidth="60" />
                                         </StackPanel>
                                     </StackPanel>
 
                                     <StackPanel x:Name="gyroMouseWeightedAvgPanel" Orientation="Horizontal" Margin="{StaticResource spaceMargin}" Visibility="{Binding GyroMouseWeightAvgPanelVisibility,FallbackValue='Collapsed'}">
-                                        <Label Content="Smooth Weight" Padding="0" />
+                                        <Label Content="{lex:Loc SmoothWeight}" Padding="0" />
                                         <xctk:DoubleUpDown d:IsHidden="True" MinWidth="60" Margin="8,0,0,0"
                                                    Value="{Binding GyroMouseSmoothWeight}" Minimum="0.0" Maximum="1.0" Increment="0.1" />
                                     </StackPanel>
@@ -1392,92 +1392,92 @@
                             </GroupBox>
 
                             <StackPanel Orientation="Horizontal" Margin="0,8,0,8">
-                                <Button x:Name="gyroCalBtn4" Content="Gyro Calibration" Width="100"  Click="GyroCalibration_Click" />
+                                <Button x:Name="gyroCalBtn4" Content="{lex:Loc GyroCalibration}" Width="100"  Click="GyroCalibration_Click" />
                             </StackPanel>
                         </StackPanel>
 
                         <StackPanel x:Name="gyroMouseJoystickPanel" Visibility="Collapsed">
                             <StackPanel Orientation="Horizontal" Margin="{StaticResource spaceMargin}">
-                                <Label Content="Triggers" />
+                                <Label Content="{lex:Loc Triggers}" />
                                 <Button x:Name="gyroMouseStickTrigBtn" Content="{Binding GyroMouseStickTrigDisplay,FallbackValue='Always On'}" MinWidth="160"
                                     Margin="8,0,0,0" Click="GyroMouseStickTrigBtn_Click" >
                                     <Button.ContextMenu>
                                         <ContextMenu>
-                                            <MenuItem Header="Cross" IsCheckable="True" Click="GyroMouseStickTrigMenuItem_Click" />
-                                            <MenuItem Header="Circle" IsCheckable="True" Click="GyroMouseStickTrigMenuItem_Click" />
-                                            <MenuItem Header="Square" IsCheckable="True" Click="GyroMouseStickTrigMenuItem_Click" />
-                                            <MenuItem Header="Triangle" IsCheckable="True" Click="GyroMouseStickTrigMenuItem_Click" />
-                                            <MenuItem Header="L1" IsCheckable="True" Click="GyroMouseStickTrigMenuItem_Click" />
-                                            <MenuItem Header="L2" IsCheckable="True" Click="GyroMouseStickTrigMenuItem_Click" />
-                                            <MenuItem Header="R1" IsCheckable="True" Click="GyroMouseStickTrigMenuItem_Click" />
-                                            <MenuItem Header="R2" IsCheckable="True" Click="GyroMouseStickTrigMenuItem_Click" />
-                                            <MenuItem Header="Up" IsCheckable="True" Click="GyroMouseStickTrigMenuItem_Click" />
-                                            <MenuItem Header="Down" IsCheckable="True" Click="GyroMouseStickTrigMenuItem_Click" />
-                                            <MenuItem Header="Left" IsCheckable="True" Click="GyroMouseStickTrigMenuItem_Click" />
-                                            <MenuItem Header="Right" IsCheckable="True" Click="GyroMouseStickTrigMenuItem_Click" />
-                                            <MenuItem Header="L3" IsCheckable="True" Click="GyroMouseStickTrigMenuItem_Click" />
-                                            <MenuItem Header="R3" IsCheckable="True" Click="GyroMouseStickTrigMenuItem_Click" />
-                                            <MenuItem Header="Finger on Touchpad" IsCheckable="True" Click="GyroMouseStickTrigMenuItem_Click" />
-                                            <MenuItem Header="2 Fingers on Touchpad" IsCheckable="True" Click="GyroMouseStickTrigMenuItem_Click" />
-                                            <MenuItem Header="Options" IsCheckable="True" Click="GyroMouseStickTrigMenuItem_Click" />
-                                            <MenuItem Header="Share" IsCheckable="True" Click="GyroMouseStickTrigMenuItem_Click" />
-                                            <MenuItem Header="PS" IsCheckable="True" Click="GyroMouseStickTrigMenuItem_Click" />
-                                            <MenuItem Header="Touchpad Click" IsCheckable="True" Click="GyroMouseStickTrigMenuItem_Click" />
-                                            <MenuItem Header="Mute" IsCheckable="True" Click="GyroMouseStickTrigMenuItem_Click" />
-                                            <MenuItem Header="Always On" IsCheckable="True" Click="GyroMouseStickTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc Cross}" IsCheckable="True" Click="GyroMouseStickTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc Circle}" IsCheckable="True" Click="GyroMouseStickTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc Square}" IsCheckable="True" Click="GyroMouseStickTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc Triangle}" IsCheckable="True" Click="GyroMouseStickTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc L1}" IsCheckable="True" Click="GyroMouseStickTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc L2}" IsCheckable="True" Click="GyroMouseStickTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc R1}" IsCheckable="True" Click="GyroMouseStickTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc R2}" IsCheckable="True" Click="GyroMouseStickTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc Up}" IsCheckable="True" Click="GyroMouseStickTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc Down}" IsCheckable="True" Click="GyroMouseStickTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc Left}" IsCheckable="True" Click="GyroMouseStickTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc Right}" IsCheckable="True" Click="GyroMouseStickTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc L3}" IsCheckable="True" Click="GyroMouseStickTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc R3}" IsCheckable="True" Click="GyroMouseStickTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc FingerOnTouchpad}" IsCheckable="True" Click="GyroMouseStickTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc TwoFingersOnTouchpad}" IsCheckable="True" Click="GyroMouseStickTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc Options}" IsCheckable="True" Click="GyroMouseStickTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc Share}" IsCheckable="True" Click="GyroMouseStickTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc PS}" IsCheckable="True" Click="GyroMouseStickTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc TouchpadClick}" IsCheckable="True" Click="GyroMouseStickTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc Mute}" IsCheckable="True" Click="GyroMouseStickTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc AlwaysOn}" IsCheckable="True" Click="GyroMouseStickTrigMenuItem_Click" />
                                         </ContextMenu>
                                     </Button.ContextMenu>
                                 </Button>
                             </StackPanel>
 
                             <StackPanel Orientation="Horizontal" Margin="{StaticResource spaceMargin}">
-                                <CheckBox Content="Turn Behavior - Turns Gyro" IsChecked="{Binding GyroMouseStickTurns}"
+                                <CheckBox Content="{lex:Loc TurnBehaviorTurnsGyro}" IsChecked="{Binding GyroMouseStickTurns}"
                                       ToolTip="{lex:Loc Resources:GyroTriggerBehavior}" />
-                                <CheckBox Content="Toggle" Margin="8,0,0,0" IsChecked="{Binding GyroMouseStickToggle}" />
+                                <CheckBox Content="{lex:Loc Toggle}" Margin="8,0,0,0" IsChecked="{Binding GyroMouseStickToggle}" />
                             </StackPanel>
 
                             <StackPanel Orientation="Horizontal" Margin="{StaticResource spaceMargin}">
-                                <Label Content="Dead Zone" />
+                                <Label Content="{lex:Loc Dead_Zone}" />
                                 <xctk:IntegerUpDown d:IsHidden="True" Margin="8,0,0,0" Value="{Binding GyroMouseStickDeadZone}" MinWidth="60" />
-                                <Label Content="Max Zone" Margin="8,0,0,0" />
+                                <Label Content="{lex:Loc MaxZone}" Margin="8,0,0,0" />
                                 <xctk:IntegerUpDown d:IsHidden="True" Margin="8,0,0,0" Value="{Binding GyroMouseStickMaxZone}" MinWidth="60"
                                                 Minimum="1" />
                             </StackPanel>
 
                             <StackPanel Orientation="Horizontal" Height="30" Margin="{StaticResource spaceMargin}">
-                                <Label Content="Minimum X" />
+                                <Label Content="{lex:Loc MinimumX}" />
                                 <xctk:DoubleUpDown d:IsHidden="True" Margin="8,0,0,0" Value="{Binding GyroMouseStickAntiDeadX}" MinWidth="60"
                                                FormatString="F0" Minimum="0.0" Maximum="100.0" Increment="10.0" />
                                 <Label Content="%" />
 
-                                <Label Content="Minimum Y" Margin="8,0,0,0" />
+                                <Label Content="{lex:Loc MinimumY}" Margin="8,0,0,0" />
                                 <xctk:DoubleUpDown d:IsHidden="True" Margin="8,0,0,0" Value="{Binding GyroMouseStickAntiDeadY}" MinWidth="60"
                                                FormatString="F0" Minimum="0.0" Maximum="100.0" Increment="10.0" />
                                 <Label Content="%" />
                             </StackPanel>
 
                             <StackPanel Orientation="Horizontal" Margin="{StaticResource spaceMargin}">
-                                <Label Content="Vertical Scale" />
+                                <Label Content="{lex:Loc VerticalScale}" />
                                 <xctk:IntegerUpDown d:IsHidden="True" Margin="8,0,0,0" Value="{Binding GyroMouseStickVertScale}" MinWidth="60"
                                                 Minimum="0" Maximum="400" Increment="10" />
                                 <Label Content="%" />
                             </StackPanel>
 
                             <StackPanel Orientation="Horizontal" Margin="{StaticResource spaceMargin}">
-                                <CheckBox Content="Max Output" IsChecked="{Binding GyroMouseStickMaxOutputEnabled,FallbackValue=False}" HorizontalAlignment="Center" VerticalAlignment="Center" />
+                                <CheckBox Content="{lex:Loc MaxOutput}" IsChecked="{Binding GyroMouseStickMaxOutputEnabled,FallbackValue=False}" HorizontalAlignment="Center" VerticalAlignment="Center" />
                                 <xctk:DoubleUpDown d:IsHidden="True" Margin="8,0,0,0" Value="{Binding GyroMouseStickMaxOutput}" IsEnabled="{Binding GyroMouseStickMaxOutputEnabled,FallbackValue=False}"
                                                FormatString="F0" MinWidth="60" Maximum="100.0" Minimum="0.0" Increment="10.0" />
                                 <Label Content="%" />
                             </StackPanel>
 
                             <StackPanel Orientation="Horizontal" Margin="{StaticResource spaceMargin}">
-                                <Label Content="Eval Cond." />
+                                <Label Content="{lex:Loc EvalCond}" />
                                 <ComboBox SelectedIndex="{Binding GyroMouseStickEvalCondIndex,FallbackValue=0}" Margin="8,0,0,0">
                                     <ComboBoxItem Content="And" />
                                     <ComboBoxItem Content="Or" />
                                 </ComboBox>
 
-                                <Label Content="X-Axis" Margin="20,0,0,0" />
+                                <Label Content="{lex:Loc XAxis}" Margin="20,0,0,0" />
                                 <ComboBox SelectedIndex="{Binding GyroMouseStickXAxis,FallbackValue=0}" Margin="8,0,0,0">
                                     <ComboBoxItem Content="Yaw" />
                                     <ComboBoxItem Content="Roll" />
@@ -1485,12 +1485,12 @@
                             </StackPanel>
 
                             <StackPanel Orientation="Horizontal" Margin="{StaticResource spaceMargin}">
-                                <CheckBox Content="Invert X" IsChecked="{Binding GyroMouseStickInvertX}"/>
-                                <CheckBox Content="Invert Y" Margin="10,0,0,0" IsChecked="{Binding GyroMouseStickInvertY}" />
+                                <CheckBox Content="{lex:Loc InvertX}" IsChecked="{Binding GyroMouseStickInvertX}"/>
+                                <CheckBox Content="{lex:Loc InvertY}" Margin="10,0,0,0" IsChecked="{Binding GyroMouseStickInvertY}" />
                             </StackPanel>
 
-                            <CheckBox Content="Smoothing" IsChecked="{Binding GyroMouseStickSmooth}" Margin="{StaticResource spaceMargin}" />
-                            <GroupBox Header="Smoothing Options" IsEnabled="{Binding GyroMouseStickSmooth,FallbackValue='False'}" Margin="{StaticResource spaceMargin}">
+                            <CheckBox Content="{lex:Loc Smoothing}" IsChecked="{Binding GyroMouseStickSmooth}" Margin="{StaticResource spaceMargin}" />
+                            <GroupBox Header="{lex:Loc ProfileEditor1493}" IsEnabled="{Binding GyroMouseStickSmooth,FallbackValue='False'}" Margin="{StaticResource spaceMargin}">
                                 <StackPanel>
                                     <ComboBox x:Name="gyroMouseStickSmoothMethodCombo" Margin="{StaticResource spaceMargin}" SelectedIndex="{Binding GyroMouseStickSmoothMethodIndex,FallbackValue='0'}">
                                         <ComboBoxItem Content="1&#x20ac; Filter" />
@@ -1499,19 +1499,19 @@
 
                                     <StackPanel x:Name="gyroMouseStickOneEuroPanel" Orientation="Horizontal" Margin="{StaticResource spaceMargin}" Visibility="{Binding GyroMouseStickOneEuroPanelVisibility,FallbackValue='Visible'}">
                                         <StackPanel Orientation="Horizontal">
-                                            <Label Content="1&#x20ac; MinCutoff" />
+                                            <Label Content="{lex:Loc OneEuroMinCutoff}" />
                                             <xctk:DoubleUpDown d:IsHidden="True" FormatString="F5" Value="{Binding GyroMouseStickOneEuroMinCutoff,FallbackValue=1.0,UpdateSourceTrigger=LostFocus}"
                                                            Minimum="0.00001" Maximum="100.0" Increment="0.1" MinWidth="60" />
                                         </StackPanel>
                                         <StackPanel Orientation="Horizontal" Margin="30,0,0,0">
-                                            <Label Content="1&#x20ac; Beta" />
+                                            <Label Content="{lex:Loc OneEuroBeta}" />
                                             <xctk:DoubleUpDown d:IsHidden="True" FormatString="F5" Value="{Binding GyroMouseStickOneEuroBeta,FallbackValue=0.0,UpdateSourceTrigger=LostFocus}"
                                                            Minimum="0.0" Maximum="1.0" Increment="0.1" MinWidth="60" />
                                         </StackPanel>
                                     </StackPanel>
 
                                     <StackPanel x:Name="gyroMouseStickWeightedAvgPanel" Orientation="Horizontal" Margin="{StaticResource spaceMargin}" Visibility="{Binding GyroMouseStickWeightAvgPanelVisibility,FallbackValue='Collapsed'}">
-                                        <Label Content="Weight" Padding="0" Margin="20,0,0,0" />
+                                        <Label Content="{lex:Loc Weight}" Padding="0" Margin="20,0,0,0" />
                                         <xctk:DoubleUpDown d:IsHidden="True" Margin="8,0,0,0" FormatString="F2" Value="{Binding GyroMouseStickSmoothWeight}"
                                                Minimum="0.0" Maximum="1.0" Increment="0.1" MinWidth="60" IsEnabled="{Binding GyroMouseStickSmooth}" />
                                     </StackPanel>
@@ -1520,69 +1520,69 @@
                             </GroupBox>
 
                             <StackPanel Orientation="Horizontal" Margin="0,8,0,8">
-                                <Button x:Name="gyroCalBtn1" Content="Gyro Calibration" Width="100"  Click="GyroCalibration_Click" />
+                                <Button x:Name="gyroCalBtn1" Content="{lex:Loc GyroCalibration}" Width="100"  Click="GyroCalibration_Click" />
                             </StackPanel>
                         </StackPanel>
 
                         <StackPanel x:Name="gyroDirSwipePanel" Visibility="Collapsed">
                             <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
-                                <Button x:Name="gyroSwipeUpBtn" Content="Swipe Up" Width="100" Tag="{Binding GyroSwipeUp, Source={StaticResource controlIndexCheck}}" Click="GyroSwipeControlsBtn_Click" />
+                                <Button x:Name="gyroSwipeUpBtn" Content="{lex:Loc SwipeUp}" Width="100" Tag="{Binding GyroSwipeUp, Source={StaticResource controlIndexCheck}}" Click="GyroSwipeControlsBtn_Click" />
                                 <Label x:Name="gyroSwipeUpLb" Content="{Binding MappingName,FallbackValue=Unassigned}" />
                             </StackPanel>
 
                             <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
-                                <Button x:Name="gyroSwipeDownBtn" Content="Swipe Down" Width="100" Tag="{Binding GyroSwipeDown, Source={StaticResource controlIndexCheck}}" Click="GyroSwipeControlsBtn_Click" />
+                                <Button x:Name="gyroSwipeDownBtn" Content="{lex:Loc SwipeDown}" Width="100" Tag="{Binding GyroSwipeDown, Source={StaticResource controlIndexCheck}}" Click="GyroSwipeControlsBtn_Click" />
                                 <Label x:Name="gyroSwipeDownLb" Content="{Binding MappingName,FallbackValue=Unassigned}" />
                             </StackPanel>
 
                             <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
-                                <Button x:Name="gyroSwipeLeftBtn" Content="Swipe Left" Width="100" Tag="{Binding GyroSwipeLeft, Source={StaticResource controlIndexCheck}}" Click="GyroSwipeControlsBtn_Click" />
+                                <Button x:Name="gyroSwipeLeftBtn" Content="{lex:Loc SwipeLeft}" Width="100" Tag="{Binding GyroSwipeLeft, Source={StaticResource controlIndexCheck}}" Click="GyroSwipeControlsBtn_Click" />
                                 <Label x:Name="gyroSwipeLeftLb" Content="{Binding MappingName,FallbackValue=Unassigned}" />
                             </StackPanel>
 
                             <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
-                                <Button x:Name="gyroSwipeRightBtn" Content="Swipe Right" Width="100" Tag="{Binding GyroSwipeRight, Source={StaticResource controlIndexCheck}}" Click="GyroSwipeControlsBtn_Click" />
+                                <Button x:Name="gyroSwipeRightBtn" Content="{lex:Loc SwipeRight}" Width="100" Tag="{Binding GyroSwipeRight, Source={StaticResource controlIndexCheck}}" Click="GyroSwipeControlsBtn_Click" />
                                 <Label x:Name="gyroSwipeRightLb" Content="{Binding MappingName,FallbackValue=Unassigned}" />
                             </StackPanel>
 
                             <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
-                                <Label Content="Triggers" />
+                                <Label Content="{lex:Loc Triggers}" />
                                 <Button x:Name="gyroSwipeTrigBtn" Content="{Binding GyroSwipeTrigDisplay,FallbackValue=Always On}" MinWidth="160" Click="GyroSwipeTrigBtn_Click" >
                                     <Button.ContextMenu>
                                         <ContextMenu>
-                                            <MenuItem Header="Cross" IsCheckable="True" Click="GyroSwipeTrigMenuItem_Click" />
-                                            <MenuItem Header="Circle" IsCheckable="True" Click="GyroSwipeTrigMenuItem_Click" />
-                                            <MenuItem Header="Square" IsCheckable="True" Click="GyroSwipeTrigMenuItem_Click" />
-                                            <MenuItem Header="Triangle" IsCheckable="True" Click="GyroSwipeTrigMenuItem_Click" />
-                                            <MenuItem Header="L1" IsCheckable="True" Click="GyroSwipeTrigMenuItem_Click" />
-                                            <MenuItem Header="L2" IsCheckable="True" Click="GyroSwipeTrigMenuItem_Click" />
-                                            <MenuItem Header="R1" IsCheckable="True" Click="GyroSwipeTrigMenuItem_Click" />
-                                            <MenuItem Header="R2" IsCheckable="True" Click="GyroSwipeTrigMenuItem_Click" />
-                                            <MenuItem Header="Up" IsCheckable="True" Click="GyroSwipeTrigMenuItem_Click" />
-                                            <MenuItem Header="Down" IsCheckable="True" Click="GyroSwipeTrigMenuItem_Click" />
-                                            <MenuItem Header="Left" IsCheckable="True" Click="GyroSwipeTrigMenuItem_Click" />
-                                            <MenuItem Header="Right" IsCheckable="True" Click="GyroSwipeTrigMenuItem_Click" />
-                                            <MenuItem Header="L3" IsCheckable="True" Click="GyroSwipeTrigMenuItem_Click" />
-                                            <MenuItem Header="R3" IsCheckable="True" Click="GyroSwipeTrigMenuItem_Click" />
-                                            <MenuItem Header="Finger on Touchpad" IsCheckable="True" Click="GyroSwipeTrigMenuItem_Click" />
-                                            <MenuItem Header="2 Fingers on Touchpad" IsCheckable="True" Click="GyroSwipeTrigMenuItem_Click" />
-                                            <MenuItem Header="Options" IsCheckable="True" Click="GyroSwipeTrigMenuItem_Click" />
-                                            <MenuItem Header="Share" IsCheckable="True" Click="GyroSwipeTrigMenuItem_Click" />
-                                            <MenuItem Header="PS" IsCheckable="True" Click="GyroSwipeTrigMenuItem_Click" />
-                                            <MenuItem Header="Touchpad Click" IsCheckable="True" Click="GyroSwipeTrigMenuItem_Click" />
-                                            <MenuItem Header="Mute" IsCheckable="True" Click="GyroSwipeTrigMenuItem_Click" />
-                                            <MenuItem Header="Always On" IsCheckable="True" Click="GyroSwipeTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc Cross}" IsCheckable="True" Click="GyroSwipeTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc Circle}" IsCheckable="True" Click="GyroSwipeTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc Square}" IsCheckable="True" Click="GyroSwipeTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc Triangle}" IsCheckable="True" Click="GyroSwipeTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc L1}" IsCheckable="True" Click="GyroSwipeTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc L2}" IsCheckable="True" Click="GyroSwipeTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc R1}" IsCheckable="True" Click="GyroSwipeTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc R2}" IsCheckable="True" Click="GyroSwipeTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc Up}" IsCheckable="True" Click="GyroSwipeTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc Down}" IsCheckable="True" Click="GyroSwipeTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc Left}" IsCheckable="True" Click="GyroSwipeTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc Right}" IsCheckable="True" Click="GyroSwipeTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc L3}" IsCheckable="True" Click="GyroSwipeTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc R3}" IsCheckable="True" Click="GyroSwipeTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc FingerOnTouchpad}" IsCheckable="True" Click="GyroSwipeTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc TwoFingersOnTouchpad}" IsCheckable="True" Click="GyroSwipeTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc Options}" IsCheckable="True" Click="GyroSwipeTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc Share}" IsCheckable="True" Click="GyroSwipeTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc PS}" IsCheckable="True" Click="GyroSwipeTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc TouchpadClick}" IsCheckable="True" Click="GyroSwipeTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc Mute}" IsCheckable="True" Click="GyroSwipeTrigMenuItem_Click" />
+                                            <MenuItem Header="{lex:Loc AlwaysOn}" IsCheckable="True" Click="GyroSwipeTrigMenuItem_Click" />
                                         </ContextMenu>
                                     </Button.ContextMenu>
                                 </Button>
                             </StackPanel>
 
-                            <CheckBox Content="Turn Behavior - Turns Gyro" Margin="0,8,0,0"
+                            <CheckBox Content="{lex:Loc TurnBehaviorTurnsGyro}" Margin="0,8,0,0"
                                   IsChecked="{Binding GyroSwipeTurns}" ToolTip="{lex:Loc Resources:GyroTriggerBehavior}" />
 
                             <StackPanel Orientation="Horizontal" Margin="{StaticResource spaceMargin}">
                                 <StackPanel>
-                                    <Label Content="Eval Cond." Margin="{StaticResource spaceMargin}" />
+                                    <Label Content="{lex:Loc EvalCond}" Margin="{StaticResource spaceMargin}" />
                                     <ComboBox SelectedIndex="{Binding GyroSwipeEvalCondIndex,FallbackValue=0}">
                                         <ComboBoxItem Content="And" />
                                         <ComboBoxItem Content="Or" />
@@ -1590,7 +1590,7 @@
                                 </StackPanel>
 
                                 <StackPanel Margin="20,0,0,0">
-                                    <Label Content="X Axis" Margin="{StaticResource spaceMargin}" />
+                                    <Label Content="{lex:Loc XAxis}" Margin="{StaticResource spaceMargin}" />
                                     <ComboBox SelectedIndex="{Binding GyroSwipeXAxis,FallbackValue=0}">
                                         <ComboBoxItem Content="Yaw" />
                                         <ComboBoxItem Content="Roll" />
@@ -1599,41 +1599,41 @@
                             </StackPanel>
 
                             <StackPanel Orientation="Horizontal" Margin="{StaticResource spaceMargin}">
-                                <Label Content="Deadzone X" />
+                                <Label Content="{lex:Loc DeadzoneX}" />
                                 <xctk:IntegerUpDown d:IsHidden="True" MinWidth="60" Margin="8,0,0,0"
                                                 Value="{Binding GyroSwipeDeadZoneX}" Minimum="0" Maximum="2000" />
-                                <Label Content="deg/sec." />
+                                <Label Content="{lex:Loc DegPerSec}" />
                             </StackPanel>
 
                             <StackPanel Orientation="Horizontal" Margin="{StaticResource spaceMargin}">
-                                <Label Content="Deadzone Y" />
+                                <Label Content="{lex:Loc DeadzoneY}" />
                                 <xctk:IntegerUpDown d:IsHidden="True" MinWidth="60" Margin="8,0,0,0"
                                                 Value="{Binding GyroSwipeDeadZoneY}" Minimum="0" Maximum="2000" />
-                                <Label Content="deg/sec." />
+                                <Label Content="{lex:Loc DegPerSec}" />
                             </StackPanel>
 
                             <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
-                                <Label Content="Delay Time" ContentStringFormat="{}{0}:" />
+                                <Label Content="{lex:Loc DelayTime}" ContentStringFormat="{}{0}:" />
                                 <xctk:IntegerUpDown d:IsHidden="True" MinWidth="60" Margin="8,0,0,0"
                                                 Value="{Binding GyroSwipeDelayTime}" Minimum="0" Maximum="5000" Increment="10" />
-                                <Label Content="ms" />
+                                <Label Content="{lex:Loc Ms}" />
                             </StackPanel>
 
                             <StackPanel Orientation="Horizontal" Margin="0,8,0,8">
-                                <Button x:Name="gyroCalBtn2" Content="Gyro Calibration" Width="100"  Click="GyroCalibration_Click" />
+                                <Button x:Name="gyroCalBtn2" Content="{lex:Loc GyroCalibration}" Width="100"  Click="GyroCalibration_Click" />
                             </StackPanel>
                         </StackPanel>
 
                         <StackPanel x:Name="passthruPanel" Visibility="Collapsed">
                             <StackPanel Orientation="Horizontal" Margin="0,8,0,8">
-                                <Button x:Name="gyroCalBtn3" Content="Gyro Calibration" Width="100"  Click="GyroCalibration_Click" />
+                                <Button x:Name="gyroCalBtn3" Content="{lex:Loc GyroCalibration}" Width="100"  Click="GyroCalibration_Click" />
                             </StackPanel>
                         </StackPanel>
                     </StackPanel>
                 </ScrollViewer>
             </TabItem>
 
-            <TabItem Header="Other">
+            <TabItem Header="{lex:Loc Other}">
                 <StackPanel>
                     <GroupBox Header="{lex:Loc Rumble}" MinHeight="50" Margin="4,4,4,0" Padding="0,4,0,4">
                         <UniformGrid Rows="1" Columns="3">
@@ -1651,16 +1651,16 @@
                                 </DockPanel>
                             </UniformGrid>
 
-                            <Button x:Name="heavyRumbleTestBtn" Content="Test Heavy" Margin="10,0,0,0" Click="HeavyRumbleTestBtn_Click" />
-                            <Button x:Name="lightRumbleTestBtn" Content="Test Light" Margin="10,0,0,0" Click="LightRumbleTestBtn_Click" />
+                            <Button x:Name="heavyRumbleTestBtn" Content="{lex:Loc TestHeavy}" Margin="10,0,0,0" Click="HeavyRumbleTestBtn_Click" />
+                            <Button x:Name="lightRumbleTestBtn" Content="{lex:Loc TestLight}" Margin="10,0,0,0" Click="LightRumbleTestBtn_Click" />
                         </UniformGrid>
                     </GroupBox>
                     <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
-                        <Label Content="Use Controller" ToolTip="{lex:Loc Resources:UseControllerForMapping}" />
+                        <Label Content="{lex:Loc UseController}" ToolTip="{lex:Loc Resources:UseControllerForMapping}" />
                         <xctk:IntegerUpDown x:Name="useControllerUD" d:IsHidden="True" Width="40" Margin="8,0,0,0"
                                             Value="0" Minimum="0" Maximum="4" IsEnabled="False"
                                             ToolTip="{lex:Loc Resources:UseControllerForMapping}" />
-                        <CheckBox x:Name="useControllerReadoutCk" FlowDirection="RightToLeft" Content="for readout" VerticalAlignment="Center"
+                        <CheckBox x:Name="useControllerReadoutCk" FlowDirection="RightToLeft" Content="{lex:Loc ForReadout}" VerticalAlignment="Center"
                                   Margin="8,0,0,0" IsChecked="{Binding UseControllerReadout}"
                                   ToolTip="{lex:Loc Resources:UseControllerForMapping}" Click="UseControllerReadoutCk_Click">
                             <CheckBox.Resources>
@@ -1671,7 +1671,7 @@
                         </CheckBox>
                     </StackPanel>
                     <StackPanel Orientation="Horizontal" Height="40" Margin="0,4,0,0">
-                        <Label Content="Mouse Sensitivity" VerticalAlignment="Center" />
+                        <Label Content="{lex:Loc MouseSensitivity}" VerticalAlignment="Center" />
                         <xctk:IntegerUpDown d:IsHidden="True" MinWidth="50" Height="20"
                                             Value="{Binding ButtonMouseSensitivity,FallbackValue=25}"
                                             Minimum="0" Maximum="255" Increment="1" Margin="10,0,0,0" />
@@ -1679,26 +1679,26 @@
                                    MinWidth="50" VerticalAlignment="Center"  Margin="10,0,0,0" />
                     </StackPanel>
                     <StackPanel Orientation="Horizontal" Height="40">
-                        <Label Content="Mouse Vertical Scale" ContentStringFormat="{}{0}:" VerticalAlignment="Center" />
+                        <Label Content="{lex:Loc MouseVerticalScale}" ContentStringFormat="{}{0}:" VerticalAlignment="Center" />
                         <xctk:IntegerUpDown d:IsHidden="True" MinWidth="50" Height="20"
                             Value="{Binding ButtonMouseVerticalScale,FallbackValue='100'}"
                             Minimum="0" Maximum="500" Increment="10" Margin="10,0,0,0" />
                         <Label Content="%" VerticalContentAlignment="Center" Margin="4,0,0,0" />
                     </StackPanel>
                     <StackPanel Orientation="Horizontal">
-                        <Label Content="Mouse Offset" VerticalAlignment="Center" />
+                        <Label Content="{lex:Loc MouseOffset}" VerticalAlignment="Center" />
                         <xctk:DoubleUpDown d:IsHidden="True" MinWidth="50" FormatString="F3" DefaultValue="0" Minimum="0" Maximum="100"
                                            Value="{Binding ButtonMouseOffset,FallbackValue=0,UpdateSourceTrigger=LostFocus}" />
                         <Label Content="%"/>
                         <TextBlock Text="{Binding MouseOffsetSpeed,Mode=OneWay,StringFormat='\{0:0.00} pps'}"
                                    MinWidth="50" VerticalAlignment="Center" Margin="10,0,0,0" />
                     </StackPanel>
-                    <CheckBox Content="Mouse Acceleration" IsChecked="{Binding MouseAcceleration}" Margin="0,6,0,0" />
-                    <CheckBox Content="Enable Touchpad Toggle" IsChecked="{Binding EnableTouchpadToggle}" Margin="0,6,0,0"
+                    <CheckBox Content="{lex:Loc MouseAcceleration}" IsChecked="{Binding MouseAcceleration}" Margin="0,6,0,0" />
+                    <CheckBox Content="{lex:Loc EnableTouchpadToggle}" IsChecked="{Binding EnableTouchpadToggle}" Margin="0,6,0,0"
                               ToolTip="{lex:Loc Resources:EnableTouchToggle}" />
                     <CheckBox Content="{lex:Loc EnableOutputDataToDS4}" IsChecked="{Binding EnableOutputDataToDS4}" Margin="0,6,0,0" ToolTip="{lex:Loc EnableOutputDataToDS4Tip}" />
                     <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
-                        <CheckBox x:Name="launchProgCk" Content="Launch program with profile" IsChecked="{Binding LaunchProgramExists}" IsEnabled="{Binding LaunchProgramExists}" />
+                        <CheckBox x:Name="launchProgCk" Content="{lex:Loc LaunchProgramWithProfile}" IsChecked="{Binding LaunchProgramExists}" IsEnabled="{Binding LaunchProgramExists}" />
                         <Button x:Name="launchProgBrowseBtn" Click="LaunchProgBrowseBtn_Click" Width="80" Height="30" Margin="20,0,0,0">
                             <Button.Content>
                                 <PriorityBinding>
@@ -1713,16 +1713,16 @@
                             </Button.Background>
                         </Button>
                     </StackPanel>
-                    <CheckBox Content="Use DInput only" IsChecked="{Binding DInputOnly}"
+                    <CheckBox Content="{lex:Loc UseDInputOnly}" IsChecked="{Binding DInputOnly}"
                               ToolTip="{lex:Loc Resources:DinputOnly}" Margin="0,6,0,0" />
                     <StackPanel Orientation="Horizontal" Height="30" Margin="0,6,0,0">
-                        <CheckBox Content="Idle Disconnect" VerticalAlignment="Center" IsChecked="{Binding IdleDisconnectExists}" />
+                        <CheckBox Content="{lex:Loc IdleDisconnect}" VerticalAlignment="Center" IsChecked="{Binding IdleDisconnectExists}" />
                         <xctk:IntegerUpDown x:Name="idleDisconnectUD" d:IsHidden="True" Value="{Binding IdleDisconnect,FallbackValue=5}"
                                             IsEnabled="{Binding IdleDisconnectExists}" MinWidth="50" Height="20" Minimum="0" Maximum="60" Margin="10,0,0,0" />
-                        <Label Content="mins" />
+                        <Label Content="{lex:Loc Mins}" />
                     </StackPanel>
                     <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
-                        <Label Content="BT Poll Rate" ToolTip="{lex:Loc Resources:BtPollRate}" />
+                        <Label Content="{lex:Loc BTPollRate}" ToolTip="{lex:Loc Resources:BtPollRate}" />
                         <ComboBox x:Name="btPollRateCombo" SelectedIndex="{Binding TempBTPollRateIndex,FallbackValue=4}" MinWidth="140"
                                   ToolTip="{lex:Loc Resources:BtPollRate}">
                             <ComboBoxItem Content="Max (1 ms)" />
@@ -1742,10 +1742,10 @@
                             <ComboBoxItem Content="71 Hz (14 ms)" />
                             <ComboBoxItem Content="66 Hz (15 ms)" />
                             <ComboBoxItem Content="62 Hz (16 ms)" />
-                        </ComboBox>
+                      </ComboBox>
                     </StackPanel>
                     <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
-                        <Label Content="Emulated Controller" ToolTip="{lex:Loc Resources:OutContNotice}" />
+                        <Label Content="{lex:Loc EmulatedController}" ToolTip="{lex:Loc Resources:OutContNotice}" />
                         <ComboBox x:Name="outConTypeCombo" SelectedIndex="{Binding TempControllerIndex,FallbackValue=0}" MinWidth="140"
                                   ToolTip="{lex:Loc Resources:OutContNotice}">
                             <ComboBoxItem Content="Xbox 360"/>

--- a/DS4Windows/DS4Forms/RecordBox.xaml
+++ b/DS4Windows/DS4Forms/RecordBox.xaml
@@ -42,44 +42,44 @@
                 <UniformGrid Rows="1" Columns="2" FirstColumn="1" Margin="0,10,0,0">
                     <Button x:Name="clearStepsBtn" Content="{lex:Loc Clear}" Margin="5,00,0,0" Click="ClearStepsBtn_Click" />
                 </UniformGrid>
-                
+
                 <UniformGrid Rows="1" Margin="0,10,0,0">
-                    <Button x:Name="loadPresetBtn" Content="Load Preset" Margin="0,0,5,0" Click="LoadPresetBtn_Click">
+                    <Button x:Name="loadPresetBtn" Content="{lex:Loc LoadPreset}" Margin="0,0,5,0" Click="LoadPresetBtn_Click">
                         <Button.ContextMenu>
                             <ContextMenu>
-                                <MenuItem x:Name="cycleProgPresetMenuItem" Header="Cycle Programs" Click="CycleProgPresetMenuItem_Click" />
-                                <MenuItem x:Name="loadPresetFromFileMenuItem" Header="From File..." Click="LoadPresetFromFileMenuItem_Click" />
+                                <MenuItem x:Name="cycleProgPresetMenuItem" Header="{lex:Loc CyclePrograms}" Click="CycleProgPresetMenuItem_Click" />
+                                <MenuItem x:Name="loadPresetFromFileMenuItem" Header="{lex:Loc FromFile}" Click="LoadPresetFromFileMenuItem_Click" />
                             </ContextMenu>
                         </Button.ContextMenu>
                     </Button>
-                    <Button x:Name="savePresetBtn" Content="Save Preset" Margin="5,0,0,0" Click="SavePresetBtn_Click" />
+                    <Button x:Name="savePresetBtn" Content="{lex:Loc SavePreset}" Margin="5,0,0,0" Click="SavePresetBtn_Click" />
                 </UniformGrid>
 
-                <Button x:Name="addWaitTimeBtn" Content="Insert Wait" Margin="0,10,5,0" Click="AddWaitTimeBtn_Click" />
+                <Button x:Name="addWaitTimeBtn" Content="{lex:Loc InsertWait}" Margin="0,10,5,0" Click="AddWaitTimeBtn_Click" />
 
-                <CheckBox x:Name="recordDelaysCk" Content="Record Delays" HorizontalAlignment="Center" IsChecked="{Binding RecordDelays}" Margin="0,10,0,0" />
+                <CheckBox x:Name="recordDelaysCk" Content="{lex:Loc RecordDelays}" HorizontalAlignment="Center" IsChecked="{Binding RecordDelays}" Margin="0,10,0,0" />
                 <TextBlock Text="Double click on a wait to edit the time" Margin="0,10,0,0" />
                 <ComboBox x:Name="macroModeCombo" SelectedIndex="{Binding MacroModeIndex,FallbackValue=0}" Margin="0,10,0,0">
                     <ComboBoxItem Content="Play Once" />
                     <ComboBoxItem Content="Repeat While Held" />
                 </ComboBox>
-                <CheckBox x:Name="useScanCode" Content="Scan Code" IsChecked="{Binding UseScanCode}" Margin="0,10,0,0"
+                <CheckBox x:Name="useScanCode" Content="{lex:Loc ScanCode}" IsChecked="{Binding UseScanCode}" Margin="0,10,0,0"
                           HorizontalAlignment="Center" />
             </StackPanel>
             <StackPanel DockPanel.Dock="Bottom">
                 <StackPanel x:Name="mouseButtonsPanel">
-                    <Button x:Name="fourMouseBtn" Content="4th Mouse Button" Width="120" Click="FourMouseBtn_Click" />
-                    <Button x:Name="fiveMouseBtn" Content="5th Mouse Button" Width="120" Click="FiveMouseBtn_Click" Margin="0,10,0,0" />
+                    <Button x:Name="fourMouseBtn" Content="{lex:Loc FourthMouseButton}" Width="120" Click="FourMouseBtn_Click" />
+                    <Button x:Name="fiveMouseBtn" Content="{lex:Loc FifthMouseButton}" Width="120" Click="FiveMouseBtn_Click" Margin="0,10,0,0" />
                 </StackPanel>
 
                 <StackPanel x:Name="extraConPanel">
                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,30,0,0">
-                        <Button x:Name="addRumbleBtn" Content="Add Rumble" Width="124" Click="AddRumbleBtn_Click" />
+                        <Button x:Name="addRumbleBtn" Content="{lex:Loc AddRumble}" Width="124" Click="AddRumbleBtn_Click" />
                         <Image Source="/DS4Windows;component/Resources/left touch.png" Width="43" Visibility="Collapsed" />
                     </StackPanel>
 
                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10">
-                        <Button x:Name="changeLightBtn" Content="Change Lightbar Color" Width="124" Click="ChangeLightBtn_Click" />
+                        <Button x:Name="changeLightBtn" Content="{lex:Loc ChangeLightbarColor}" Width="124" Click="ChangeLightBtn_Click" />
                         <Image Source="/DS4Windows;component/Resources/left touch.png" Width="43" Visibility="Collapsed" />
                     </StackPanel>
                 </StackPanel>
@@ -87,8 +87,8 @@
         </DockPanel>
         <DockPanel x:Name="leftSideDockPanel" DockPanel.Dock="Left">
             <DockPanel DockPanel.Dock="Top">
-                <Label Content="Macro Order" />
-                <Label Content="Use Keyboard/Mouse + Controller 1 to record" DockPanel.Dock="Right" HorizontalAlignment="Right" />
+                <Label Content="{lex:Loc MacroOrder}" />
+                <Label Content="{lex:Loc UseKeyboardAndMouseAndController}" DockPanel.Dock="Right" HorizontalAlignment="Right" />
             </DockPanel>
             <ListBox x:Name="macroListBox" ItemsSource="{Binding MacroSteps}" SelectedIndex="{Binding MacroStepIndex}"
                      ItemTemplate="{StaticResource DisplayTemplate}" MouseDoubleClick="MacroListBox_MouseDoubleClick"

--- a/DS4Windows/DS4Forms/SaveWhere.xaml
+++ b/DS4Windows/DS4Forms/SaveWhere.xaml
@@ -3,27 +3,31 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:lex="http://wpflocalizeextension.codeplex.com"
+        lex:LocalizeDictionary.DesignCulture=""
+        lex:ResxLocalizationProvider.DefaultAssembly="DS4Windows"
+        lex:ResxLocalizationProvider.DefaultDictionary="Strings"
         xmlns:local="clr-namespace:DS4WinWPF.DS4Forms"
         mc:Ignorable="d"
         Title="SaveWhere" Height="184" Width="453" ResizeMode="NoResize" WindowStartupLocation="CenterScreen" Closing="Window_Closing"
         Style="{DynamicResource WindowStyle}">
     <StackPanel>
         <DockPanel x:Name="multipleSavesDockP" Margin="4,0">
-            <Label Content="Multiple save locations detected" />
-            <CheckBox x:Name="dontDeleteCk" Content="Don't Delete the other settings yet" DockPanel.Dock="Right" HorizontalAlignment="Right" VerticalAlignment="Center" />
+            <Label Content="{lex:Loc MultipleSaveLocationsDetected}" />
+            <CheckBox x:Name="dontDeleteCk" Content="{lex:Loc DontDelete}" DockPanel.Dock="Right" HorizontalAlignment="Right" VerticalAlignment="Center" />
         </DockPanel>
         <TextBlock x:Name="pickWhereTxt" Text="Pick where you want profiles and settings to be saved"
                    TextWrapping="Wrap" HorizontalAlignment="Center" Margin="4,10,4,0" TextAlignment="Center" />
         <DockPanel Margin="4,10,4,0">
             <StackPanel x:Name="progFolderPanel" Width="200">
-                <Button x:Name="progFolderBtn" Content="Program Folder" Click="ProgFolderBtn_Click" />
+                <Button x:Name="progFolderBtn" Content="{lex:Loc ProgramFolder}" Click="ProgFolderBtn_Click" />
                 <TextBlock TextWrapping="Wrap" TextAlignment="Center">
                     For those who prefer a portable program.
                     Note: this option does not work if in an admin folder w/o UAC
                 </TextBlock>
             </StackPanel>
             <StackPanel DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200">
-                <Button x:Name="appdataBtn" Content="Appdata" Click="AppdataBtn_Click" />
+                <Button x:Name="appdataBtn" Content="{lex:Loc Appdata}" Click="AppdataBtn_Click" />
                 <TextBlock TextWrapping="Wrap" TextAlignment="Center">
                     For those who prefer a regular install. Settings saved at %appdata%\DS4Windows
                 </TextBlock>

--- a/DS4Windows/DS4Forms/SpecialActionEditor.xaml
+++ b/DS4Windows/DS4Forms/SpecialActionEditor.xaml
@@ -14,7 +14,7 @@
              d:DesignHeight="350" d:DesignWidth="420">
     <DockPanel>
         <DockPanel DockPanel.Dock="Top" Margin="4,8,4,8">
-            <Label Content="Name:" DockPanel.Dock="Left" />
+            <Label Content="{lex:Loc Name_}" DockPanel.Dock="Left" />
             <TextBox x:Name="actionNameTxt" Text="{Binding ActionName,FallbackValue=Name,ValidatesOnNotifyDataErrors=True}"
                      Margin="8,0,0,0" DockPanel.Dock="Right" VerticalContentAlignment="Center" />
         </DockPanel>
@@ -24,7 +24,7 @@
                     <ListView.View>
                         <GridView>
                             <GridView.Columns>
-                                <GridViewColumn Header="Trigger" Width="170">
+                                <GridViewColumn Header="{lex:Loc Trigger}" Width="170">
                                     <GridViewColumn.HeaderContainerStyle>
                                         <Style TargetType="{x:Type GridViewColumnHeader}">
                                             <Setter Property="HorizontalContentAlignment" Value="Left" />
@@ -37,124 +37,124 @@
                         </GridView>
                     </ListView.View>
                     <ListViewItem>
-                        <CheckBox x:Name="crossTrigCk" Content="Cross" Tag="Cross" Click="ControlTriggerCheckBox_Click" />
+                        <CheckBox x:Name="crossTrigCk" Content="{lex:Loc Cross}" Tag="Cross" Click="ControlTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="circleTrigCk" Content="Circle" Tag="Circle" Click="ControlTriggerCheckBox_Click" />
+                        <CheckBox x:Name="circleTrigCk" Content="{lex:Loc Circle}" Tag="Circle" Click="ControlTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="squareTrigCk" Content="Square" Tag="Square" Click="ControlTriggerCheckBox_Click" />
+                        <CheckBox x:Name="squareTrigCk" Content="{lex:Loc Square}" Tag="Square" Click="ControlTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="triangleTrigCk" Content="Triangle" Tag="Triangle" Click="ControlTriggerCheckBox_Click" />
+                        <CheckBox x:Name="triangleTrigCk" Content="{lex:Loc Triangle}" Tag="Triangle" Click="ControlTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="optionsTrigCk" Content="Options" Tag="Options" Click="ControlTriggerCheckBox_Click" />
+                        <CheckBox x:Name="optionsTrigCk" Content="{lex:Loc Options}" Tag="Options" Click="ControlTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="shareTrigCk" Content="Share" Tag="Share" Click="ControlTriggerCheckBox_Click" />
+                        <CheckBox x:Name="shareTrigCk" Content="{lex:Loc Share}" Tag="Share" Click="ControlTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="upTrigCk" Content="Up" Tag="Up" Click="ControlTriggerCheckBox_Click" />
+                        <CheckBox x:Name="upTrigCk" Content="{lex:Loc Up}" Tag="Up" Click="ControlTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="downTrigCk" Content="Down" Tag="Down" Click="ControlTriggerCheckBox_Click" />
+                        <CheckBox x:Name="downTrigCk" Content="{lex:Loc Down}" Tag="Down" Click="ControlTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="leftTrigCk" Content="Left" Tag="Left" Click="ControlTriggerCheckBox_Click" />
+                        <CheckBox x:Name="leftTrigCk" Content="{lex:Loc Left}" Tag="Left" Click="ControlTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="rightTrigCk" Content="Right" Tag="Right" Click="ControlTriggerCheckBox_Click" />
+                        <CheckBox x:Name="rightTrigCk" Content="{lex:Loc Right}" Tag="Right" Click="ControlTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="psTrigCk" Content="PS" Tag="PS" Click="ControlTriggerCheckBox_Click" />
+                        <CheckBox x:Name="psTrigCk" Content="{lex:Loc SpecialActionEditor0070}" Tag="PS" Click="ControlTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="muteTrigCk" Content="Mute" Tag="Mute" Click="ControlTriggerCheckBox_Click" />
+                        <CheckBox x:Name="muteTrigCk" Content="{lex:Loc Mute}" Tag="Mute" Click="ControlTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="l1TrigCk" Content="L1" Tag="L1" Click="ControlTriggerCheckBox_Click" />
+                        <CheckBox x:Name="l1TrigCk" Content="{lex:Loc L1}" Tag="L1" Click="ControlTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="r1TrigCk" Content="R1" Tag="R1" Click="ControlTriggerCheckBox_Click" />
+                        <CheckBox x:Name="r1TrigCk" Content="{lex:Loc R1}" Tag="R1" Click="ControlTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="l2TrigCk" Content="L2" Tag="L2" Click="ControlTriggerCheckBox_Click" />
+                        <CheckBox x:Name="l2TrigCk" Content="{lex:Loc L2}" Tag="L2" Click="ControlTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="l2FullPullTrigCk" Content="L2 Full Pull" Tag="L2 Full Pull" Click="ControlTriggerCheckBox_Click" />
+                        <CheckBox x:Name="l2FullPullTrigCk" Content="{lex:Loc L2FullPull}" Tag="L2 Full Pull" Click="ControlTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="r2TrigCk" Content="R2" Tag="R2" Click="ControlTriggerCheckBox_Click" />
+                        <CheckBox x:Name="r2TrigCk" Content="{lex:Loc R2}" Tag="R2" Click="ControlTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="r2TrigFullPullCk" Content="R2 Full Pull" Tag="R2 Full Pull" Click="ControlTriggerCheckBox_Click" />
+                        <CheckBox x:Name="r2TrigFullPullCk" Content="{lex:Loc R2FullPull}" Tag="R2 Full Pull" Click="ControlTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="l3TrigCk" Content="L3" Tag="L3" Click="ControlTriggerCheckBox_Click" />
+                        <CheckBox x:Name="l3TrigCk" Content="{lex:Loc L3}" Tag="L3" Click="ControlTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="r3TrigCk" Content="R3" Tag="R3" Click="ControlTriggerCheckBox_Click" />
+                        <CheckBox x:Name="r3TrigCk" Content="{lex:Loc R3}" Tag="R3" Click="ControlTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="leftTouchTrigCk" Content="Left Touch" Tag="Left Touch" Click="ControlTriggerCheckBox_Click" />
+                        <CheckBox x:Name="leftTouchTrigCk" Content="{lex:Loc LeftTouch}" Tag="Left Touch" Click="ControlTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="upperTouchTrigCk" Content="Upper Touch" Tag="Upper Touch" Click="ControlTriggerCheckBox_Click" />
+                        <CheckBox x:Name="upperTouchTrigCk" Content="{lex:Loc UpperTouch}" Tag="Upper Touch" Click="ControlTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="multitouchTrigCk" Content="Multitouch" Tag="Multitouch" Click="ControlTriggerCheckBox_Click" />
+                        <CheckBox x:Name="multitouchTrigCk" Content="{lex:Loc MultiTouch}" Tag="Multitouch" Click="ControlTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="rightTouchTrigCk" Content="Right Touch" Tag="Right Touch" Click="ControlTriggerCheckBox_Click" />
+                        <CheckBox x:Name="rightTouchTrigCk" Content="{lex:Loc RightTouch}" Tag="Right Touch" Click="ControlTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="lsuTrigCk" Content="Left Stick Up" Tag="Left Stick Up" Click="ControlTriggerCheckBox_Click" />
+                        <CheckBox x:Name="lsuTrigCk" Content="{lex:Loc LeftStickUp}" Tag="Left Stick Up" Click="ControlTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="lsdTrigCk" Content="Left Stick Down" Tag="Left Stick Down" Click="ControlTriggerCheckBox_Click" />
+                        <CheckBox x:Name="lsdTrigCk" Content="{lex:Loc LeftStickDown}" Tag="Left Stick Down" Click="ControlTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="lslTrigCk" Content="Left Stick Left" Tag="Left Stick Left" Click="ControlTriggerCheckBox_Click" />
+                        <CheckBox x:Name="lslTrigCk" Content="{lex:Loc LeftStickLeft}" Tag="Left Stick Left" Click="ControlTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="lsrTrigCk" Content="Left Stick Right" Tag="Left Stick Right" Click="ControlTriggerCheckBox_Click" />
+                        <CheckBox x:Name="lsrTrigCk" Content="{lex:Loc LeftStickRight}" Tag="Left Stick Right" Click="ControlTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="rsuTrigCk" Content="Right Stick Up" Tag="Right Stick Up" Click="ControlTriggerCheckBox_Click" />
+                        <CheckBox x:Name="rsuTrigCk" Content="{lex:Loc RightStickUp}" Tag="Right Stick Up" Click="ControlTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="rsdTrigCk" Content="Right Stick Down" Tag="Right Stick Down" Click="ControlTriggerCheckBox_Click" />
+                        <CheckBox x:Name="rsdTrigCk" Content="{lex:Loc RightStickDown}" Tag="Right Stick Down" Click="ControlTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="rslTrigCk" Content="Right Stick Left" Tag="Right Stick Left" Click="ControlTriggerCheckBox_Click" />
+                        <CheckBox x:Name="rslTrigCk" Content="{lex:Loc RightStickLeft}" Tag="Right Stick Left" Click="ControlTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="rsrTrigCk" Content="Right Stick Right" Tag="Right Stick Right" Click="ControlTriggerCheckBox_Click" />
+                        <CheckBox x:Name="rsrTrigCk" Content="{lex:Loc RightStickRight}" Tag="Right Stick Right" Click="ControlTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="swipeUpTrigCk" Content="Swipe Up" Tag="Swipe Up" Click="ControlTriggerCheckBox_Click" />
+                        <CheckBox x:Name="swipeUpTrigCk" Content="{lex:Loc SwipeUp}" Tag="Swipe Up" Click="ControlTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="swipeDownTrigCk" Content="Swipe Down" Tag="Swipe Down" Click="ControlTriggerCheckBox_Click" />
+                        <CheckBox x:Name="swipeDownTrigCk" Content="{lex:Loc SwipeDown}" Tag="Swipe Down" Click="ControlTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="swipeLeftTrigCk" Content="Swipe Left" Tag="Swipe Left" Click="ControlTriggerCheckBox_Click" />
+                        <CheckBox x:Name="swipeLeftTrigCk" Content="{lex:Loc SwipeLeft}" Tag="Swipe Left" Click="ControlTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="swipeRightTrigCk" Content="Swipe Right" Tag="Swipe Right" Click="ControlTriggerCheckBox_Click" />
+                        <CheckBox x:Name="swipeRightTrigCk" Content="{lex:Loc SwipeRight}" Tag="Swipe Right" Click="ControlTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="tiltUpTrigCk" Content="Tilt Up" Tag="Tilt Up" Click="ControlTriggerCheckBox_Click" />
+                        <CheckBox x:Name="tiltUpTrigCk" Content="{lex:Loc TiltUp}" Tag="Tilt Up" Click="ControlTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="tiltDownTrigCk" Content="Tilt Down" Tag="Tilt Down" Click="ControlTriggerCheckBox_Click" />
+                        <CheckBox x:Name="tiltDownTrigCk" Content="{lex:Loc TiltDown}" Tag="Tilt Down" Click="ControlTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="tiltLeftTrigCk" Content="Tilt Left" Tag="Tilt Left" Click="ControlTriggerCheckBox_Click" />
+                        <CheckBox x:Name="tiltLeftTrigCk" Content="{lex:Loc TiltLeft}" Tag="Tilt Left" Click="ControlTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="tiltRightTrigCk" Content="Tilt Right" Tag="Tilt Right" Click="ControlTriggerCheckBox_Click" />
+                        <CheckBox x:Name="tiltRightTrigCk" Content="{lex:Loc TiltRight}" Tag="Tilt Right" Click="ControlTriggerCheckBox_Click" />
                     </ListViewItem>
                 </ListView>
 
@@ -162,7 +162,7 @@
                     <ListView.View>
                         <GridView>
                             <GridView.Columns>
-                                <GridViewColumn Header="Unload Trigger" Width="170">
+                                <GridViewColumn Header="{lex:Loc UnloadTrigger}" Width="170">
                                     <GridViewColumn.HeaderContainerStyle>
                                         <Style TargetType="{x:Type GridViewColumnHeader}">
                                             <Setter Property="HorizontalContentAlignment" Value="Left" />
@@ -173,124 +173,124 @@
                         </GridView>
                     </ListView.View>
                     <ListViewItem>
-                        <CheckBox x:Name="unloadCrossTrigCk" Content="Cross" Tag="Cross" Click="ControlUnloadTriggerCheckBox_Click" />
+                        <CheckBox x:Name="unloadCrossTrigCk" Content="{lex:Loc Cross}" Tag="Cross" Click="ControlUnloadTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="unloadCircleTrigCk" Content="Circle" Tag="Circle" Click="ControlUnloadTriggerCheckBox_Click" />
+                        <CheckBox x:Name="unloadCircleTrigCk" Content="{lex:Loc Circle}" Tag="Circle" Click="ControlUnloadTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="unloadSquareTrigCk" Content="Square" Tag="Square" Click="ControlUnloadTriggerCheckBox_Click" />
+                        <CheckBox x:Name="unloadSquareTrigCk" Content="{lex:Loc Square}" Tag="Square" Click="ControlUnloadTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="unloadTriangleTrigCk" Content="Triangle" Tag="Triangle" Click="ControlUnloadTriggerCheckBox_Click" />
+                        <CheckBox x:Name="unloadTriangleTrigCk" Content="{lex:Loc Triangle}" Tag="Triangle" Click="ControlUnloadTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="unloadOptionsTrigCk" Content="Options" Tag="Options" Click="ControlUnloadTriggerCheckBox_Click" />
+                        <CheckBox x:Name="unloadOptionsTrigCk" Content="{lex:Loc Options}" Tag="Options" Click="ControlUnloadTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="unloadShareTrigCk" Content="Share" Tag="Share" Click="ControlUnloadTriggerCheckBox_Click" />
+                        <CheckBox x:Name="unloadShareTrigCk" Content="{lex:Loc Share}" Tag="Share" Click="ControlUnloadTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="unloadUpTrigCk" Content="Up" Tag="Up" Click="ControlUnloadTriggerCheckBox_Click" />
+                        <CheckBox x:Name="unloadUpTrigCk" Content="{lex:Loc Up}" Tag="Up" Click="ControlUnloadTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="unloadDownTrigCk" Content="Down" Tag="Down" Click="ControlUnloadTriggerCheckBox_Click" />
+                        <CheckBox x:Name="unloadDownTrigCk" Content="{lex:Loc Down}" Tag="Down" Click="ControlUnloadTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="unloadLeftTrigCk" Content="Left" Tag="Left" Click="ControlUnloadTriggerCheckBox_Click" />
+                        <CheckBox x:Name="unloadLeftTrigCk" Content="{lex:Loc Left}" Tag="Left" Click="ControlUnloadTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="unloadRightTrigCk" Content="Right" Tag="Right" Click="ControlUnloadTriggerCheckBox_Click" />
+                        <CheckBox x:Name="unloadRightTrigCk" Content="{lex:Loc Right}" Tag="Right" Click="ControlUnloadTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="unloadPsTrigCk" Content="PS" Tag="PS" Click="ControlUnloadTriggerCheckBox_Click" />
+                        <CheckBox x:Name="unloadPsTrigCk" Content="{lex:Loc SpecialActionEditor0206}" Tag="PS" Click="ControlUnloadTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="unloadMuteTrigCk" Content="Mute" Tag="Mute" Click="ControlUnloadTriggerCheckBox_Click" />
+                        <CheckBox x:Name="unloadMuteTrigCk" Content="{lex:Loc Mute}" Tag="Mute" Click="ControlUnloadTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="unloadL1TrigCk" Content="L1" Tag="L1" Click="ControlUnloadTriggerCheckBox_Click" />
+                        <CheckBox x:Name="unloadL1TrigCk" Content="{lex:Loc L1}" Tag="L1" Click="ControlUnloadTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="unloadR1TrigCk" Content="R1" Tag="R1" Click="ControlUnloadTriggerCheckBox_Click" />
+                        <CheckBox x:Name="unloadR1TrigCk" Content="{lex:Loc R1}" Tag="R1" Click="ControlUnloadTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="unloadL2TrigCk" Content="L2" Tag="L2" Click="ControlUnloadTriggerCheckBox_Click" />
+                        <CheckBox x:Name="unloadL2TrigCk" Content="{lex:Loc L2}" Tag="L2" Click="ControlUnloadTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="unloadL2FullPullTrigCk" Content="L2 Full Pull" Tag="L2 Full Pull" Click="ControlUnloadTriggerCheckBox_Click" />
+                        <CheckBox x:Name="unloadL2FullPullTrigCk" Content="{lex:Loc L2FullPull}" Tag="L2 Full Pull" Click="ControlUnloadTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="unloadR2TrigCk" Content="R2" Tag="R2" Click="ControlUnloadTriggerCheckBox_Click" />
+                        <CheckBox x:Name="unloadR2TrigCk" Content="{lex:Loc R2}" Tag="R2" Click="ControlUnloadTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="unloadR2FullPullTrigCk" Content="R2 Full Pull" Tag="R2 Full Pull" Click="ControlUnloadTriggerCheckBox_Click" />
+                        <CheckBox x:Name="unloadR2FullPullTrigCk" Content="{lex:Loc R2FullPull}" Tag="R2 Full Pull" Click="ControlUnloadTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="unloadL3TrigCk" Content="L3" Tag="L3" Click="ControlUnloadTriggerCheckBox_Click" />
+                        <CheckBox x:Name="unloadL3TrigCk" Content="{lex:Loc L3}" Tag="L3" Click="ControlUnloadTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="unloadR3TrigCk" Content="R3" Tag="R3" Click="ControlUnloadTriggerCheckBox_Click" />
+                        <CheckBox x:Name="unloadR3TrigCk" Content="{lex:Loc R3}" Tag="R3" Click="ControlUnloadTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="unloadLeftTouchTrigCk" Content="Left Touch" Tag="Left Touch" Click="ControlUnloadTriggerCheckBox_Click" />
+                        <CheckBox x:Name="unloadLeftTouchTrigCk" Content="{lex:Loc LeftTouch}" Tag="Left Touch" Click="ControlUnloadTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="unloadUpperTouchTrigCk" Content="Upper Touch" Tag="Upper Touch" Click="ControlUnloadTriggerCheckBox_Click" />
+                        <CheckBox x:Name="unloadUpperTouchTrigCk" Content="{lex:Loc UpperTouch}" Tag="Upper Touch" Click="ControlUnloadTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="unloadMultitouchTrigCk" Content="Multitouch" Tag="Multitouch" Click="ControlUnloadTriggerCheckBox_Click" />
+                        <CheckBox x:Name="unloadMultitouchTrigCk" Content="{lex:Loc MultiTouch}" Tag="Multitouch" Click="ControlUnloadTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="unloadRightTouchTrigCk" Content="Right Touch" Tag="Right Touch" Click="ControlUnloadTriggerCheckBox_Click" />
+                        <CheckBox x:Name="unloadRightTouchTrigCk" Content="{lex:Loc RightTouch}" Tag="Right Touch" Click="ControlUnloadTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="unloadLsuTrigCk" Content="Left Stick Up" Tag="Left Stick Up" Click="ControlUnloadTriggerCheckBox_Click" />
+                        <CheckBox x:Name="unloadLsuTrigCk" Content="{lex:Loc LeftStickUp}" Tag="Left Stick Up" Click="ControlUnloadTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="unloadLsdTrigCk" Content="Left Stick Down" Tag="Left Stick Down" Click="ControlUnloadTriggerCheckBox_Click" />
+                        <CheckBox x:Name="unloadLsdTrigCk" Content="{lex:Loc LeftStickDown}" Tag="Left Stick Down" Click="ControlUnloadTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="unloadLslTrigCk" Content="Left Stick Left" Tag="Left Stick Left" Click="ControlUnloadTriggerCheckBox_Click" />
+                        <CheckBox x:Name="unloadLslTrigCk" Content="{lex:Loc LeftStickLeft}" Tag="Left Stick Left" Click="ControlUnloadTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="unloadLsrTrigCk" Content="Left Stick Right" Tag="Left Stick Right" Click="ControlUnloadTriggerCheckBox_Click" />
+                        <CheckBox x:Name="unloadLsrTrigCk" Content="{lex:Loc LeftStickRight}" Tag="Left Stick Right" Click="ControlUnloadTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="unloadRsuTrigCk" Content="Right Stick Up" Tag="Right Stick Up" Click="ControlUnloadTriggerCheckBox_Click" />
+                        <CheckBox x:Name="unloadRsuTrigCk" Content="{lex:Loc RightStickUp}" Tag="Right Stick Up" Click="ControlUnloadTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="unloadRsdTrigCk" Content="Right Stick Down" Tag="Right Stick Down" Click="ControlUnloadTriggerCheckBox_Click" />
+                        <CheckBox x:Name="unloadRsdTrigCk" Content="{lex:Loc SpecialActionEditor0263}" Tag="Right Stick Down" Click="ControlUnloadTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="unloadRslTrigCk" Content="Right Stick Left" Tag="Right Stick Left" Click="ControlUnloadTriggerCheckBox_Click" />
+                        <CheckBox x:Name="unloadRslTrigCk" Content="{lex:Loc RightStickLeft}" Tag="Right Stick Left" Click="ControlUnloadTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="unloadRsrTrigCk" Content="Right Stick Right" Tag="Right Stick Right" Click="ControlUnloadTriggerCheckBox_Click" />
+                        <CheckBox x:Name="unloadRsrTrigCk" Content="{lex:Loc RightStickRight}" Tag="Right Stick Right" Click="ControlUnloadTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="unloadSwipeUpTrigCk" Content="Swipe Up" Tag="Swipe Up" Click="ControlUnloadTriggerCheckBox_Click" />
+                        <CheckBox x:Name="unloadSwipeUpTrigCk" Content="{lex:Loc SwipeUp}" Tag="Swipe Up" Click="ControlUnloadTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="unloadSwipeDownTrigCk" Content="Swipe Down" Tag="Swipe Down" Click="ControlUnloadTriggerCheckBox_Click" />
+                        <CheckBox x:Name="unloadSwipeDownTrigCk" Content="{lex:Loc SwipeDown}" Tag="Swipe Down" Click="ControlUnloadTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="unloadSwipeLeftTrigCk" Content="Swipe Left" Tag="Swipe Left" Click="ControlUnloadTriggerCheckBox_Click" />
+                        <CheckBox x:Name="unloadSwipeLeftTrigCk" Content="{lex:Loc SwipeLeft}" Tag="Swipe Left" Click="ControlUnloadTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="unloadSwipeRightTrigCk" Content="Swipe Right" Tag="Swipe Right" Click="ControlUnloadTriggerCheckBox_Click" />
+                        <CheckBox x:Name="unloadSwipeRightTrigCk" Content="{lex:Loc SwipeRight}" Tag="Swipe Right" Click="ControlUnloadTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="unloadTiltUpTrigCk" Content="Tilt Up" Tag="Tilt Up" Click="ControlUnloadTriggerCheckBox_Click" />
+                        <CheckBox x:Name="unloadTiltUpTrigCk" Content="{lex:Loc TiltUp}" Tag="Tilt Up" Click="ControlUnloadTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="unloadTiltDownTrigCk" Content="Tilt Down" Tag="Tilt Down" Click="ControlUnloadTriggerCheckBox_Click" />
+                        <CheckBox x:Name="unloadTiltDownTrigCk" Content="{lex:Loc TiltDown}" Tag="Tilt Down" Click="ControlUnloadTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="unloadTiltLeftTrigCk" Content="Tilt Left" Tag="Tilt Left" Click="ControlUnloadTriggerCheckBox_Click" />
+                        <CheckBox x:Name="unloadTiltLeftTrigCk" Content="{lex:Loc TiltLeft}" Tag="Tilt Left" Click="ControlUnloadTriggerCheckBox_Click" />
                     </ListViewItem>
                     <ListViewItem>
-                        <CheckBox x:Name="unloadTiltRightTrigCk" Content="Tilt Right" Tag="Tilt Right" Click="ControlUnloadTriggerCheckBox_Click" />
+                        <CheckBox x:Name="unloadTiltRightTrigCk" Content="{lex:Loc TiltRight}" Tag="Tilt Right" Click="ControlUnloadTriggerCheckBox_Click" />
                     </ListViewItem>
                 </ListView>
             </DockPanel>
@@ -315,25 +315,25 @@
                         <TabItem x:Name="blankActTab" Header="">
 
                         </TabItem>
-                        <TabItem x:Name="macroActTab" Header="Macro">
+                        <TabItem x:Name="macroActTab" Header="{lex:Loc Macro}">
                             <StackPanel Margin="{StaticResource spaceMargin}">
-                                <Button x:Name="recordMacroBtn" Content="Record a macro"
+                                <Button x:Name="recordMacroBtn" Content="{lex:Loc RecordMacro}"
                                         Tag="{Binding Macro,Mode=OneWay,ValidatesOnNotifyDataErrors=True}" Margin="{StaticResource spaceMargin}"
                                         Click="RecordMacroBtn_Click" />
-                                <CheckBox Content="Scan Code" Margin="{StaticResource spaceMargin}" IsChecked="{Binding UseScanCode}" />
-                                <CheckBox Content="Run on Trigger Release" Margin="{StaticResource spaceMargin}" IsChecked="{Binding RunTriggerRelease}" />
-                                <CheckBox Content="Synchronized Run" Margin="{StaticResource spaceMargin}" IsChecked="{Binding SyncRun}" />
-                                <CheckBox Content="Keep key state" Margin="{StaticResource spaceMargin}" IsChecked="{Binding KeepKeyState}" />
-                                <CheckBox Content="Repeat while held" Margin="{StaticResource spaceMargin}" IsChecked="{Binding RepeatHeld}" />
+                                <CheckBox Content="{lex:Loc ScanCode}" Margin="{StaticResource spaceMargin}" IsChecked="{Binding UseScanCode}" />
+                                <CheckBox Content="{lex:Loc RunTriggerRelease}" Margin="{StaticResource spaceMargin}" IsChecked="{Binding RunTriggerRelease}" />
+                                <CheckBox Content="{lex:Loc SyncRun}" Margin="{StaticResource spaceMargin}" IsChecked="{Binding SyncRun}" />
+                                <CheckBox Content="{lex:Loc KeepKeyState}" Margin="{StaticResource spaceMargin}" IsChecked="{Binding KeepKeyState}" />
+                                <CheckBox Content="{lex:Loc RepeatHeld}" Margin="{StaticResource spaceMargin}" IsChecked="{Binding RepeatHeld}" />
                                 <TextBlock Text="{Binding Macrostring,FallbackValue='Macro Recorded'}" Margin="{StaticResource spaceMargin}" />
                             </StackPanel>
                         </TabItem>
-                        <TabItem x:Name="launchProgActTab" Header="Launch Program">
+                        <TabItem x:Name="launchProgActTab" Header="{lex:Loc LaunchProgram}">
                             <StackPanel Margin="{StaticResource spaceMargin}">
                                 <StackPanel Orientation="Horizontal" Margin="{StaticResource spaceMargin}">
-                                    <Label Content="Hold for "></Label>
+                                    <Label Content="{lex:Loc HoldFor}"></Label>
                                     <xctk:IntegerUpDown Value="{Binding Delay}" Width="60" Minimum="0" Maximum="60" />
-                                    <Label Content="secs" />
+                                    <Label Content="{lex:Loc Secs}" />
                                 </StackPanel>
                                 <Button x:Name="launchProgBrowseBtn" Content="{lex:Loc Browse}" Margin="{StaticResource spaceMargin}"
                                         Click="LaunchProgBrowseBtn_Click" />
@@ -342,12 +342,12 @@
                                     <Image Source="{Binding ProgramIcon}" Width="32" Height="32" Margin="10,0,0,0" />
                                 </StackPanel>
                                 <StackPanel Margin="{StaticResource spaceMargin}">
-                                    <Label Content="Arguments"/>
+                                    <Label Content="{lex:Loc Arguments}"/>
                                     <TextBox Text="{Binding Arguments}" />
                                 </StackPanel>
                             </StackPanel>
                         </TabItem>
-                        <TabItem x:Name="loadProfileTab" Header="Load Profile">
+                        <TabItem x:Name="loadProfileTab" Header="{lex:Loc LoadProfile}">
                             <StackPanel Margin="{StaticResource spaceMargin}">
                                 <ComboBox SelectedIndex="{Binding ProfileIndex,FallbackValue=0}"
                                           Margin="{StaticResource spaceMargin}">
@@ -369,22 +369,22 @@
                                         </CompositeCollection>
                                     </ComboBox.ItemsSource>
                                 </ComboBox>
-                                <Button x:Name="loadProfUnloadBtn" Content="Set Unload Trigger" Margin="{StaticResource spaceMargin}"
+                                <Button x:Name="loadProfUnloadBtn" Content="{lex:Loc SetUnloadTrigger}" Margin="{StaticResource spaceMargin}"
                                         IsEnabled="{Binding UnloadEnabled}" Click="LoadProfUnloadBtn_Click" />
-                                <CheckBox Content="Unload on trigger release" Margin="{StaticResource spaceMargin}" IsChecked="{Binding AutoUntrigger}" />
+                                <CheckBox Content="{lex:Loc AutoUntrigger}" Margin="{StaticResource spaceMargin}" IsChecked="{Binding AutoUntrigger}" />
                             </StackPanel>
                         </TabItem>
-                        <TabItem x:Name="pressKetActTab" Header="Press Key">
+                        <TabItem x:Name="pressKetActTab" Header="{lex:Loc PressKey}">
                             <StackPanel Margin="{StaticResource spaceMargin}">
                                 <Button x:Name="pressKeySelectBtn" Content="{Binding DescribeText,FallbackValue='Select a Key'}"
                                         Margin="{StaticResource spaceMargin}" Click="PressKeySelectBtn_Click" />
-                                <Button x:Name="pressKeyToggleTriggerBtn" Content="Set Unload Trigger"
+                                <Button x:Name="pressKeyToggleTriggerBtn" Content="{lex:Loc SetUnloadTrigger}"
                                         Tag="{Binding UnloadError,ValidatesOnNotifyDataErrors=True}"
                                         Visibility="{Binding ShowToggleControls}"
                                         Margin="{StaticResource spaceMargin}" Click="PressKeyToggleTriggerBtn_Click" />
 
                                 <StackPanel Margin="{StaticResource spaceMargin}" Visibility="{Binding ShowToggleControls}">
-                                    <Label Content="Untoggle key by" />
+                                    <Label Content="{lex:Loc UntoggleKeyBy}" />
                                     <ComboBox x:Name="pressReleaseKeyCombo" SelectedIndex="{Binding PressReleaseIndex}">
                                         <ComboBoxItem Content="pressing unload trigger" />
                                         <ComboBoxItem Content="releasing unload trigger" />
@@ -392,22 +392,22 @@
                                 </StackPanel>
                             </StackPanel>
                         </TabItem>
-                        <TabItem x:Name="disconnectBTTab" Header="DisBT">
+                        <TabItem x:Name="disconnectBTTab" Header="{lex:Loc DisconnectBT}">
                             <StackPanel Orientation="Horizontal" Margin="{StaticResource spaceMargin}">
-                                <Label Content="Hold for "></Label>
+                                <Label Content="{lex:Loc HoldFor}"></Label>
                                 <xctk:IntegerUpDown Value="{Binding HoldInterval}" Width="60" Minimum="0" Maximum="60" />
-                                <Label Content="secs" />
+                                <Label Content="{lex:Loc Secs}" />
                             </StackPanel>
                         </TabItem>
-                        <TabItem x:Name="checkBatteryTab" Header="Check Battery">
+                        <TabItem x:Name="checkBatteryTab" Header="{lex:Loc CheckBattery}">
                             <StackPanel Margin="{StaticResource spaceMargin}">
                                 <StackPanel Orientation="Horizontal" Margin="0,8,0,8">
-                                    <Label Content="Hold for "></Label>
+                                    <Label Content="{lex:Loc HoldFor}"></Label>
                                     <xctk:IntegerUpDown Value="{Binding Delay}" Width="60" Minimum="0" Maximum="60" />
-                                    <Label Content="secs" />
+                                    <Label Content="{lex:Loc Secs}" />
                                 </StackPanel>
-                                <CheckBox Content="via notification" IsChecked="{Binding Notification}" Margin="{StaticResource spaceMargin}" />
-                                <CheckBox Content="via lightbar" IsChecked="{Binding Lightbar}" Margin="{StaticResource spaceMargin}" />
+                                <CheckBox Content="{lex:Loc ViaNotification}" IsChecked="{Binding Notification}" Margin="{StaticResource spaceMargin}" />
+                                <CheckBox Content="{lex:Loc ViaLightbar}" IsChecked="{Binding Lightbar}" Margin="{StaticResource spaceMargin}" />
                                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,8,0,8">
                                     <StackPanel HorizontalAlignment="Left">
                                         <Button x:Name="batteryLowColorBtn" Width="20" Height="20" Click="BatteryEmptyColorBtn_Click">
@@ -437,24 +437,24 @@
                                 </StackPanel>
                             </StackPanel>
                         </TabItem>
-                        <TabItem x:Name="multiActTab" Header="MultiAct">
+                        <TabItem x:Name="multiActTab" Header="{lex:Loc MultiAct}">
                             <StackPanel Margin="{StaticResource spaceMargin}">
-                                <Label Content="Tap Trigger" Margin="{StaticResource spaceMargin}" />
+                                <Label Content="{lex:Loc TapTrigger}" Margin="{StaticResource spaceMargin}" />
                                 <Button x:Name="multiTapTrigBtn" Content="{Binding TapMacroText,FallbackValue='Select a macro'}"
                                         Margin="{StaticResource spaceMargin}" Click="MultiTapTrigBtn_Click" />
-                                <Label Content="Hold Trigger" Margin="{StaticResource spaceMargin}" />
+                                <Label Content="{lex:Loc HoldTrigger}" Margin="{StaticResource spaceMargin}" />
                                 <Button x:Name="multiHoldTapTrigBtn" Content="{Binding HoldMacroText,FallbackValue='Select a macro'}"
                                         Margin="{StaticResource spaceMargin}" Click="MultiHoldTapTrigBtn_Click" />
-                                <Label Content="Double Tap Trigger" Margin="{StaticResource spaceMargin}" />
+                                <Label Content="{lex:Loc DoubleTapTrigger}" Margin="{StaticResource spaceMargin}" />
                                 <Button x:Name="multiDoubleTapTrigBtn" Content="{Binding DoubleTapMacroText,FallbackValue='Select a macro'}"
                                         Margin="{StaticResource spaceMargin}" Click="MultiDoubleTapTrigBtn_Click" />
                             </StackPanel>
                         </TabItem>
-                        <TabItem x:Name="sixaxisWheelCalibrateTab" Header="Sixaxis Wheel">
+                        <TabItem x:Name="sixaxisWheelCalibrateTab" Header="{lex:Loc SixaxisWheel}">
                             <StackPanel Orientation="Horizontal" Margin="{StaticResource spaceMargin}">
-                                <Label Content="Hold for "></Label>
+                                <Label Content="{lex:Loc HoldFor}"></Label>
                                 <xctk:IntegerUpDown Value="{Binding Delay}" Width="60" Minimum="0" Maximum="60" />
-                                <Label Content="secs" />
+                                <Label Content="{lex:Loc Secs}" />
                             </StackPanel>
                         </TabItem>
                     </TabControl>

--- a/DS4Windows/DS4Forms/UpdaterWindow.xaml
+++ b/DS4Windows/DS4Forms/UpdaterWindow.xaml
@@ -4,6 +4,9 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:lex="http://wpflocalizeextension.codeplex.com"
+        lex:LocalizeDictionary.DesignCulture=""
+        lex:ResxLocalizationProvider.DefaultAssembly="DS4Windows"
+        lex:ResxLocalizationProvider.DefaultDictionary="Strings"
         xmlns:local="clr-namespace:DS4WinWPF.DS4Forms"
         mc:Ignorable="d"
         Title="UpdaterWindow" Height="450" Width="800"
@@ -11,9 +14,9 @@
     <DockPanel Margin="8,0">
         <TextBlock x:Name="captionTextBlock" Text="{Binding IntroText}" DockPanel.Dock="Top" Margin="0,4" />
         <StackPanel Orientation="Horizontal" DockPanel.Dock="Bottom" HorizontalAlignment="Right" Margin="0,0,0,8">
-            <Button x:Name="skipVersionBtn" Content="Skip Version" MinWidth="80" Click="SkipVersionBtn_Click" />
-            <Button x:Name="yesBtn" Content="Yes" MinWidth="60" Click="YesBtn_Click" Margin="10,0,0,0" />
-            <Button x:Name="noBtn" Content="No" MinWidth="60" Click="NoBtn_Click" Margin="10,0,0,0" />
+            <Button x:Name="skipVersionBtn" Content="{lex:Loc SkipVersion}" MinWidth="80" Click="SkipVersionBtn_Click" />
+            <Button x:Name="yesBtn" Content="{lex:Loc Yes}" MinWidth="60" Click="YesBtn_Click" Margin="10,0,0,0" />
+            <Button x:Name="noBtn" Content="{lex:Loc No}" MinWidth="60" Click="NoBtn_Click" Margin="10,0,0,0" />
         </StackPanel>
 
         <!--<TextBox x:Name="changelogText" Text="{Binding ChangelogText,Mode=OneWay}" AllowDrop="False" VerticalScrollBarVisibility="Auto" IsReadOnly="True" IsUndoEnabled="False" />-->

--- a/DS4Windows/DS4Forms/WelcomeDialog.xaml
+++ b/DS4Windows/DS4Forms/WelcomeDialog.xaml
@@ -3,6 +3,10 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:lex="http://wpflocalizeextension.codeplex.com"
+        lex:LocalizeDictionary.DesignCulture=""
+        lex:ResxLocalizationProvider.DefaultAssembly="DS4Windows"
+        lex:ResxLocalizationProvider.DefaultDictionary="Strings"
         xmlns:local="clr-namespace:DS4WinWPF.DS4Forms"
         mc:Ignorable="d"
         Title="Welcome to DS4Windows" Height="440" Width="418" MinWidth="500" MinHeight="500"
@@ -17,13 +21,13 @@
     </Window.Resources>
     <ScrollViewer>
         <DockPanel Margin="10,10,10,10" LastChildFill="False">
-            <Button x:Name="vigemInstallBtn" Content="Step 1: Install ViGEmBus Driver" Style="{StaticResource CommonMargin}" DockPanel.Dock="Top" Click="VigemInstallBtn_Click" />
+            <Button x:Name="vigemInstallBtn" Content="{lex:Loc Step1}" Style="{StaticResource CommonMargin}" DockPanel.Dock="Top" Click="VigemInstallBtn_Click" />
             <TextBlock TextAlignment="Center" DockPanel.Dock="Top" TextWrapping="Wrap">
                 <TextBlock.Text>
                     If this window reappears after installing, you may need to reboot your PC.
                 </TextBlock.Text>
             </TextBlock>
-            <Button x:Name="step2Btn" Content="Step 2: If on Windows 7, Install 360 Driver" Style="{StaticResource CommonMargin}" DockPanel.Dock="Top"
+            <Button x:Name="step2Btn" Content="{lex:Loc Step2}" Style="{StaticResource CommonMargin}" DockPanel.Dock="Top"
                 Click="Step2Btn_Click" />
             <TextBlock TextAlignment="Center" DockPanel.Dock="Top">
                 <TextBlock.Text>
@@ -48,7 +52,7 @@
             </DockPanel>
 
             <StackPanel x:Name="step4HidHidePanel" DockPanel.Dock="Top" Margin="0,8,0,0">
-                <Button x:Name="hidHideInstallBtn" Content="(Optional) Step 4: Install HidHide Driver" Click="HidHideInstall_Click" />
+                <Button x:Name="hidHideInstallBtn" Content="{lex:Loc Step4}" Click="HidHideInstall_Click" />
                 <TextBlock TextWrapping="Wrap" TextAlignment="Center" Margin="0, 10, 0, 0">
                     <TextBlock.Text>
                         Use HidHide to configure and hide any input controllers from other apps running on your system.
@@ -58,7 +62,7 @@
             </StackPanel>
 
             <StackPanel x:Name="step5FakerInputPanel" DockPanel.Dock="Top" Margin="0,8,0,0">
-                <Button x:Name="fakerInputInstallBtn" Content="(Optional) Step 5: Install FakerInput Driver" Click="FakerInputInstallBtn_Click" />
+                <Button x:Name="fakerInputInstallBtn" Content="{lex:Loc Step5}" Click="FakerInputInstallBtn_Click" />
                 <TextBlock TextWrapping="Wrap" TextAlignment="Center" Margin="0, 10, 0, 0">
                     <TextBlock.Text>
                         Use FakerInput driver to expose system-wide virtual keyboard, relative mouse, and absolute mouse.
@@ -70,7 +74,7 @@
                 </TextBlock>
             </StackPanel>
 
-            <Button x:Name="finishedBtn" Content="Finished" HorizontalAlignment="Center" Padding="10,1" Style="{StaticResource CommonMargin}" Click="FinishedBtn_Click" DockPanel.Dock="Bottom" />
+            <Button x:Name="finishedBtn" Content="{lex:Loc Finished}" HorizontalAlignment="Center" Padding="10,1" Style="{StaticResource CommonMargin}" Click="FinishedBtn_Click" DockPanel.Dock="Bottom" />
         </DockPanel>
     </ScrollViewer>
 </Window>

--- a/DS4Windows/Translations/Strings.Designer.cs
+++ b/DS4Windows/Translations/Strings.Designer.cs
@@ -2127,9 +2127,9 @@ namespace DS4WinWPF.Translations {
         /// <summary>
         ///   Looks up a localized string similar to Minimize to Taskbar instead of System Tray.
         /// </summary>
-        public static string MinimizeToTaskbarInsteadOfSystemTray {
+        public static string MinimizeToTaskbarTip {
             get {
-                return ResourceManager.GetString("MinimizeToTaskbarInsteadOfSystemTray", resourceCulture);
+                return ResourceManager.GetString("MinimizeToTaskbarTip", resourceCulture);
             }
         }
         

--- a/DS4Windows/Translations/Strings.Designer.cs
+++ b/DS4Windows/Translations/Strings.Designer.cs
@@ -61,6 +61,24 @@ namespace DS4WinWPF.Translations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to 360 Steering Wheel.
+        /// </summary>
+        public static string _360SteeringWheel {
+            get {
+                return ResourceManager.GetString("360SteeringWheel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Absolute Mouse.
+        /// </summary>
+        public static string AbsoluteMouse {
+            get {
+                return ResourceManager.GetString("AbsoluteMouse", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Accel.
         /// </summary>
         public static string Accel {
@@ -70,11 +88,56 @@ namespace DS4WinWPF.Translations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to X.
+        /// </summary>
+        public static string AccelX {
+            get {
+                return ResourceManager.GetString("AccelX", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Y.
+        /// </summary>
+        public static string AccelY {
+            get {
+                return ResourceManager.GetString("AccelY", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Z.
+        /// </summary>
+        public static string AccelZ {
+            get {
+                return ResourceManager.GetString("AccelZ", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Accept.
+        /// </summary>
+        public static string Accept {
+            get {
+                return ResourceManager.GetString("Accept", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Action.
         /// </summary>
         public static string Action {
             get {
                 return ResourceManager.GetString("Action", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Active.
+        /// </summary>
+        public static string Active {
+            get {
+                return ResourceManager.GetString("Active", resourceCulture);
             }
         }
         
@@ -93,6 +156,15 @@ namespace DS4WinWPF.Translations {
         public static string AddPrograms {
             get {
                 return ResourceManager.GetString("AddPrograms", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Add Rumble.
+        /// </summary>
+        public static string AddRumble {
+            get {
+                return ResourceManager.GetString("AddRumble", resourceCulture);
             }
         }
         
@@ -124,11 +196,83 @@ namespace DS4WinWPF.Translations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Always On.
+        /// </summary>
+        public static string AlwaysOn {
+            get {
+                return ResourceManager.GetString("AlwaysOn", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Anti-dead Zone:.
+        /// </summary>
+        public static string AntiDeadZone {
+            get {
+                return ResourceManager.GetString("AntiDeadZone", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Anti Snapback:.
+        /// </summary>
+        public static string AntiSnapback {
+            get {
+                return ResourceManager.GetString("AntiSnapback", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Anti Snapback timing:.
+        /// </summary>
+        public static string AntiSnapbackTiming {
+            get {
+                return ResourceManager.GetString("AntiSnapbackTiming", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Appdata.
+        /// </summary>
+        public static string Appdata {
+            get {
+                return ResourceManager.GetString("Appdata", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Apply.
         /// </summary>
         public static string Apply {
             get {
                 return ResourceManager.GetString("Apply", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to App Theme:.
+        /// </summary>
+        public static string AppTheme {
+            get {
+                return ResourceManager.GetString("AppTheme", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Arguments.
+        /// </summary>
+        public static string Arguments {
+            get {
+                return ResourceManager.GetString("Arguments", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Arrow Keys.
+        /// </summary>
+        public static string ArrowKeys {
+            get {
+                return ResourceManager.GetString("ArrowKeys", resourceCulture);
             }
         }
         
@@ -160,11 +304,56 @@ namespace DS4WinWPF.Translations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Unload on trigger release.
+        /// </summary>
+        public static string AutoUntrigger {
+            get {
+                return ResourceManager.GetString("AutoUntrigger", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Axial.
+        /// </summary>
+        public static string Axial {
+            get {
+                return ResourceManager.GetString("Axial", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Axis Config.
+        /// </summary>
+        public static string AxisConfig {
+            get {
+                return ResourceManager.GetString("AxisConfig", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Battery.
         /// </summary>
         public static string Battery {
             get {
                 return ResourceManager.GetString("Battery", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Battery: 0%.
+        /// </summary>
+        public static string Battery0 {
+            get {
+                return ResourceManager.GetString("Battery0", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Blank.
+        /// </summary>
+        public static string Blank {
+            get {
+                return ResourceManager.GetString("Blank", resourceCulture);
             }
         }
         
@@ -187,6 +376,24 @@ namespace DS4WinWPF.Translations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to BT Poll Rate.
+        /// </summary>
+        public static string BTPollRate {
+            get {
+                return ResourceManager.GetString("BTPollRate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Calibrate.
+        /// </summary>
+        public static string Calibrate {
+            get {
+                return ResourceManager.GetString("Calibrate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Cancel.
         /// </summary>
         public static string Cancel {
@@ -196,11 +403,56 @@ namespace DS4WinWPF.Translations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Change Light.
+        /// </summary>
+        public static string ChangeLight {
+            get {
+                return ResourceManager.GetString("ChangeLight", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Change Lightbar Color.
+        /// </summary>
+        public static string ChangeLightbarColor {
+            get {
+                return ResourceManager.GetString("ChangeLightbarColor", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Changelog.
         /// </summary>
         public static string Changelog {
             get {
                 return ResourceManager.GetString("Changelog", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Change Mouse Sensitivity.
+        /// </summary>
+        public static string ChangeMouseSensitivity {
+            get {
+                return ResourceManager.GetString("ChangeMouseSensitivity", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Check Battery.
+        /// </summary>
+        public static string CheckBattery {
+            get {
+                return ResourceManager.GetString("CheckBattery", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Check every .
+        /// </summary>
+        public static string CheckEvery {
+            get {
+                return ResourceManager.GetString("CheckEvery", resourceCulture);
             }
         }
         
@@ -219,6 +471,15 @@ namespace DS4WinWPF.Translations {
         public static string CheckUpdateStartup {
             get {
                 return ResourceManager.GetString("CheckUpdateStartup", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Circle.
+        /// </summary>
+        public static string Circle {
+            get {
+                return ResourceManager.GetString("Circle", resourceCulture);
             }
         }
         
@@ -255,6 +516,42 @@ namespace DS4WinWPF.Translations {
         public static string Color {
             get {
                 return ResourceManager.GetString("Color", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to B.
+        /// </summary>
+        public static string ColorB {
+            get {
+                return ResourceManager.GetString("ColorB", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Color by Battery %.
+        /// </summary>
+        public static string ColorByBatteryPercent {
+            get {
+                return ResourceManager.GetString("ColorByBatteryPercent", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to G.
+        /// </summary>
+        public static string ColorG {
+            get {
+                return ResourceManager.GetString("ColorG", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to R.
+        /// </summary>
+        public static string ColorR {
+            get {
+                return ResourceManager.GetString("ColorR", resourceCulture);
             }
         }
         
@@ -331,6 +628,15 @@ namespace DS4WinWPF.Translations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Controller Readings.
+        /// </summary>
+        public static string ControllerReadings {
+            get {
+                return ResourceManager.GetString("ControllerReadings", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Controllers.
         /// </summary>
         public static string Controllers {
@@ -349,11 +655,83 @@ namespace DS4WinWPF.Translations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Controls.
+        /// </summary>
+        public static string Controls {
+            get {
+                return ResourceManager.GetString("Controls", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Right click to disconnect wireless.
+        /// </summary>
+        public static string ContStatusTip {
+            get {
+                return ResourceManager.GetString("ContStatusTip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Copycat.
+        /// </summary>
+        public static string Copycat {
+            get {
+                return ResourceManager.GetString("Copycat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Change some flags used for a non-Sony DS4 controller. It might fix rumble and lightbar support for some third party DS4 clones.
+        /// </summary>
+        public static string CopycatTip {
+            get {
+                return ResourceManager.GetString("CopycatTip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Data integrity checks failed for wireless device. Closing device..
         /// </summary>
         public static string CRC32Fail {
             get {
                 return ResourceManager.GetString("CRC32Fail", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Credits.
+        /// </summary>
+        public static string Credits {
+            get {
+                return ResourceManager.GetString("Credits", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cross.
+        /// </summary>
+        public static string Cross {
+            get {
+                return ResourceManager.GetString("Cross", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Current.
+        /// </summary>
+        public static string Current {
+            get {
+                return ResourceManager.GetString("Current", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Curve (Input):.
+        /// </summary>
+        public static string CurveInput {
+            get {
+                return ResourceManager.GetString("CurveInput", resourceCulture);
             }
         }
         
@@ -378,6 +756,105 @@ namespace DS4WinWPF.Translations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cycle Programs.
+        /// </summary>
+        public static string CyclePrograms {
+            get {
+                return ResourceManager.GetString("CyclePrograms", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Data.
+        /// </summary>
+        public static string Data {
+            get {
+                return ResourceManager.GetString("Data", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Dead Zone.
+        /// </summary>
+        public static string Dead_Zone {
+            get {
+                return ResourceManager.GetString("Dead_Zone", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Deadzone.
+        /// </summary>
+        public static string Deadzone {
+            get {
+                return ResourceManager.GetString("Deadzone", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Dead Zone:.
+        /// </summary>
+        public static string DeadZone_ {
+            get {
+                return ResourceManager.GetString("DeadZone_", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Dead Zone Type.
+        /// </summary>
+        public static string DeadZoneType {
+            get {
+                return ResourceManager.GetString("DeadZoneType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Deadzone X.
+        /// </summary>
+        public static string DeadzoneX {
+            get {
+                return ResourceManager.GetString("DeadzoneX", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Deadzone Y.
+        /// </summary>
+        public static string DeadzoneY {
+            get {
+                return ResourceManager.GetString("DeadzoneY", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Default.
+        /// </summary>
+        public static string Default {
+            get {
+                return ResourceManager.GetString("Default", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to deg/sec..
+        /// </summary>
+        public static string DegPerSec {
+            get {
+                return ResourceManager.GetString("DegPerSec", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Delay Time.
+        /// </summary>
+        public static string DelayTime {
+            get {
+                return ResourceManager.GetString("DelayTime", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Delete.
         /// </summary>
         public static string Delete {
@@ -396,11 +873,137 @@ namespace DS4WinWPF.Translations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Detected Controllers.
+        /// </summary>
+        public static string DetectedControllers {
+            get {
+                return ResourceManager.GetString("DetectedControllers", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Device Options.
+        /// </summary>
+        public static string DeviceOptions {
+            get {
+                return ResourceManager.GetString("DeviceOptions", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Disable Invert.
+        /// </summary>
+        public static string DisableInvert {
+            get {
+                return ResourceManager.GetString("DisableInvert", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to DisBT.
+        /// </summary>
+        public static string DisconnectBT {
+            get {
+                return ResourceManager.GetString("DisconnectBT", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Disconnect from BT when Stopping.
+        /// </summary>
+        public static string DisconnectBTStop {
+            get {
+                return ResourceManager.GetString("DisconnectBTStop", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Don&apos;t Delete the other settings yet.
+        /// </summary>
+        public static string DontDelete {
+            get {
+                return ResourceManager.GetString("DontDelete", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Double Tap.
+        /// </summary>
+        public static string DoubleTap {
+            get {
+                return ResourceManager.GetString("DoubleTap", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Double Tap Trigger.
+        /// </summary>
+        public static string DoubleTapTrigger {
+            get {
+                return ResourceManager.GetString("DoubleTapTrigger", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Down.
+        /// </summary>
+        public static string Down {
+            get {
+                return ResourceManager.GetString("Down", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to DPad.
+        /// </summary>
+        public static string DPad {
+            get {
+                return ResourceManager.GetString("DPad", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Controller/Driver Setup.
         /// </summary>
         public static string DriverSetup {
             get {
                 return ResourceManager.GetString("DriverSetup", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to DS4.
+        /// </summary>
+        public static string DS4 {
+            get {
+                return ResourceManager.GetString("DS4", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to DS4 Controller Support.
+        /// </summary>
+        public static string DS4ControllerSupport {
+            get {
+                return ResourceManager.GetString("DS4ControllerSupport", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to DualSense.
+        /// </summary>
+        public static string DualSense {
+            get {
+                return ResourceManager.GetString("DualSense", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to DualSense Controller Support.
+        /// </summary>
+        public static string DualSenseControllerSupport {
+            get {
+                return ResourceManager.GetString("DualSenseControllerSupport", resourceCulture);
             }
         }
         
@@ -432,6 +1035,33 @@ namespace DS4WinWPF.Translations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Empty.
+        /// </summary>
+        public static string Empty {
+            get {
+                return ResourceManager.GetString("Empty", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Emulated Controller.
+        /// </summary>
+        public static string EmulatedController {
+            get {
+                return ResourceManager.GetString("EmulatedController", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enable Home LED.
+        /// </summary>
+        public static string EnableHomeLED {
+            get {
+                return ResourceManager.GetString("EnableHomeLED", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Enable Output data to DS4.
         /// </summary>
         public static string EnableOutputDataToDS4 {
@@ -451,6 +1081,51 @@ namespace DS4WinWPF.Translations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Enable Rumble Emulation.
+        /// </summary>
+        public static string EnableRumbleEmulation {
+            get {
+                return ResourceManager.GetString("EnableRumbleEmulation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enable Server.
+        /// </summary>
+        public static string EnableServer {
+            get {
+                return ResourceManager.GetString("EnableServer", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enable Touchpad Toggle.
+        /// </summary>
+        public static string EnableTouchpadToggle {
+            get {
+                return ResourceManager.GetString("EnableTouchpadToggle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Eval Cond..
+        /// </summary>
+        public static string EvalCond {
+            get {
+                return ResourceManager.GetString("EvalCond", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Ex.
+        /// </summary>
+        public static string Ex {
+            get {
+                return ResourceManager.GetString("Ex", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Exclusive Access.
         /// </summary>
         public static string ExclusiveAccess {
@@ -460,11 +1135,92 @@ namespace DS4WinWPF.Translations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Exit.
+        /// </summary>
+        public static string Exit {
+            get {
+                return ResourceManager.GetString("Exit", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Export.
         /// </summary>
         public static string Export {
             get {
                 return ResourceManager.GetString("Export", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Extra.
+        /// </summary>
+        public static string Extra {
+            get {
+                return ResourceManager.GetString("Extra", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Face Buttons.
+        /// </summary>
+        public static string FaceButtons {
+            get {
+                return ResourceManager.GetString("FaceButtons", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 5th Mouse Button.
+        /// </summary>
+        public static string FifthMouseButton {
+            get {
+                return ResourceManager.GetString("FifthMouseButton", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Finger on Touchpad.
+        /// </summary>
+        public static string FingerOnTouchpad {
+            get {
+                return ResourceManager.GetString("FingerOnTouchpad", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Finished.
+        /// </summary>
+        public static string Finished {
+            get {
+                return ResourceManager.GetString("Finished", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Flash Lightbar at High Latency.
+        /// </summary>
+        public static string FlashHighLatency {
+            get {
+                return ResourceManager.GetString("FlashHighLatency", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Flash Rate.
+        /// </summary>
+        public static string FlashRate {
+            get {
+                return ResourceManager.GetString("FlashRate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to FlickStick.
+        /// </summary>
+        public static string FlickStick {
+            get {
+                return ResourceManager.GetString("FlickStick", resourceCulture);
             }
         }
         
@@ -487,6 +1243,42 @@ namespace DS4WinWPF.Translations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to for readout.
+        /// </summary>
+        public static string ForReadout {
+            get {
+                return ResourceManager.GetString("ForReadout", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 4th Mouse Button.
+        /// </summary>
+        public static string FourthMouseButton {
+            get {
+                return ResourceManager.GetString("FourthMouseButton", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Friction:.
+        /// </summary>
+        public static string Friction {
+            get {
+                return ResourceManager.GetString("Friction", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to From File....
+        /// </summary>
+        public static string FromFile {
+            get {
+                return ResourceManager.GetString("FromFile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Full.
         /// </summary>
         public static string Full {
@@ -496,11 +1288,38 @@ namespace DS4WinWPF.Translations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Full.
+        /// </summary>
+        public static string FullPull {
+            get {
+                return ResourceManager.GetString("FullPull", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Full Pull Btn:.
+        /// </summary>
+        public static string FullPullBtn {
+            get {
+                return ResourceManager.GetString("FullPullBtn", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to .NET 5 Runtime was not detected on your system. Please download and install .NET 5 Runtime to ensure compatibility with future DS4Windows builds. You will be redirected to the .NET 5 Runtime download page upon closing this window..
         /// </summary>
         public static string FutureNetNotInstalled {
             get {
                 return ResourceManager.GetString("FutureNetNotInstalled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Fuzz:.
+        /// </summary>
+        public static string Fuzz {
+            get {
+                return ResourceManager.GetString("Fuzz", resourceCulture);
             }
         }
         
@@ -550,11 +1369,74 @@ namespace DS4WinWPF.Translations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Guide.
+        /// </summary>
+        public static string Guide {
+            get {
+                return ResourceManager.GetString("Guide", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Gyro.
         /// </summary>
         public static string Gyro {
             get {
                 return ResourceManager.GetString("Gyro", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Gyro Calibration.
+        /// </summary>
+        public static string GyroCalibration {
+            get {
+                return ResourceManager.GetString("GyroCalibration", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to X.
+        /// </summary>
+        public static string GyroMouseInvertX {
+            get {
+                return ResourceManager.GetString("GyroMouseInvertX", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Y.
+        /// </summary>
+        public static string GyroMouseInvertY {
+            get {
+                return ResourceManager.GetString("GyroMouseInvertY", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Gyro Sensitivity:.
+        /// </summary>
+        public static string GyroSensitivity {
+            get {
+                return ResourceManager.GetString("GyroSensitivity", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Heavy.
+        /// </summary>
+        public static string Heavy {
+            get {
+                return ResourceManager.GetString("Heavy", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Hide DS4 Controller.
+        /// </summary>
+        public static string HideDS4Controller {
+            get {
+                return ResourceManager.GetString("HideDS4Controller", resourceCulture);
             }
         }
         
@@ -613,11 +1495,209 @@ namespace DS4WinWPF.Translations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Hip Fire Delay:.
+        /// </summary>
+        public static string HipFireDelay {
+            get {
+                return ResourceManager.GetString("HipFireDelay", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Hold for .
+        /// </summary>
+        public static string HoldFor {
+            get {
+                return ResourceManager.GetString("HoldFor", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Hold Trigger.
+        /// </summary>
+        public static string HoldTrigger {
+            get {
+                return ResourceManager.GetString("HoldTrigger", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Hotkeys.
+        /// </summary>
+        public static string Hotkeys {
+            get {
+                return ResourceManager.GetString("Hotkeys", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Icon Choice:.
+        /// </summary>
+        public static string IconChoice {
+            get {
+                return ResourceManager.GetString("IconChoice", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to ID.
+        /// </summary>
+        public static string ID {
+            get {
+                return ResourceManager.GetString("ID", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Idle Disconnect.
+        /// </summary>
+        public static string IdleDisconnect {
+            get {
+                return ResourceManager.GetString("IdleDisconnect", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Import.
         /// </summary>
         public static string Import {
             get {
                 return ResourceManager.GetString("Import", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Input Delay: N/A.
+        /// </summary>
+        public static string InputDelayNA {
+            get {
+                return ResourceManager.GetString("InputDelayNA", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Insert Wait.
+        /// </summary>
+        public static string InsertWait {
+            get {
+                return ResourceManager.GetString("InsertWait", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Intro.
+        /// </summary>
+        public static string Intro {
+            get {
+                return ResourceManager.GetString("Intro", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to I: .
+        /// </summary>
+        public static string InVal {
+            get {
+                return ResourceManager.GetString("InVal", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Invert.
+        /// </summary>
+        public static string Invert {
+            get {
+                return ResourceManager.GetString("Invert", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Inverted.
+        /// </summary>
+        public static string Inverted {
+            get {
+                return ResourceManager.GetString("Inverted", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Inverted X.
+        /// </summary>
+        public static string InvertedX {
+            get {
+                return ResourceManager.GetString("InvertedX", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Inverted Y.
+        /// </summary>
+        public static string InvertedY {
+            get {
+                return ResourceManager.GetString("InvertedY", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Invert X.
+        /// </summary>
+        public static string InvertX {
+            get {
+                return ResourceManager.GetString("InvertX", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Invert Y.
+        /// </summary>
+        public static string InvertY {
+            get {
+                return ResourceManager.GetString("InvertY", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Jitter Compensation.
+        /// </summary>
+        public static string JitterCompensation {
+            get {
+                return ResourceManager.GetString("JitterCompensation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Joined Gyro Provider.
+        /// </summary>
+        public static string JoinedGyroProvider {
+            get {
+                return ResourceManager.GetString("JoinedGyroProvider", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to JoyCon.
+        /// </summary>
+        public static string JoyCon {
+            get {
+                return ResourceManager.GetString("JoyCon", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to JoyCon Controller Support.
+        /// </summary>
+        public static string JoyConControllerSupport {
+            get {
+                return ResourceManager.GetString("JoyConControllerSupport", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to JoyCon Global Options.
+        /// </summary>
+        public static string JoyConGlobalOptions {
+            get {
+                return ResourceManager.GetString("JoyConGlobalOptions", resourceCulture);
             }
         }
         
@@ -658,11 +1738,191 @@ namespace DS4WinWPF.Translations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Keep key state.
+        /// </summary>
+        public static string KeepKeyState {
+            get {
+                return ResourceManager.GetString("KeepKeyState", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to L1.
+        /// </summary>
+        public static string L1 {
+            get {
+                return ResourceManager.GetString("L1", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to L2.
+        /// </summary>
+        public static string L2 {
+            get {
+                return ResourceManager.GetString("L2", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to L2 &amp; R2.
+        /// </summary>
+        public static string L2AndR2 {
+            get {
+                return ResourceManager.GetString("L2AndR2", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to L2 Full Pull.
+        /// </summary>
+        public static string L2FullPull {
+            get {
+                return ResourceManager.GetString("L2FullPull", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to L3.
+        /// </summary>
+        public static string L3 {
+            get {
+                return ResourceManager.GetString("L3", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Launch Program.
+        /// </summary>
+        public static string LaunchProgram {
+            get {
+                return ResourceManager.GetString("LaunchProgram", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Launch program with profile.
+        /// </summary>
+        public static string LaunchProgramWithProfile {
+            get {
+                return ResourceManager.GetString("LaunchProgramWithProfile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Left.
+        /// </summary>
+        public static string Left {
+            get {
+                return ResourceManager.GetString("Left", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Left Stick.
         /// </summary>
         public static string LeftStick {
             get {
                 return ResourceManager.GetString("LeftStick", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Left Stick Down.
+        /// </summary>
+        public static string LeftStickDown {
+            get {
+                return ResourceManager.GetString("LeftStickDown", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Left Stick Left.
+        /// </summary>
+        public static string LeftStickLeft {
+            get {
+                return ResourceManager.GetString("LeftStickLeft", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Left Stick Right.
+        /// </summary>
+        public static string LeftStickRight {
+            get {
+                return ResourceManager.GetString("LeftStickRight", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Left Stick Up.
+        /// </summary>
+        public static string LeftStickUp {
+            get {
+                return ResourceManager.GetString("LeftStickUp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Left Touch.
+        /// </summary>
+        public static string LeftTouch {
+            get {
+                return ResourceManager.GetString("LeftTouch", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Light.
+        /// </summary>
+        public static string Light {
+            get {
+                return ResourceManager.GetString("Light", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Lightbar.
+        /// </summary>
+        public static string Lightbar {
+            get {
+                return ResourceManager.GetString("Lightbar", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Link Mode.
+        /// </summary>
+        public static string LinkMode {
+            get {
+                return ResourceManager.GetString("LinkMode", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Link Profile/ID.
+        /// </summary>
+        public static string LinkProfileOrID {
+            get {
+                return ResourceManager.GetString("LinkProfileOrID", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Load Preset.
+        /// </summary>
+        public static string LoadPreset {
+            get {
+                return ResourceManager.GetString("LoadPreset", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Load Profile.
+        /// </summary>
+        public static string LoadProfile {
+            get {
+                return ResourceManager.GetString("LoadProfile", resourceCulture);
             }
         }
         
@@ -676,11 +1936,236 @@ namespace DS4WinWPF.Translations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Lower Right as RMB.
+        /// </summary>
+        public static string LowerRightAsRMB {
+            get {
+                return ResourceManager.GetString("LowerRightAsRMB", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to LS.
+        /// </summary>
+        public static string LS {
+            get {
+                return ResourceManager.GetString("LS", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to LSD.
+        /// </summary>
+        public static string LSD {
+            get {
+                return ResourceManager.GetString("LSD", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to LSL.
+        /// </summary>
+        public static string LSL {
+            get {
+                return ResourceManager.GetString("LSL", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to LSR.
+        /// </summary>
+        public static string LSR {
+            get {
+                return ResourceManager.GetString("LSR", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to LSU.
+        /// </summary>
+        public static string LSU {
+            get {
+                return ResourceManager.GetString("LSU", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to LX (I): .
+        /// </summary>
+        public static string LxInVal {
+            get {
+                return ResourceManager.GetString("LxInVal", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to LX (O): .
+        /// </summary>
+        public static string LxOutVal {
+            get {
+                return ResourceManager.GetString("LxOutVal", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to LY (I): .
+        /// </summary>
+        public static string LyInVal {
+            get {
+                return ResourceManager.GetString("LyInVal", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to LY (O): .
+        /// </summary>
+        public static string LyOutVal {
+            get {
+                return ResourceManager.GetString("LyOutVal", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Macro.
+        /// </summary>
+        public static string Macro {
+            get {
+                return ResourceManager.GetString("Macro", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Macro On, Choose a key to disable, else close this window to save.
+        /// </summary>
+        public static string MacroOn {
+            get {
+                return ResourceManager.GetString("MacroOn", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Macro Order.
+        /// </summary>
+        public static string MacroOrder {
+            get {
+                return ResourceManager.GetString("MacroOrder", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Max Output.
+        /// </summary>
+        public static string MaxOutput {
+            get {
+                return ResourceManager.GetString("MaxOutput", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Max Output:.
+        /// </summary>
+        public static string MaxOutput_ {
+            get {
+                return ResourceManager.GetString("MaxOutput_", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Max Zone.
+        /// </summary>
+        public static string MaxZone {
+            get {
+                return ResourceManager.GetString("MaxZone", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Max Zone:.
+        /// </summary>
+        public static string MaxZone_ {
+            get {
+                return ResourceManager.GetString("MaxZone_", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Max Zone X:.
+        /// </summary>
+        public static string MaxZoneX_ {
+            get {
+                return ResourceManager.GetString("MaxZoneX_", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Max Zone Y:.
+        /// </summary>
+        public static string MaxZoneY_ {
+            get {
+                return ResourceManager.GetString("MaxZoneY_", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Min Angle Threshold.
         /// </summary>
         public static string MinAngleThreshold {
             get {
                 return ResourceManager.GetString("MinAngleThreshold", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Minimize to Taskbar.
+        /// </summary>
+        public static string MinimizeToTaskbar {
+            get {
+                return ResourceManager.GetString("MinimizeToTaskbar", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Minimize to Taskbar instead of System Tray.
+        /// </summary>
+        public static string MinimizeToTaskbarInsteadOfSystemTray {
+            get {
+                return ResourceManager.GetString("MinimizeToTaskbarInsteadOfSystemTray", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Minimum X.
+        /// </summary>
+        public static string MinimumX {
+            get {
+                return ResourceManager.GetString("MinimumX", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Minimum Y.
+        /// </summary>
+        public static string MinimumY {
+            get {
+                return ResourceManager.GetString("MinimumY", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to mins.
+        /// </summary>
+        public static string Mins {
+            get {
+                return ResourceManager.GetString("Mins", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Min Threshold.
+        /// </summary>
+        public static string MinThreshold {
+            get {
+                return ResourceManager.GetString("MinThreshold", resourceCulture);
             }
         }
         
@@ -721,6 +2206,60 @@ namespace DS4WinWPF.Translations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Mode:.
+        /// </summary>
+        public static string Mode {
+            get {
+                return ResourceManager.GetString("Mode", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Mouse.
+        /// </summary>
+        public static string Mouse {
+            get {
+                return ResourceManager.GetString("Mouse", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Mouse Acceleration.
+        /// </summary>
+        public static string MouseAcceleration {
+            get {
+                return ResourceManager.GetString("MouseAcceleration", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Mouse Offset.
+        /// </summary>
+        public static string MouseOffset {
+            get {
+                return ResourceManager.GetString("MouseOffset", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Mouse Sensitivity.
+        /// </summary>
+        public static string MouseSensitivity {
+            get {
+                return ResourceManager.GetString("MouseSensitivity", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Mouse Vertical Scale.
+        /// </summary>
+        public static string MouseVerticalScale {
+            get {
+                return ResourceManager.GetString("MouseVerticalScale", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Move Down.
         /// </summary>
         public static string MoveDown {
@@ -739,11 +2278,83 @@ namespace DS4WinWPF.Translations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to ms.
+        /// </summary>
+        public static string Ms {
+            get {
+                return ResourceManager.GetString("Ms", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Multi Touch.
+        /// </summary>
+        public static string Multi_Touch {
+            get {
+                return ResourceManager.GetString("Multi_Touch", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to MultiAct.
+        /// </summary>
+        public static string MultiAct {
+            get {
+                return ResourceManager.GetString("MultiAct", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Multiple save locations detected.
+        /// </summary>
+        public static string MultipleSaveLocationsDetected {
+            get {
+                return ResourceManager.GetString("MultipleSaveLocationsDetected", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Multitouch.
+        /// </summary>
+        public static string MultiTouch {
+            get {
+                return ResourceManager.GetString("MultiTouch", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Mute.
+        /// </summary>
+        public static string Mute {
+            get {
+                return ResourceManager.GetString("Mute", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Mute LED Mode.
+        /// </summary>
+        public static string MuteLEDMode {
+            get {
+                return ResourceManager.GetString("MuteLEDMode", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Name.
         /// </summary>
         public static string Name {
             get {
                 return ResourceManager.GetString("Name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Name:.
+        /// </summary>
+        public static string Name_ {
+            get {
+                return ResourceManager.GetString("Name_", resourceCulture);
             }
         }
         
@@ -775,6 +2386,15 @@ namespace DS4WinWPF.Translations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to No.
+        /// </summary>
+        public static string No {
+            get {
+                return ResourceManager.GetString("No", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to No Controllers Connected (Max {0}).
         /// </summary>
         public static string NoControllersConnected {
@@ -793,11 +2413,173 @@ namespace DS4WinWPF.Translations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Normal.
+        /// </summary>
+        public static string Normal {
+            get {
+                return ResourceManager.GetString("Normal", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to OK.
+        /// </summary>
+        public static string Ok {
+            get {
+                return ResourceManager.GetString("Ok", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 1€ Beta.
+        /// </summary>
+        public static string OneEuroBeta {
+            get {
+                return ResourceManager.GetString("OneEuroBeta", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 1€ MinCutoff.
+        /// </summary>
+        public static string OneEuroMinCutoff {
+            get {
+                return ResourceManager.GetString("OneEuroMinCutoff", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Open.
+        /// </summary>
+        public static string Open {
+            get {
+                return ResourceManager.GetString("Open", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Options.
+        /// </summary>
+        public static string Options {
+            get {
+                return ResourceManager.GetString("Options", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Other.
+        /// </summary>
+        public static string Other {
+            get {
+                return ResourceManager.GetString("Other", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Output Controller:.
+        /// </summary>
+        public static string OutputController {
+            get {
+                return ResourceManager.GetString("OutputController", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Output Curve:.
+        /// </summary>
+        public static string OutputCurve {
+            get {
+                return ResourceManager.GetString("OutputCurve", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Output Mode.
+        /// </summary>
+        public static string OutputMode {
+            get {
+                return ResourceManager.GetString("OutputMode", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Output Slots.
+        /// </summary>
+        public static string OutputSlots {
+            get {
+                return ResourceManager.GetString("OutputSlots", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to O: .
+        /// </summary>
+        public static string OutVal {
+            get {
+                return ResourceManager.GetString("OutVal", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Passthru.
+        /// </summary>
+        public static string Passthru {
+            get {
+                return ResourceManager.GetString("Passthru", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Passthru Click Action (DS4 mode).
+        /// </summary>
+        public static string PassthruClickAction {
+            get {
+                return ResourceManager.GetString("PassthruClickAction", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Path.
         /// </summary>
         public static string Path {
             get {
                 return ResourceManager.GetString("Path", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Pitch.
+        /// </summary>
+        public static string Pitch {
+            get {
+                return ResourceManager.GetString("Pitch", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Player LED Mode.
+        /// </summary>
+        public static string PlayerLEDMode {
+            get {
+                return ResourceManager.GetString("PlayerLEDMode", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Plug.
+        /// </summary>
+        public static string Plug {
+            get {
+                return ResourceManager.GetString("Plug", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Port.
+        /// </summary>
+        public static string Port {
+            get {
+                return ResourceManager.GetString("Port", resourceCulture);
             }
         }
         
@@ -811,11 +2593,29 @@ namespace DS4WinWPF.Translations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Preset Menu.
+        /// </summary>
+        public static string PresetMenu {
+            get {
+                return ResourceManager.GetString("PresetMenu", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Presets.
         /// </summary>
         public static string Presets {
             get {
                 return ResourceManager.GetString("Presets", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Press Key.
+        /// </summary>
+        public static string PressKey {
+            get {
+                return ResourceManager.GetString("PressKey", resourceCulture);
             }
         }
         
@@ -847,11 +2647,92 @@ namespace DS4WinWPF.Translations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Program.
+        /// </summary>
+        public static string Program {
+            get {
+                return ResourceManager.GetString("Program", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Program Folder.
+        /// </summary>
+        public static string ProgramFolder {
+            get {
+                return ResourceManager.GetString("ProgramFolder", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to DS4Windows - Ryochan7 Build (Version .
+        /// </summary>
+        public static string ProgramName {
+            get {
+                return ResourceManager.GetString("ProgramName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to PS.
+        /// </summary>
+        public static string PS {
+            get {
+                return ResourceManager.GetString("PS", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Quick Charge.
         /// </summary>
         public static string QuickCharge {
             get {
                 return ResourceManager.GetString("QuickCharge", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to R1.
+        /// </summary>
+        public static string R1 {
+            get {
+                return ResourceManager.GetString("R1", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to R2.
+        /// </summary>
+        public static string R2 {
+            get {
+                return ResourceManager.GetString("R2", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to R2 Full Pull.
+        /// </summary>
+        public static string R2FullPull {
+            get {
+                return ResourceManager.GetString("R2FullPull", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to R3.
+        /// </summary>
+        public static string R3 {
+            get {
+                return ResourceManager.GetString("R3", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Radial.
+        /// </summary>
+        public static string Radial {
+            get {
+                return ResourceManager.GetString("Radial", resourceCulture);
             }
         }
         
@@ -865,11 +2746,38 @@ namespace DS4WinWPF.Translations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Record Delays.
+        /// </summary>
+        public static string RecordDelays {
+            get {
+                return ResourceManager.GetString("RecordDelays", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Record a macro.
+        /// </summary>
+        public static string RecordMacro {
+            get {
+                return ResourceManager.GetString("RecordMacro", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Record.
         /// </summary>
         public static string RecordText {
             get {
                 return ResourceManager.GetString("RecordText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Regular.
+        /// </summary>
+        public static string Regular {
+            get {
+                return ResourceManager.GetString("Regular", resourceCulture);
             }
         }
         
@@ -892,11 +2800,182 @@ namespace DS4WinWPF.Translations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Repeat while held.
+        /// </summary>
+        public static string RepeatHeld {
+            get {
+                return ResourceManager.GetString("RepeatHeld", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Requested.
+        /// </summary>
+        public static string Requested {
+            get {
+                return ResourceManager.GetString("Requested", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Revert to default profile on unknown.
+        /// </summary>
+        public static string RevertDefaultProfile {
+            get {
+                return ResourceManager.GetString("RevertDefaultProfile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Right.
+        /// </summary>
+        public static string Right {
+            get {
+                return ResourceManager.GetString("Right", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Right Stick.
         /// </summary>
         public static string RightStick {
             get {
                 return ResourceManager.GetString("RightStick", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Right Stick Down.
+        /// </summary>
+        public static string RightStickDown {
+            get {
+                return ResourceManager.GetString("RightStickDown", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Right Stick Left.
+        /// </summary>
+        public static string RightStickLeft {
+            get {
+                return ResourceManager.GetString("RightStickLeft", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Right Stick Right.
+        /// </summary>
+        public static string RightStickRight {
+            get {
+                return ResourceManager.GetString("RightStickRight", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Right Stick Up.
+        /// </summary>
+        public static string RightStickUp {
+            get {
+                return ResourceManager.GetString("RightStickUp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Right Touch.
+        /// </summary>
+        public static string RightTouch {
+            get {
+                return ResourceManager.GetString("RightTouch", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Roll.
+        /// </summary>
+        public static string Roll {
+            get {
+                return ResourceManager.GetString("Roll", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rotate -90°.
+        /// </summary>
+        public static string Rotate_90 {
+            get {
+                return ResourceManager.GetString("Rotate-90", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rotate 90°.
+        /// </summary>
+        public static string Rotate90 {
+            get {
+                return ResourceManager.GetString("Rotate90", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rotation.
+        /// </summary>
+        public static string Rotation {
+            get {
+                return ResourceManager.GetString("Rotation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rotation:.
+        /// </summary>
+        public static string Rotation_ {
+            get {
+                return ResourceManager.GetString("Rotation_", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to RS.
+        /// </summary>
+        public static string RS {
+            get {
+                return ResourceManager.GetString("RS", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to RSD.
+        /// </summary>
+        public static string RSD {
+            get {
+                return ResourceManager.GetString("RSD", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to RSL.
+        /// </summary>
+        public static string RSL {
+            get {
+                return ResourceManager.GetString("RSL", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to RSR.
+        /// </summary>
+        public static string RSR {
+            get {
+                return ResourceManager.GetString("RSR", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to RSU.
+        /// </summary>
+        public static string RSU {
+            get {
+                return ResourceManager.GetString("RSU", resourceCulture);
             }
         }
         
@@ -928,11 +3007,74 @@ namespace DS4WinWPF.Translations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Rumble Strength.
+        /// </summary>
+        public static string RumbleStrength {
+            get {
+                return ResourceManager.GetString("RumbleStrength", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Run As.
+        /// </summary>
+        public static string RunAs {
+            get {
+                return ResourceManager.GetString("RunAs", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Run At Startup.
         /// </summary>
         public static string RunAtStartup {
             get {
                 return ResourceManager.GetString("RunAtStartup", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Run on Trigger Release.
+        /// </summary>
+        public static string RunTriggerRelease {
+            get {
+                return ResourceManager.GetString("RunTriggerRelease", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to RX (I): .
+        /// </summary>
+        public static string RxInVal {
+            get {
+                return ResourceManager.GetString("RxInVal", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to RX (O): .
+        /// </summary>
+        public static string RxOutVal {
+            get {
+                return ResourceManager.GetString("RxOutVal", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to RY (I): .
+        /// </summary>
+        public static string RyInVal {
+            get {
+                return ResourceManager.GetString("RyInVal", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to RY (O): .
+        /// </summary>
+        public static string RyOutVal {
+            get {
+                return ResourceManager.GetString("RyOutVal", resourceCulture);
             }
         }
         
@@ -946,11 +3088,74 @@ namespace DS4WinWPF.Translations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Save Preset.
+        /// </summary>
+        public static string SavePreset {
+            get {
+                return ResourceManager.GetString("SavePreset", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Save.
         /// </summary>
         public static string SaveProfile {
             get {
                 return ResourceManager.GetString("SaveProfile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Scan Code.
+        /// </summary>
+        public static string ScanCode {
+            get {
+                return ResourceManager.GetString("ScanCode", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to secs.
+        /// </summary>
+        public static string Secs {
+            get {
+                return ResourceManager.GetString("Secs", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to secs/cycle.
+        /// </summary>
+        public static string SecsPerCycle {
+            get {
+                return ResourceManager.GetString("SecsPerCycle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Selected Profile.
+        /// </summary>
+        public static string SelectedProfile {
+            get {
+                return ResourceManager.GetString("SelectedProfile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Select Preset.
+        /// </summary>
+        public static string SelectPreset {
+            get {
+                return ResourceManager.GetString("SelectPreset", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Sensitivity:.
+        /// </summary>
+        public static string Sensitivity {
+            get {
+                return ResourceManager.GetString("Sensitivity", resourceCulture);
             }
         }
         
@@ -964,6 +3169,24 @@ namespace DS4WinWPF.Translations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Set Unload Trigger.
+        /// </summary>
+        public static string SetUnloadTrigger {
+            get {
+                return ResourceManager.GetString("SetUnloadTrigger", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Share.
+        /// </summary>
+        public static string Share {
+            get {
+                return ResourceManager.GetString("Share", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Shared Access.
         /// </summary>
         public static string SharedAccess {
@@ -973,11 +3196,119 @@ namespace DS4WinWPF.Translations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Shift Modifier.
+        /// </summary>
+        public static string ShiftModifier {
+            get {
+                return ResourceManager.GetString("ShiftModifier", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Show auto-profile debug messages.
+        /// </summary>
+        public static string ShowAutoDebug {
+            get {
+                return ResourceManager.GetString("ShowAutoDebug", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Show Notifications.
         /// </summary>
         public static string ShowNotifications {
             get {
                 return ResourceManager.GetString("ShowNotifications", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to SixAxis.
+        /// </summary>
+        public static string SixAxis {
+            get {
+                return ResourceManager.GetString("SixAxis", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Sixaxis Wheel.
+        /// </summary>
+        public static string SixaxisWheel {
+            get {
+                return ResourceManager.GetString("SixaxisWheel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Skip Version.
+        /// </summary>
+        public static string SkipVersion {
+            get {
+                return ResourceManager.GetString("SkipVersion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Smoothing.
+        /// </summary>
+        public static string Smoothing {
+            get {
+                return ResourceManager.GetString("Smoothing", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Smoothing Options.
+        /// </summary>
+        public static string SmoothingOptions {
+            get {
+                return ResourceManager.GetString("SmoothingOptions", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Smooth Weight.
+        /// </summary>
+        public static string SmoothWeight {
+            get {
+                return ResourceManager.GetString("SmoothWeight", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Snap To Center on Release:.
+        /// </summary>
+        public static string SnapToCenterOnRelease {
+            get {
+                return ResourceManager.GetString("SnapToCenterOnRelease", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Special Actions.
+        /// </summary>
+        public static string SpecialActions {
+            get {
+                return ResourceManager.GetString("SpecialActions", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Square.
+        /// </summary>
+        public static string Square {
+            get {
+                return ResourceManager.GetString("Square", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Square Stick:.
+        /// </summary>
+        public static string SquareStick {
+            get {
+                return ResourceManager.GetString("SquareStick", resourceCulture);
             }
         }
         
@@ -1000,6 +3331,15 @@ namespace DS4WinWPF.Translations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Start with Slide/Scroll Off.
+        /// </summary>
+        public static string StartTouchpadOff {
+            get {
+                return ResourceManager.GetString("StartTouchpadOff", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Status.
         /// </summary>
         public static string Status {
@@ -1009,11 +3349,272 @@ namespace DS4WinWPF.Translations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Steering wheel axis.
+        /// </summary>
+        public static string SteeringWheelAxis {
+            get {
+                return ResourceManager.GetString("SteeringWheelAxis", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Steering wheel range.
+        /// </summary>
+        public static string SteeringWheelRange {
+            get {
+                return ResourceManager.GetString("SteeringWheelRange", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Step 1: Install ViGEmBus Driver.
+        /// </summary>
+        public static string Step1 {
+            get {
+                return ResourceManager.GetString("Step1", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Step 2: If on Windows 7, Install 360 Driver.
+        /// </summary>
+        public static string Step2 {
+            get {
+                return ResourceManager.GetString("Step2", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to (Optional) Step 4: Install HidHide Driver.
+        /// </summary>
+        public static string Step4 {
+            get {
+                return ResourceManager.GetString("Step4", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to (Optional) Step 5: Install FakerInput Driver.
+        /// </summary>
+        public static string Step5 {
+            get {
+                return ResourceManager.GetString("Step5", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Stop.
         /// </summary>
         public static string StopText {
             get {
                 return ResourceManager.GetString("StopText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Swipe Down.
+        /// </summary>
+        public static string SwipeDown {
+            get {
+                return ResourceManager.GetString("SwipeDown", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Swipe Left.
+        /// </summary>
+        public static string SwipeLeft {
+            get {
+                return ResourceManager.GetString("SwipeLeft", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Swipe Right.
+        /// </summary>
+        public static string SwipeRight {
+            get {
+                return ResourceManager.GetString("SwipeRight", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Swipe Touchpad To Switch Profiles.
+        /// </summary>
+        public static string SwipeTouch {
+            get {
+                return ResourceManager.GetString("SwipeTouch", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Swipe Up.
+        /// </summary>
+        public static string SwipeUp {
+            get {
+                return ResourceManager.GetString("SwipeUp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Switch Pro.
+        /// </summary>
+        public static string SwitchPro {
+            get {
+                return ResourceManager.GetString("SwitchPro", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Switch Pro Controller Support.
+        /// </summary>
+        public static string SwitchProControllerSupport {
+            get {
+                return ResourceManager.GetString("SwitchProControllerSupport", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Synchronized Run.
+        /// </summary>
+        public static string SyncRun {
+            get {
+                return ResourceManager.GetString("SyncRun", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Tap Trigger.
+        /// </summary>
+        public static string TapTrigger {
+            get {
+                return ResourceManager.GetString("TapTrigger", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Task.
+        /// </summary>
+        public static string Task {
+            get {
+                return ResourceManager.GetString("Task", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Test.
+        /// </summary>
+        public static string Test {
+            get {
+                return ResourceManager.GetString("Test", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Test Heavy.
+        /// </summary>
+        public static string TestHeavy {
+            get {
+                return ResourceManager.GetString("TestHeavy", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Test Light.
+        /// </summary>
+        public static string TestLight {
+            get {
+                return ResourceManager.GetString("TestLight", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Tilt Down.
+        /// </summary>
+        public static string TiltDown {
+            get {
+                return ResourceManager.GetString("TiltDown", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Tilt Left.
+        /// </summary>
+        public static string TiltLeft {
+            get {
+                return ResourceManager.GetString("TiltLeft", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Tilt Right.
+        /// </summary>
+        public static string TiltRight {
+            get {
+                return ResourceManager.GetString("TiltRight", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Tilt Up.
+        /// </summary>
+        public static string TiltUp {
+            get {
+                return ResourceManager.GetString("TiltUp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Time.
+        /// </summary>
+        public static string Time {
+            get {
+                return ResourceManager.GetString("Time", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Tip.
+        /// </summary>
+        public static string Tip {
+            get {
+                return ResourceManager.GetString("Tip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Toggle.
+        /// </summary>
+        public static string Toggle {
+            get {
+                return ResourceManager.GetString("Toggle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Top Touch.
+        /// </summary>
+        public static string TopTouch {
+            get {
+                return ResourceManager.GetString("TopTouch", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Touchpad.
+        /// </summary>
+        public static string Touchpad {
+            get {
+                return ResourceManager.GetString("Touchpad", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Touchpad Click.
+        /// </summary>
+        public static string TouchpadClick {
+            get {
+                return ResourceManager.GetString("TouchpadClick", resourceCulture);
             }
         }
         
@@ -1045,6 +3646,33 @@ namespace DS4WinWPF.Translations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Trackball.
+        /// </summary>
+        public static string Trackball {
+            get {
+                return ResourceManager.GetString("Trackball", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Translators:.
+        /// </summary>
+        public static string Translators {
+            get {
+                return ResourceManager.GetString("Translators", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Triangle.
+        /// </summary>
+        public static string Triangle {
+            get {
+                return ResourceManager.GetString("Triangle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Trigger.
         /// </summary>
         public static string Trigger {
@@ -1054,11 +3682,254 @@ namespace DS4WinWPF.Translations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Trigger Effect:.
+        /// </summary>
+        public static string TriggerEffect {
+            get {
+                return ResourceManager.GetString("TriggerEffect", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Triggers.
+        /// </summary>
+        public static string Triggers {
+            get {
+                return ResourceManager.GetString("Triggers", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Turn Behavior - Turns Gyro.
+        /// </summary>
+        public static string TurnBehaviorTurnsGyro {
+            get {
+                return ResourceManager.GetString("TurnBehaviorTurnsGyro", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Turn Off DS4Window Temporarily.
+        /// </summary>
+        public static string TurnOffTemporarily {
+            get {
+                return ResourceManager.GetString("TurnOffTemporarily", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 2 Fingers on Touchpad.
+        /// </summary>
+        public static string TwoFingersOnTouchpad {
+            get {
+                return ResourceManager.GetString("TwoFingersOnTouchpad", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Two Stage Mode:.
+        /// </summary>
+        public static string TwoStageMode {
+            get {
+                return ResourceManager.GetString("TwoStageMode", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to UDP Server.
+        /// </summary>
+        public static string UDPServer {
+            get {
+                return ResourceManager.GetString("UDPServer", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unbound.
+        /// </summary>
+        public static string Unbound {
+            get {
+                return ResourceManager.GetString("Unbound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unload Trigger.
+        /// </summary>
+        public static string UnloadTrigger {
+            get {
+                return ResourceManager.GetString("UnloadTrigger", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unplug.
+        /// </summary>
+        public static string Unplug {
+            get {
+                return ResourceManager.GetString("Unplug", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Untoggle key by.
+        /// </summary>
+        public static string UntoggleKeyBy {
+            get {
+                return ResourceManager.GetString("UntoggleKeyBy", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Up.
+        /// </summary>
+        public static string Up {
+            get {
+                return ResourceManager.GetString("Up", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Please update .NET Runtime.
         /// </summary>
         public static string UpgradeNetCaption {
             get {
                 return ResourceManager.GetString("UpgradeNetCaption", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Upper Touch.
+        /// </summary>
+        public static string UpperTouch {
+            get {
+                return ResourceManager.GetString("UpperTouch", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use Controller.
+        /// </summary>
+        public static string UseController {
+            get {
+                return ResourceManager.GetString("UseController", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use Custom Color.
+        /// </summary>
+        public static string UseCustomColor {
+            get {
+                return ResourceManager.GetString("UseCustomColor", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use custom Steam Folder.
+        /// </summary>
+        public static string UseCustomSteamFolder {
+            get {
+                return ResourceManager.GetString("UseCustomSteamFolder", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use DInput only.
+        /// </summary>
+        public static string UseDInputOnly {
+            get {
+                return ResourceManager.GetString("UseDInputOnly", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use Keyboard/Mouse + Controller 1 to record.
+        /// </summary>
+        public static string UseKeyboardAndMouseAndController {
+            get {
+                return ResourceManager.GetString("UseKeyboardAndMouseAndController", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use language pack.
+        /// </summary>
+        public static string UseLanguagePack {
+            get {
+                return ResourceManager.GetString("UseLanguagePack", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use language pack:.
+        /// </summary>
+        public static string UseLanguagePack_ {
+            get {
+                return ResourceManager.GetString("UseLanguagePack_", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use Profile Color.
+        /// </summary>
+        public static string UseProfileColor {
+            get {
+                return ResourceManager.GetString("UseProfileColor", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use Smoothing.
+        /// </summary>
+        public static string UseSmoothing {
+            get {
+                return ResourceManager.GetString("UseSmoothing", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Utils.
+        /// </summary>
+        public static string Utils {
+            get {
+                return ResourceManager.GetString("Utils", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Vertical Scale.
+        /// </summary>
+        public static string VerticalScale {
+            get {
+                return ResourceManager.GetString("VerticalScale", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Vertical Scale:.
+        /// </summary>
+        public static string VerticalScale_ {
+            get {
+                return ResourceManager.GetString("VerticalScale_", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to via lightbar.
+        /// </summary>
+        public static string ViaLightbar {
+            get {
+                return ResourceManager.GetString("ViaLightbar", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to via notification.
+        /// </summary>
+        public static string ViaNotification {
+            get {
+                return ResourceManager.GetString("ViaNotification", resourceCulture);
             }
         }
         
@@ -1081,6 +3952,33 @@ namespace DS4WinWPF.Translations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to WASD.
+        /// </summary>
+        public static string WASD {
+            get {
+                return ResourceManager.GetString("WASD", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Weight.
+        /// </summary>
+        public static string Weight {
+            get {
+                return ResourceManager.GetString("Weight", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to While Charging:.
+        /// </summary>
+        public static string WhileCharging {
+            get {
+                return ResourceManager.GetString("WhileCharging", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Window Title.
         /// </summary>
         public static string WindowTitle {
@@ -1090,11 +3988,74 @@ namespace DS4WinWPF.Translations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to X Axis.
+        /// </summary>
+        public static string XAxis {
+            get {
+                return ResourceManager.GetString("XAxis", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to XInputChecker.
         /// </summary>
         public static string XInputChecker {
             get {
                 return ResourceManager.GetString("XInputChecker", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to X (I): .
+        /// </summary>
+        public static string XInVal {
+            get {
+                return ResourceManager.GetString("XInVal", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to X (O): .
+        /// </summary>
+        public static string XOutVal {
+            get {
+                return ResourceManager.GetString("XOutVal", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Yaw.
+        /// </summary>
+        public static string Yaw {
+            get {
+                return ResourceManager.GetString("Yaw", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Yes.
+        /// </summary>
+        public static string Yes {
+            get {
+                return ResourceManager.GetString("Yes", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Z (I): .
+        /// </summary>
+        public static string ZInVal {
+            get {
+                return ResourceManager.GetString("ZInVal", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Z (O): .
+        /// </summary>
+        public static string ZOutVal {
+            get {
+                return ResourceManager.GetString("ZOutVal", resourceCulture);
             }
         }
     }

--- a/DS4Windows/Translations/Strings.resx
+++ b/DS4Windows/Translations/Strings.resx
@@ -466,4 +466,994 @@ Example: whyme_DS4Windows</value>
   <data name="SharedAccess" xml:space="preserve">
     <value>Shared Access</value>
   </data>
+  <data name="DeadZone_" xml:space="preserve">
+		<value>Dead Zone:</value>
+	</data>
+	<data name="MaxZone_" xml:space="preserve">
+		<value>Max Zone:</value>
+	</data>
+	<data name="AntiDeadZone" xml:space="preserve">
+		<value>Anti-dead Zone:</value>
+	</data>
+	<data name="MaxOutput_" xml:space="preserve">
+		<value>Max Output:</value>
+	</data>
+	<data name="Ok" xml:space="preserve">
+		<value>OK</value>
+	</data>
+	<data name="LoadPreset" xml:space="preserve">
+		<value>Load Preset</value>
+	</data>
+	<data name="CyclePrograms" xml:space="preserve">
+		<value>Cycle Programs</value>
+	</data>
+	<data name="FromFile" xml:space="preserve">
+		<value>From File...</value>
+	</data>
+	<data name="SavePreset" xml:space="preserve">
+		<value>Save Preset</value>
+	</data>
+	<data name="InsertWait" xml:space="preserve">
+		<value>Insert Wait</value>
+	</data>
+	<data name="RecordDelays" xml:space="preserve">
+		<value>Record Delays</value>
+	</data>
+	<data name="ScanCode" xml:space="preserve">
+		<value>Scan Code</value>
+	</data>
+	<data name="FourthMouseButton" xml:space="preserve">
+		<value>4th Mouse Button</value>
+	</data>
+	<data name="FifthMouseButton" xml:space="preserve">
+		<value>5th Mouse Button</value>
+	</data>
+	<data name="AddRumble" xml:space="preserve">
+		<value>Add Rumble</value>
+	</data>
+	<data name="ChangeLightbarColor" xml:space="preserve">
+		<value>Change Lightbar Color</value>
+	</data>
+	<data name="MacroOrder" xml:space="preserve">
+		<value>Macro Order</value>
+	</data>
+	<data name="UseKeyboardAndMouseAndController" xml:space="preserve">
+		<value>Use Keyboard/Mouse + Controller 1 to record</value>
+	</data>
+	<data name="Name_" xml:space="preserve">
+		<value>Name:</value>
+	</data>
+	<data name="Cross" xml:space="preserve">
+		<value>Cross</value>
+	</data>
+	<data name="Circle" xml:space="preserve">
+		<value>Circle</value>
+	</data>
+	<data name="Square" xml:space="preserve">
+		<value>Square</value>
+	</data>
+	<data name="Triangle" xml:space="preserve">
+		<value>Triangle</value>
+	</data>
+	<data name="Options" xml:space="preserve">
+		<value>Options</value>
+	</data>
+	<data name="Share" xml:space="preserve">
+		<value>Share</value>
+	</data>
+	<data name="Up" xml:space="preserve">
+		<value>Up</value>
+	</data>
+	<data name="Down" xml:space="preserve">
+		<value>Down</value>
+	</data>
+	<data name="Left" xml:space="preserve">
+		<value>Left</value>
+	</data>
+	<data name="Right" xml:space="preserve">
+		<value>Right</value>
+	</data>
+	<data name="PS" xml:space="preserve">
+		<value>PS</value>
+	</data>
+	<data name="Mute" xml:space="preserve">
+		<value>Mute</value>
+	</data>
+	<data name="L1" xml:space="preserve">
+		<value>L1</value>
+	</data>
+	<data name="R1" xml:space="preserve">
+		<value>R1</value>
+	</data>
+	<data name="L2" xml:space="preserve">
+		<value>L2</value>
+	</data>
+	<data name="L2FullPull" xml:space="preserve">
+		<value>L2 Full Pull</value>
+	</data>
+	<data name="R2" xml:space="preserve">
+		<value>R2</value>
+	</data>
+	<data name="R2FullPull" xml:space="preserve">
+		<value>R2 Full Pull</value>
+	</data>
+	<data name="L3" xml:space="preserve">
+		<value>L3</value>
+	</data>
+	<data name="R3" xml:space="preserve">
+		<value>R3</value>
+	</data>
+	<data name="LeftTouch" xml:space="preserve">
+		<value>Left Touch</value>
+	</data>
+	<data name="UpperTouch" xml:space="preserve">
+		<value>Upper Touch</value>
+	</data>
+	<data name="MultiTouch" xml:space="preserve">
+		<value>Multitouch</value>
+	</data>
+	<data name="RightTouch" xml:space="preserve">
+		<value>Right Touch</value>
+	</data>
+	<data name="LeftStickUp" xml:space="preserve">
+		<value>Left Stick Up</value>
+	</data>
+	<data name="LeftStickDown" xml:space="preserve">
+		<value>Left Stick Down</value>
+	</data>
+	<data name="LeftStickLeft" xml:space="preserve">
+		<value>Left Stick Left</value>
+	</data>
+	<data name="LeftStickRight" xml:space="preserve">
+		<value>Left Stick Right</value>
+	</data>
+	<data name="RightStickUp" xml:space="preserve">
+		<value>Right Stick Up</value>
+	</data>
+	<data name="RightStickDown" xml:space="preserve">
+		<value>Right Stick Down</value>
+	</data>
+	<data name="RightStickLeft" xml:space="preserve">
+		<value>Right Stick Left</value>
+	</data>
+	<data name="RightStickRight" xml:space="preserve">
+		<value>Right Stick Right</value>
+	</data>
+	<data name="TiltDown" xml:space="preserve">
+		<value>Tilt Down</value>
+	</data>
+	<data name="UnloadTrigger" xml:space="preserve">
+		<value>Unload Trigger</value>
+	</data>
+	<data name="Macro" xml:space="preserve">
+		<value>Macro</value>
+	</data>
+	<data name="RecordMacro" xml:space="preserve">
+		<value>Record a macro</value>
+	</data>
+	<data name="RunTriggerRelease" xml:space="preserve">
+		<value>Run on Trigger Release</value>
+	</data>
+	<data name="SyncRun" xml:space="preserve">
+		<value>Synchronized Run</value>
+	</data>
+	<data name="KeepKeyState" xml:space="preserve">
+		<value>Keep key state</value>
+	</data>
+	<data name="RepeatHeld" xml:space="preserve">
+		<value>Repeat while held</value>
+	</data>
+	<data name="LaunchProgram" xml:space="preserve">
+		<value>Launch Program</value>
+	</data>
+	<data name="HoldFor" xml:space="preserve">
+		<value>Hold for </value>
+	</data>
+	<data name="Secs" xml:space="preserve">
+		<value>secs</value>
+	</data>
+	<data name="Arguments" xml:space="preserve">
+		<value>Arguments</value>
+	</data>
+	<data name="LoadProfile" xml:space="preserve">
+		<value>Load Profile</value>
+	</data>
+	<data name="SetUnloadTrigger" xml:space="preserve">
+		<value>Set Unload Trigger</value>
+	</data>
+	<data name="AutoUntrigger" xml:space="preserve">
+		<value>Unload on trigger release</value>
+	</data>
+	<data name="PressKey" xml:space="preserve">
+		<value>Press Key</value>
+	</data>
+	<data name="UntoggleKeyBy" xml:space="preserve">
+		<value>Untoggle key by</value>
+	</data>
+	<data name="DisconnectBT" xml:space="preserve">
+		<value>DisBT</value>
+	</data>
+	<data name="CheckBattery" xml:space="preserve">
+		<value>Check Battery</value>
+	</data>
+	<data name="ViaNotification" xml:space="preserve">
+		<value>via notification</value>
+	</data>
+	<data name="ViaLightbar" xml:space="preserve">
+		<value>via lightbar</value>
+	</data>
+	<data name="MultiAct" xml:space="preserve">
+		<value>MultiAct</value>
+	</data>
+	<data name="TapTrigger" xml:space="preserve">
+		<value>Tap Trigger</value>
+	</data>
+	<data name="HoldTrigger" xml:space="preserve">
+		<value>Hold Trigger</value>
+	</data>
+	<data name="DoubleTapTrigger" xml:space="preserve">
+		<value>Double Tap Trigger</value>
+	</data>
+	<data name="SixaxisWheel" xml:space="preserve">
+		<value>Sixaxis Wheel</value>
+	</data>
+	<data name="Intro" xml:space="preserve">
+		<value>Intro</value>
+	</data>
+	<data name="No" xml:space="preserve">
+		<value>No</value>
+	</data>
+	<data name="Yes" xml:space="preserve">
+		<value>Yes</value>
+	</data>
+	<data name="PresetMenu" xml:space="preserve">
+		<value>Preset Menu</value>
+	</data>
+	<data name="OutputController" xml:space="preserve">
+		<value>Output Controller:</value>
+	</data>
+	<data name="TurnOffTemporarily" xml:space="preserve">
+		<value>Turn Off DS4Window Temporarily</value>
+	</data>
+	<data name="RevertDefaultProfile" xml:space="preserve">
+		<value>Revert to default profile on unknown</value>
+	</data>
+	<data name="ShowAutoDebug" xml:space="preserve">
+		<value>Show auto-profile debug messages</value>
+	</data>
+	<data name="MultipleSaveLocationsDetected" xml:space="preserve">
+		<value>Multiple save locations detected</value>
+	</data>
+	<data name="DontDelete" xml:space="preserve">
+		<value>Don't Delete the other settings yet</value>
+	</data>
+	<data name="ProgramFolder" xml:space="preserve">
+		<value>Program Folder</value>
+	</data>
+	<data name="Appdata" xml:space="preserve">
+		<value>Appdata</value>
+	</data>
+	<data name="DS4ControllerSupport" xml:space="preserve">
+		<value>DS4 Controller Support</value>
+	</data>
+	<data name="DualSenseControllerSupport" xml:space="preserve">
+		<value>DualSense Controller Support</value>
+	</data>
+	<data name="SwitchProControllerSupport" xml:space="preserve">
+		<value>Switch Pro Controller Support</value>
+	</data>
+	<data name="JoyConControllerSupport" xml:space="preserve">
+		<value>JoyCon Controller Support</value>
+	</data>
+	<data name="DetectedControllers" xml:space="preserve">
+		<value>Detected Controllers</value>
+	</data>
+	<data name="Blank" xml:space="preserve">
+		<value>Blank</value>
+	</data>
+	<data name="DS4" xml:space="preserve">
+		<value>DS4</value>
+	</data>
+	<data name="Copycat" xml:space="preserve">
+		<value>Copycat</value>
+	</data>
+	<data name="CopycatTip" xml:space="preserve">
+		<value>Change some flags used for a non-Sony DS4 controller. It might fix rumble and lightbar support for some third party DS4 clones</value>
+	</data>
+	<data name="DualSense" xml:space="preserve">
+		<value>DualSense</value>
+	</data>
+	<data name="EnableRumbleEmulation" xml:space="preserve">
+		<value>Enable Rumble Emulation</value>
+	</data>
+	<data name="RumbleStrength" xml:space="preserve">
+		<value>Rumble Strength</value>
+	</data>
+	<data name="PlayerLEDMode" xml:space="preserve">
+		<value>Player LED Mode</value>
+	</data>
+	<data name="MuteLEDMode" xml:space="preserve">
+		<value>Mute LED Mode</value>
+	</data>
+	<data name="SwitchPro" xml:space="preserve">
+		<value>Switch Pro</value>
+	</data>
+	<data name="EnableHomeLED" xml:space="preserve">
+		<value>Enable Home LED</value>
+	</data>
+	<data name="JoyCon" xml:space="preserve">
+		<value>JoyCon</value>
+	</data>
+	<data name="JoyConGlobalOptions" xml:space="preserve">
+		<value>JoyCon Global Options</value>
+	</data>
+	<data name="LinkMode" xml:space="preserve">
+		<value>Link Mode</value>
+	</data>
+	<data name="JoinedGyroProvider" xml:space="preserve">
+		<value>Joined Gyro Provider</value>
+	</data>
+	<data name="ProgramName" xml:space="preserve">
+		<value>DS4Windows - Ryochan7 Build (Version </value>
+	</data>
+	<data name="Hotkeys" xml:space="preserve">
+		<value>Hotkeys</value>
+	</data>
+	<data name="Credits" xml:space="preserve">
+		<value>Credits</value>
+	</data>
+	<data name="Translators" xml:space="preserve">
+		<value>Translators:</value>
+	</data>
+	<data name="Tip" xml:space="preserve">
+		<value>Tip</value>
+	</data>
+	<data name="Accept" xml:space="preserve">
+		<value>Accept</value>
+	</data>
+	<data name="Extra" xml:space="preserve">
+		<value>Extra</value>
+	</data>
+	<data name="Test" xml:space="preserve">
+		<value>Test</value>
+	</data>
+	<data name="Heavy" xml:space="preserve">
+		<value>Heavy</value>
+	</data>
+	<data name="Light" xml:space="preserve">
+		<value>Light</value>
+	</data>
+	<data name="ChangeLight" xml:space="preserve">
+		<value>Change Light</value>
+	</data>
+	<data name="ColorR" xml:space="preserve">
+		<value>R</value>
+	</data>
+	<data name="ColorG" xml:space="preserve">
+		<value>G</value>
+	</data>
+	<data name="ColorB" xml:space="preserve">
+		<value>B</value>
+	</data>
+	<data name="FlashRate" xml:space="preserve">
+		<value>Flash Rate</value>
+	</data>
+	<data name="ChangeMouseSensitivity" xml:space="preserve">
+		<value>Change Mouse Sensitivity</value>
+	</data>
+	<data name="Regular" xml:space="preserve">
+		<value>Regular</value>
+	</data>
+	<data name="ShiftModifier" xml:space="preserve">
+		<value>Shift Modifier</value>
+	</data>
+	<data name="Unbound" xml:space="preserve">
+		<value>Unbound</value>
+	</data>
+	<data name="MacroOn" xml:space="preserve">
+		<value>Macro On, Choose a key to disable, else close this window to save</value>
+	</data>
+	<data name="Plug" xml:space="preserve">
+		<value>Plug</value>
+	</data>
+	<data name="Unplug" xml:space="preserve">
+		<value>Unplug</value>
+	</data>
+	<data name="Current" xml:space="preserve">
+		<value>Current</value>
+	</data>
+	<data name="Requested" xml:space="preserve">
+		<value>Requested</value>
+	</data>
+	<data name="Active" xml:space="preserve">
+		<value>Active</value>
+	</data>
+	<data name="SkipVersion" xml:space="preserve">
+		<value>Skip Version</value>
+	</data>
+	<data name="UseLanguagePack_" xml:space="preserve">
+		<value>Use language pack:</value>
+	</data>
+	<data name="Open" xml:space="preserve">
+		<value>Open</value>
+	</data>
+	<data name="Exit" xml:space="preserve">
+		<value>Exit</value>
+	</data>
+	<data name="ID" xml:space="preserve">
+		<value>ID</value>
+	</data>
+	<data name="ContStatusTip" xml:space="preserve">
+		<value>Right click to disconnect wireless</value>
+	</data>
+	<data name="Ex" xml:space="preserve">
+		<value>Ex</value>
+	</data>
+	<data name="LinkProfileOrID" xml:space="preserve">
+		<value>Link Profile/ID</value>
+	</data>
+	<data name="SelectedProfile" xml:space="preserve">
+		<value>Selected Profile</value>
+	</data>
+	<data name="UseProfileColor" xml:space="preserve">
+		<value>Use Profile Color</value>
+	</data>
+	<data name="UseCustomColor" xml:space="preserve">
+		<value>Use Custom Color</value>
+	</data>
+	<data name="OutputSlots" xml:space="preserve">
+		<value>Output Slots</value>
+	</data>
+	<data name="HideDS4Controller" xml:space="preserve">
+		<value>Hide DS4 Controller</value>
+	</data>
+	<data name="SwipeTouch" xml:space="preserve">
+		<value>Swipe Touchpad To Switch Profiles</value>
+	</data>
+	<data name="RunAs" xml:space="preserve">
+		<value>Run As</value>
+	</data>
+	<data name="Program" xml:space="preserve">
+		<value>Program</value>
+	</data>
+	<data name="Task" xml:space="preserve">
+		<value>Task</value>
+	</data>
+	<data name="DisconnectBTStop" xml:space="preserve">
+		<value>Disconnect from BT when Stopping</value>
+	</data>
+	<data name="FlashHighLatency" xml:space="preserve">
+		<value>Flash Lightbar at High Latency</value>
+	</data>
+	<data name="Ms" xml:space="preserve">
+		<value>ms</value>
+	</data>
+	<data name="MinimizeToTaskbar" xml:space="preserve">
+		<value>Minimize to Taskbar</value>
+	</data>
+	<data name="MinimizeToTaskbarInsteadOfSystemTray" xml:space="preserve">
+		<value>Minimize to Taskbar instead of System Tray</value>
+	</data>
+	<data name="IconChoice" xml:space="preserve">
+		<value>Icon Choice:</value>
+	</data>
+	<data name="AppTheme" xml:space="preserve">
+		<value>App Theme:</value>
+	</data>
+	<data name="CheckEvery" xml:space="preserve">
+		<value>Check every </value>
+	</data>
+	<data name="UDPServer" xml:space="preserve">
+		<value>UDP Server</value>
+	</data>
+	<data name="EnableServer" xml:space="preserve">
+		<value>Enable Server</value>
+	</data>
+	<data name="Port" xml:space="preserve">
+		<value>Port</value>
+	</data>
+	<data name="UseSmoothing" xml:space="preserve">
+		<value>Use Smoothing</value>
+	</data>
+	<data name="OneEuroMinCutoff" xml:space="preserve">
+		<value>1&#x20ac; MinCutoff</value>
+	</data>
+	<data name="OneEuroBeta" xml:space="preserve">
+		<value>1&#x20ac; Beta</value>
+	</data>
+	<data name="UseLanguagePack" xml:space="preserve">
+		<value>Use language pack</value>
+	</data>
+	<data name="UseCustomSteamFolder" xml:space="preserve">
+		<value>Use custom Steam Folder</value>
+	</data>
+	<data name="Utils" xml:space="preserve">
+		<value>Utils</value>
+	</data>
+	<data name="DeviceOptions" xml:space="preserve">
+		<value>Device Options</value>
+	</data>
+	<data name="Time" xml:space="preserve">
+		<value>Time</value>
+	</data>
+	<data name="Data" xml:space="preserve">
+		<value>Data</value>
+	</data>
+	<data name="InputDelayNA" xml:space="preserve">
+		<value>Input Delay: N/A</value>
+	</data>
+	<data name="Battery0" xml:space="preserve">
+		<value>Battery: 0%</value>
+	</data>
+	<data name="LxInVal" xml:space="preserve">
+		<value>LX (I): </value>
+	</data>
+	<data name="LxOutVal" xml:space="preserve">
+		<value>LX (O): </value>
+	</data>
+	<data name="LyInVal" xml:space="preserve">
+		<value>LY (I): </value>
+	</data>
+	<data name="LyOutVal" xml:space="preserve">
+		<value>LY (O): </value>
+	</data>
+	<data name="RxInVal" xml:space="preserve">
+		<value>RX (I): </value>
+	</data>
+	<data name="RxOutVal" xml:space="preserve">
+		<value>RX (O): </value>
+	</data>
+	<data name="RyInVal" xml:space="preserve">
+		<value>RY (I): </value>
+	</data>
+	<data name="RyOutVal" xml:space="preserve">
+		<value>RY (O): </value>
+	</data>
+	<data name="XInVal" xml:space="preserve">
+		<value>X (I): </value>
+	</data>
+	<data name="XOutVal" xml:space="preserve">
+		<value>X (O): </value>
+	</data>
+	<data name="ZInVal" xml:space="preserve">
+		<value>Z (I): </value>
+	</data>
+	<data name="ZOutVal" xml:space="preserve">
+		<value>Z (O): </value>
+	</data>
+	<data name="InVal" xml:space="preserve">
+		<value>I: </value>
+	</data>
+	<data name="OutVal" xml:space="preserve">
+		<value>O: </value>
+	</data>
+	<data name="Yaw" xml:space="preserve">
+		<value>Yaw</value>
+	</data>
+	<data name="Pitch" xml:space="preserve">
+		<value>Pitch</value>
+	</data>
+	<data name="Roll" xml:space="preserve">
+		<value>Roll</value>
+	</data>
+	<data name="AccelX" xml:space="preserve">
+		<value>X</value>
+	</data>
+	<data name="AccelY" xml:space="preserve">
+		<value>Y</value>
+	</data>
+	<data name="AccelZ" xml:space="preserve">
+		<value>Z</value>
+	</data>
+	<data name="Step1" xml:space="preserve">
+		<value>Step 1: Install ViGEmBus Driver</value>
+	</data>
+	<data name="Step2" xml:space="preserve">
+		<value>Step 2: If on Windows 7, Install 360 Driver</value>
+	</data>
+	<data name="Step4" xml:space="preserve">
+		<value>(Optional) Step 4: Install HidHide Driver</value>
+	</data>
+	<data name="Step5" xml:space="preserve">
+		<value>(Optional) Step 5: Install FakerInput Driver</value>
+	</data>
+	<data name="Finished" xml:space="preserve">
+		<value>Finished</value>
+	</data>
+	<data name="SelectPreset" xml:space="preserve">
+		<value>Select Preset</value>
+	</data>
+	<data name="Controls" xml:space="preserve">
+		<value>Controls</value>
+	</data>
+	<data name="Default" xml:space="preserve">
+		<value>Default</value>
+	</data>
+	<data name="DPad" xml:space="preserve">
+		<value>DPad</value>
+	</data>
+	<data name="Normal" xml:space="preserve">
+		<value>Normal</value>
+	</data>
+	<data name="Inverted" xml:space="preserve">
+		<value>Inverted</value>
+	</data>
+	<data name="InvertedX" xml:space="preserve">
+		<value>Inverted X</value>
+	</data>
+	<data name="InvertedY" xml:space="preserve">
+		<value>Inverted Y</value>
+	</data>
+	<data name="Rotate90" xml:space="preserve">
+		<value>Rotate 90&#xb0;</value>
+	</data>
+	<data name="Rotate-90" xml:space="preserve">
+		<value>Rotate -90&#xb0;</value>
+	</data>
+	<data name="FaceButtons" xml:space="preserve">
+		<value>Face Buttons</value>
+	</data>
+	<data name="WASD" xml:space="preserve">
+		<value>WASD</value>
+	</data>
+	<data name="ArrowKeys" xml:space="preserve">
+		<value>Arrow Keys</value>
+	</data>
+	<data name="Mouse" xml:space="preserve">
+		<value>Mouse</value>
+	</data>
+	<data name="Guide" xml:space="preserve">
+		<value>Guide</value>
+	</data>
+	<data name="Multi_Touch" xml:space="preserve">
+		<value>Multi Touch</value>
+	</data>
+	<data name="TopTouch" xml:space="preserve">
+		<value>Top Touch</value>
+	</data>
+	<data name="LSU" xml:space="preserve">
+		<value>LSU</value>
+	</data>
+	<data name="LSR" xml:space="preserve">
+		<value>LSR</value>
+	</data>
+	<data name="LSD" xml:space="preserve">
+		<value>LSD</value>
+	</data>
+	<data name="LSL" xml:space="preserve">
+		<value>LSL</value>
+	</data>
+	<data name="RSU" xml:space="preserve">
+		<value>RSU</value>
+	</data>
+	<data name="RSR" xml:space="preserve">
+		<value>RSR</value>
+	</data>
+	<data name="RSD" xml:space="preserve">
+		<value>RSD</value>
+	</data>
+	<data name="RSL" xml:space="preserve">
+		<value>RSL</value>
+	</data>
+	<data name="SpecialActions" xml:space="preserve">
+		<value>Special Actions</value>
+	</data>
+	<data name="ControllerReadings" xml:space="preserve">
+		<value>Controller Readings</value>
+	</data>
+	<data name="AxisConfig" xml:space="preserve">
+		<value>Axis Config</value>
+	</data>
+	<data name="LS" xml:space="preserve">
+		<value>LS</value>
+	</data>
+	<data name="DeadZoneType" xml:space="preserve">
+		<value>Dead Zone Type</value>
+	</data>
+	<data name="Radial" xml:space="preserve">
+		<value>Radial</value>
+	</data>
+	<data name="VerticalScale_" xml:space="preserve">
+		<value>Vertical Scale:</value>
+	</data>
+	<data name="Sensitivity" xml:space="preserve">
+		<value>Sensitivity:</value>
+	</data>
+	<data name="Axial" xml:space="preserve">
+		<value>Axial</value>
+	</data>
+	<data name="OutputCurve" xml:space="preserve">
+		<value>Output Curve:</value>
+	</data>
+	<data name="SquareStick" xml:space="preserve">
+		<value>Square Stick:</value>
+	</data>
+	<data name="CurveInput" xml:space="preserve">
+		<value>Curve (Input):</value>
+	</data>
+	<data name="Rotation_" xml:space="preserve">
+		<value>Rotation:</value>
+	</data>
+	<data name="Fuzz" xml:space="preserve">
+		<value>Fuzz:</value>
+	</data>
+	<data name="AntiSnapback" xml:space="preserve">
+		<value>Anti Snapback:</value>
+	</data>
+	<data name="AntiSnapbackTiming" xml:space="preserve">
+		<value>Anti Snapback timing:</value>
+	</data>
+	<data name="FlickStick" xml:space="preserve">
+		<value>FlickStick</value>
+	</data>
+	<data name="RS" xml:space="preserve">
+		<value>RS</value>
+	</data>
+	<data name="L2AndR2" xml:space="preserve">
+		<value>L2 &amp; R2</value>
+	</data>
+	<data name="TwoStageMode" xml:space="preserve">
+		<value>Two Stage Mode:</value>
+	</data>
+	<data name="FullPull" xml:space="preserve">
+		<value>Full</value>
+	</data>
+	<data name="FullPullBtn" xml:space="preserve">
+		<value>Full Pull Btn:</value>
+	</data>
+	<data name="HipFireDelay" xml:space="preserve">
+		<value>Hip Fire Delay:</value>
+	</data>
+	<data name="TriggerEffect" xml:space="preserve">
+		<value>Trigger Effect:</value>
+	</data>
+	<data name="SixAxis" xml:space="preserve">
+		<value>SixAxis</value>
+	</data>
+	<data name="MaxZone_" xml:space="preserve">
+		<value>Max Zone:</value>
+	</data>
+	<data name="Lightbar" xml:space="preserve">
+		<value>Lightbar</value>
+	</data>
+	<data name="Mode" xml:space="preserve">
+		<value>Mode:</value>
+	</data>
+	<data name="Empty" xml:space="preserve">
+		<value>Empty</value>
+	</data>
+	<data name="WhileCharging" xml:space="preserve">
+		<value>While Charging:</value>
+	</data>
+	<data name="ColorByBatteryPercent" xml:space="preserve">
+		<value>Color by Battery %</value>
+	</data>
+	<data name="SecsPerCycle" xml:space="preserve">
+		<value>secs/cycle</value>
+	</data>
+	<data name="Touchpad" xml:space="preserve">
+		<value>Touchpad</value>
+	</data>
+	<data name="JitterCompensation" xml:space="preserve">
+		<value>Jitter Compensation</value>
+	</data>
+	<data name="DoubleTap" xml:space="preserve">
+		<value>Double Tap</value>
+	</data>
+	<data name="LowerRightAsRMB" xml:space="preserve">
+		<value>Lower Right as RMB</value>
+	</data>
+	<data name="PassthruClickAction" xml:space="preserve">
+		<value>Passthru Click Action (DS4 mode)</value>
+	</data>
+	<data name="StartTouchpadOff" xml:space="preserve">
+		<value>Start with Slide/Scroll Off</value>
+	</data>
+	<data name="Rotation" xml:space="preserve">
+		<value>Rotation</value>
+	</data>
+	<data name="MinThreshold" xml:space="preserve">
+		<value>Min Threshold</value>
+	</data>
+	<data name="Trackball" xml:space="preserve">
+		<value>Trackball</value>
+	</data>
+	<data name="Friction" xml:space="preserve">
+		<value>Friction:</value>
+	</data>
+	<data name="Invert" xml:space="preserve">
+		<value>Invert</value>
+	</data>
+	<data name="DisableInvert" xml:space="preserve">
+		<value>Disable Invert</value>
+	</data>
+	<data name="FingerOnTouchpad" xml:space="preserve">
+		<value>Finger on Touchpad</value>
+	</data>
+	<data name="TwoFingersOnTouchpad" xml:space="preserve">
+		<value>2 Fingers on Touchpad</value>
+	</data>
+	<data name="TouchpadClick" xml:space="preserve">
+		<value>Touchpad Click</value>
+	</data>
+	<data name="SwipeUp" xml:space="preserve">
+		<value>Swipe Up</value>
+	</data>
+	<data name="SwipeDown" xml:space="preserve">
+		<value>Swipe Down</value>
+	</data>
+	<data name="SwipeLeft" xml:space="preserve">
+		<value>Swipe Left</value>
+	</data>
+	<data name="SwipeRight" xml:space="preserve">
+		<value>Swipe Right</value>
+	</data>
+	<data name="AbsoluteMouse" xml:space="preserve">
+		<value>Absolute Mouse</value>
+	</data>
+	<data name="MaxZoneX_" xml:space="preserve">
+		<value>Max Zone X:</value>
+	</data>
+	<data name="MaxZoneY_" xml:space="preserve">
+		<value>Max Zone Y:</value>
+	</data>
+	<data name="SnapToCenterOnRelease" xml:space="preserve">
+		<value>Snap To Center on Release:</value>
+	</data>
+	<data name="Passthru" xml:space="preserve">
+		<value>Passthru</value>
+	</data>
+	<data name="OutputMode" xml:space="preserve">
+		<value>Output Mode</value>
+	</data>
+	<data name="TiltUp" xml:space="preserve">
+		<value>Tilt Up</value>
+	</data>
+	<data name="TiltLeft" xml:space="preserve">
+		<value>Tilt Left</value>
+	</data>
+	<data name="TiltRight" xml:space="preserve">
+		<value>Tilt Right</value>
+	</data>
+	<data name="Triggers" xml:space="preserve">
+		<value>Triggers</value>
+	</data>
+	<data name="AlwaysOn" xml:space="preserve">
+		<value>Always On</value>
+	</data>
+	<data name="TurnBehaviorTurnsGyro" xml:space="preserve">
+		<value>Turn Behavior - Turns Gyro</value>
+	</data>
+	<data name="Toggle" xml:space="preserve">
+		<value>Toggle</value>
+	</data>
+	<data name="EvalCond" xml:space="preserve">
+		<value>Eval Cond.</value>
+	</data>
+	<data name="360SteeringWheel" xml:space="preserve">
+		<value>360 Steering Wheel</value>
+	</data>
+	<data name="SteeringWheelAxis" xml:space="preserve">
+		<value>Steering wheel axis</value>
+	</data>
+	<data name="SteeringWheelRange" xml:space="preserve">
+		<value>Steering wheel range</value>
+	</data>
+	<data name="Calibrate" xml:space="preserve">
+		<value>Calibrate</value>
+	</data>
+	<data name="GyroCalibration" xml:space="preserve">
+		<value>Gyro Calibration</value>
+	</data>
+	<data name="GyroSensitivity" xml:space="preserve">
+		<value>Gyro Sensitivity:</value>
+	</data>
+	<data name="XAxis" xml:space="preserve">
+		<value>X Axis</value>
+	</data>
+	<data name="GyroMouseInvertX" xml:space="preserve">
+		<value>X</value>
+	</data>
+	<data name="GyroMouseInvertY" xml:space="preserve">
+		<value>Y</value>
+	</data>
+	<data name="Deadzone" xml:space="preserve">
+		<value>Deadzone</value>
+	</data>
+	<data name="Smoothing" xml:space="preserve">
+		<value>Smoothing</value>
+	</data>
+	<data name="SmoothingOptions" xml:space="preserve">
+		<value>Smoothing Options</value>
+	</data>
+	<data name="SmoothWeight" xml:space="preserve">
+		<value>Smooth Weight</value>
+	</data>
+	<data name="Dead_Zone" xml:space="preserve">
+		<value>Dead Zone</value>
+	</data>
+	<data name="MaxZone" xml:space="preserve">
+		<value>Max Zone</value>
+	</data>
+	<data name="MinimumX" xml:space="preserve">
+		<value>Minimum X</value>
+	</data>
+	<data name="MinimumY" xml:space="preserve">
+		<value>Minimum Y</value>
+	</data>
+	<data name="VerticalScale" xml:space="preserve">
+		<value>Vertical Scale</value>
+	</data>
+	<data name="MaxOutput" xml:space="preserve">
+		<value>Max Output</value>
+	</data>
+	<data name="InvertX" xml:space="preserve">
+		<value>Invert X</value>
+	</data>
+	<data name="InvertY" xml:space="preserve">
+		<value>Invert Y</value>
+	</data>
+	<data name="Weight" xml:space="preserve">
+		<value>Weight</value>
+	</data>
+	<data name="DeadzoneX" xml:space="preserve">
+		<value>Deadzone X</value>
+	</data>
+	<data name="DegPerSec" xml:space="preserve">
+		<value>deg/sec.</value>
+	</data>
+	<data name="DeadzoneY" xml:space="preserve">
+		<value>Deadzone Y</value>
+	</data>
+	<data name="DelayTime" xml:space="preserve">
+		<value>Delay Time</value>
+	</data>
+	<data name="Other" xml:space="preserve">
+		<value>Other</value>
+	</data>
+	<data name="TestHeavy" xml:space="preserve">
+		<value>Test Heavy</value>
+	</data>
+	<data name="TestLight" xml:space="preserve">
+		<value>Test Light</value>
+	</data>
+	<data name="UseController" xml:space="preserve">
+		<value>Use Controller</value>
+	</data>
+	<data name="ForReadout" xml:space="preserve">
+		<value>for readout</value>
+	</data>
+	<data name="MouseSensitivity" xml:space="preserve">
+		<value>Mouse Sensitivity</value>
+	</data>
+	<data name="MouseVerticalScale" xml:space="preserve">
+		<value>Mouse Vertical Scale</value>
+	</data>
+	<data name="MouseOffset" xml:space="preserve">
+		<value>Mouse Offset</value>
+	</data>
+	<data name="MouseAcceleration" xml:space="preserve">
+		<value>Mouse Acceleration</value>
+	</data>
+	<data name="EnableTouchpadToggle" xml:space="preserve">
+		<value>Enable Touchpad Toggle</value>
+	</data>
+	<data name="LaunchProgramWithProfile" xml:space="preserve">
+		<value>Launch program with profile</value>
+	</data>
+	<data name="UseDInputOnly" xml:space="preserve">
+		<value>Use DInput only</value>
+	</data>
+	<data name="IdleDisconnect" xml:space="preserve">
+		<value>Idle Disconnect</value>
+	</data>
+	<data name="Mins" xml:space="preserve">
+		<value>mins</value>
+	</data>
+	<data name="BTPollRate" xml:space="preserve">
+		<value>BT Poll Rate</value>
+	</data>
+	<data name="EmulatedController" xml:space="preserve">
+		<value>Emulated Controller</value>
+	</data>
 </root>

--- a/DS4Windows/Translations/Strings.resx
+++ b/DS4Windows/Translations/Strings.resx
@@ -931,7 +931,7 @@ Example: whyme_DS4Windows</value>
 	<data name="MinimizeToTaskbar" xml:space="preserve">
 		<value>Minimize to Taskbar</value>
 	</data>
-	<data name="MinimizeToTaskbarInsteadOfSystemTray" xml:space="preserve">
+	<data name="MinimizeToTaskbarTip" xml:space="preserve">
 		<value>Minimize to Taskbar instead of System Tray</value>
 	</data>
 	<data name="IconChoice" xml:space="preserve">
@@ -1209,9 +1209,6 @@ Example: whyme_DS4Windows</value>
 	</data>
 	<data name="SixAxis" xml:space="preserve">
 		<value>SixAxis</value>
-	</data>
-	<data name="MaxZone_" xml:space="preserve">
-		<value>Max Zone:</value>
 	</data>
 	<data name="Lightbar" xml:space="preserve">
 		<value>Lightbar</value>


### PR DESCRIPTION
I am trying to make more strings localization ready.
I have made the following changes and committed them.

- find Content="...", Header="...", and ToolTip="..." in *.xaml (excluding ComboBoxItem)
- add them to Strings.resx
- substitute these strings to "{lex:Loc ...}"

This is still in progress, but I would like your opinion on whether my approach is right or not.
Please let me know if anybody has better approach than my one.

And I have a question.
At the present implementation, localization is implemented by using two files, they are Resources.resx and Strings.resx.
Could you tell me the reason why using these two files?
I think they should be combined if there are not any reasons.