### PR TITLE
"Hold for X secs" special action delay value now supports decimal values

### DIFF
--- a/DS4Windows/DS4Control/MouseCursor.cs
+++ b/DS4Windows/DS4Control/MouseCursor.cs
@@ -59,7 +59,7 @@ namespace DS4Windows
 
         int tempInt = 0;
         double tempDouble = 0.0;
-        bool tempBool = false;
+        //bool tempBool = false;
 
         public virtual void sixaxisMoved(SixAxisEventArgs arg)
         {

--- a/DS4Windows/DS4Control/ScpUtil.cs
+++ b/DS4Windows/DS4Control/ScpUtil.cs
@@ -418,8 +418,12 @@ namespace DS4Windows
         public const int TEST_PROFILE_ITEM_COUNT = MAX_DS4_CONTROLLER_COUNT + 1;
         public const int TEST_PROFILE_INDEX = TEST_PROFILE_ITEM_COUNT - 1;
         public const int OLD_XINPUT_CONTROLLER_COUNT = 4;
+
+        public static CultureInfo configFileDecimalCulture = new CultureInfo("en-US"); // Loading and Saving decimal values in configuration files should always use en-US decimal format (ie. dot char as decimal separator char, not comma char)
+
         protected static BackingStore m_Config = new BackingStore();
         protected static Int32 m_IdleTimeout = 600000;
+
         public static string exelocation = Process.GetCurrentProcess().MainModule.FileName;
         public static string exedirpath = Directory.GetParent(exelocation).FullName;
         public static string exeFileName = Path.GetFileName(exelocation);
@@ -6469,7 +6473,7 @@ namespace DS4Windows
                     else if (type == "DisconnectBT")
                     {
                         double doub;
-                        if (double.TryParse(details, out doub))
+                        if (double.TryParse(details, System.Globalization.NumberStyles.Float, Global.configFileDecimalCulture, out doub))
                             actions.Add(new SpecialAction(name, controls, type, "", doub));
                         else
                             actions.Add(new SpecialAction(name, controls, type, ""));
@@ -6477,9 +6481,9 @@ namespace DS4Windows
                     else if (type == "BatteryCheck")
                     {
                         double doub;
-                        if (double.TryParse(details.Split('|')[0], out doub))
+                        if (double.TryParse(details.Split('|')[0], System.Globalization.NumberStyles.Float, Global.configFileDecimalCulture, out doub))
                             actions.Add(new SpecialAction(name, controls, type, details, doub));
-                        else if (double.TryParse(details.Split(',')[0], out doub))
+                        else if (double.TryParse(details.Split(',')[0], System.Globalization.NumberStyles.Float, Global.configFileDecimalCulture, out doub))
                             actions.Add(new SpecialAction(name, controls, type, details, doub));
                         else
                             actions.Add(new SpecialAction(name, controls, type, details));
@@ -6490,7 +6494,7 @@ namespace DS4Windows
                         if (x.ChildNodes[3] != null)
                         {
                             extras = x.ChildNodes[3].InnerText;
-                            if (double.TryParse(x.ChildNodes[4].InnerText, out doub))
+                            if (double.TryParse(x.ChildNodes[4].InnerText, System.Globalization.NumberStyles.Float, Global.configFileDecimalCulture, out doub))
                                 actions.Add(new SpecialAction(name, controls, type, details, doub, extras));
                             else
                                 actions.Add(new SpecialAction(name, controls, type, details, 0, extras));
@@ -6507,7 +6511,7 @@ namespace DS4Windows
                     else if (type == "SASteeringWheelEmulationCalibrate")
                     {
                         double doub;
-                        if (double.TryParse(details, out doub))
+                        if (double.TryParse(details, System.Globalization.NumberStyles.Float, Global.configFileDecimalCulture, out doub))
                             actions.Add(new SpecialAction(name, controls, type, "", doub));
                         else
                             actions.Add(new SpecialAction(name, controls, type, ""));

--- a/DS4Windows/DS4Control/UdpServer.cs
+++ b/DS4Windows/DS4Control/UdpServer.cs
@@ -216,7 +216,7 @@ namespace DS4Windows
                 sentAsync = udpSock.SendToAsync(args);
                 if (!sentAsync) CompletedSynchronousSocketEvent();
             }
-            catch (Exception e) { }
+            catch (Exception /*e*/) { }
             finally
             {
                 if (!sentAsync) CompletedSynchronousSocketEvent();
@@ -370,7 +370,7 @@ namespace DS4Windows
                     }
                 }
             }
-            catch (Exception e) { }
+            catch (Exception /*e*/) { }
         }
 
         private void ReceiveCallback(IAsyncResult iar)
@@ -387,7 +387,7 @@ namespace DS4Windows
                 localMsg = new byte[msgLen];
                 Array.Copy(recvBuffer, localMsg, msgLen);
             }
-            catch (Exception e) { }
+            catch (Exception /*e*/) { }
 
             //Start another receive as soon as we copied the data
             StartReceive();
@@ -407,7 +407,7 @@ namespace DS4Windows
                     udpSock.BeginReceiveFrom(recvBuffer, 0, recvBuffer.Length, SocketFlags.None, ref newClientEP, ReceiveCallback, udpSock);
                 }
             }
-            catch (SocketException ex)
+            catch (SocketException /*ex*/)
             {
                 uint IOC_IN = 0x80000000;
                 uint IOC_VENDOR = 0x18000000;
@@ -715,7 +715,7 @@ namespace DS4Windows
                     try {
                         sentAsync = udpSock.SendToAsync(args);
                     }
-                    catch (SocketException ex) { }
+                    catch (SocketException /*ex*/) { }
                     finally
                     {
                         if (!sentAsync) CompletedSynchronousSocketEvent();

--- a/DS4Windows/DS4Forms/SpecialActionEditor.xaml
+++ b/DS4Windows/DS4Forms/SpecialActionEditor.xaml
@@ -332,7 +332,7 @@
                             <StackPanel Margin="{StaticResource spaceMargin}">
                                 <StackPanel Orientation="Horizontal" Margin="{StaticResource spaceMargin}">
                                     <Label Content="Hold for "></Label>
-                                    <xctk:IntegerUpDown Value="{Binding Delay}" Width="60" Minimum="0" Maximum="60" />
+                                    <xctk:DecimalUpDown Value="{Binding Delay}" Width="60" Minimum="0" Maximum="60" FormatString= "F2" Increment="0.5" />
                                     <Label Content="secs" />
                                 </StackPanel>
                                 <Button x:Name="launchProgBrowseBtn" Content="{lex:Loc Browse}" Margin="{StaticResource spaceMargin}"
@@ -395,7 +395,7 @@
                         <TabItem x:Name="disconnectBTTab" Header="DisBT">
                             <StackPanel Orientation="Horizontal" Margin="{StaticResource spaceMargin}">
                                 <Label Content="Hold for "></Label>
-                                <xctk:IntegerUpDown Value="{Binding HoldInterval}" Width="60" Minimum="0" Maximum="60" />
+                                <xctk:DecimalUpDown Value="{Binding HoldInterval}" Width="60" Minimum="0" Maximum="60" FormatString= "F2" Increment="0.5" />
                                 <Label Content="secs" />
                             </StackPanel>
                         </TabItem>
@@ -403,7 +403,7 @@
                             <StackPanel Margin="{StaticResource spaceMargin}">
                                 <StackPanel Orientation="Horizontal" Margin="0,8,0,8">
                                     <Label Content="Hold for "></Label>
-                                    <xctk:IntegerUpDown Value="{Binding Delay}" Width="60" Minimum="0" Maximum="60" />
+                                    <xctk:DecimalUpDown Value="{Binding Delay}" Width="60" Minimum="0" Maximum="60" FormatString= "F2" Increment="0.5"/>
                                     <Label Content="secs" />
                                 </StackPanel>
                                 <CheckBox Content="via notification" IsChecked="{Binding Notification}" Margin="{StaticResource spaceMargin}" />
@@ -453,7 +453,7 @@
                         <TabItem x:Name="sixaxisWheelCalibrateTab" Header="Sixaxis Wheel">
                             <StackPanel Orientation="Horizontal" Margin="{StaticResource spaceMargin}">
                                 <Label Content="Hold for "></Label>
-                                <xctk:IntegerUpDown Value="{Binding Delay}" Width="60" Minimum="0" Maximum="60" />
+                                <xctk:DecimalUpDown Value="{Binding Delay}" Width="60" Minimum="0" Maximum="60" FormatString= "F2" Increment="0.5" />
                                 <Label Content="secs" />
                             </StackPanel>
                         </TabItem>

--- a/DS4Windows/DS4Forms/ViewModels/MappingListViewModel.cs
+++ b/DS4Windows/DS4Forms/ViewModels/MappingListViewModel.cs
@@ -11,7 +11,7 @@ namespace DS4WinWPF.DS4Forms.ViewModels
 {
     public class MappingListViewModel
     {
-        private int devIndex;
+        //private int devIndex;
         private ObservableCollection<MappedControl> mappings = new ObservableCollection<MappedControl>();
         public ObservableCollection<MappedControl> Mappings { get => mappings; }
 

--- a/DS4Windows/DS4Forms/ViewModels/SpecialActions/CheckBatteryViewModel.cs
+++ b/DS4Windows/DS4Forms/ViewModels/SpecialActions/CheckBatteryViewModel.cs
@@ -11,7 +11,7 @@ namespace DS4WinWPF.DS4Forms.ViewModels.SpecialActions
 {
     public class CheckBatteryViewModel : NotifyDataErrorBase
     {
-        private int delay;
+        private double delay;
         private bool notification;
         private bool lightbar = true;
         private Color emptyColor
@@ -19,7 +19,7 @@ namespace DS4WinWPF.DS4Forms.ViewModels.SpecialActions
         private Color fullColor =
             new Color() { A = 255, R = 0, G = 255, B = 0 };
 
-        public int Delay { get => delay; set => delay = value; }
+        public double Delay { get => delay; set => delay = value; }
         public bool Notification { get => notification; set => notification = value; }
         public bool Lightbar { get => lightbar; set => lightbar = value; }
         public Color EmptyColor
@@ -80,7 +80,7 @@ namespace DS4WinWPF.DS4Forms.ViewModels.SpecialActions
         public void LoadAction(SpecialAction action)
         {
             string[] details = action.details.Split(',');
-            delay = (int)action.delayTime;
+            delay = action.delayTime;
             bool.TryParse(details[1], out notification);
             bool.TryParse(details[2], out lightbar);
             emptyColor = Color.FromArgb(255, byte.Parse(details[3]), byte.Parse(details[4]), byte.Parse(details[5]));
@@ -89,7 +89,7 @@ namespace DS4WinWPF.DS4Forms.ViewModels.SpecialActions
 
         public void SaveAction(SpecialAction action, bool edit = false)
         {
-            string details = $"{delay}|{notification}|{lightbar}|{emptyColor.R}|{emptyColor.G}|{emptyColor.B}|" +
+            string details = $"{delay.ToString("#.##", Global.configFileDecimalCulture)}|{notification}|{lightbar}|{emptyColor.R}|{emptyColor.G}|{emptyColor.B}|" +
                 $"{fullColor.R}|{fullColor.G}|{fullColor.B}";
 
             Global.SaveAction(action.name, action.controls, 6, details, edit);

--- a/DS4Windows/DS4Forms/ViewModels/SpecialActions/DisconnectBTViewModel.cs
+++ b/DS4Windows/DS4Forms/ViewModels/SpecialActions/DisconnectBTViewModel.cs
@@ -10,17 +10,17 @@ namespace DS4WinWPF.DS4Forms.ViewModels.SpecialActions
 {
     public class DisconnectBTViewModel : NotifyDataErrorBase
     {
-        private int holdInterval;
-        public int HoldInterval { get => holdInterval; set => holdInterval = value; }
+        private double holdInterval;
+        public double HoldInterval { get => holdInterval; set => holdInterval = value; }
 
         public void LoadAction(SpecialAction action)
         {
-            holdInterval = (int)action.delayTime;
+            holdInterval = action.delayTime;
         }
 
         public void SaveAction(SpecialAction action, bool edit = false)
         {
-            Global.SaveAction(action.name, action.controls, 5, $"{holdInterval}", edit);
+            Global.SaveAction(action.name, action.controls, 5, $"{holdInterval.ToString("#.##", Global.configFileDecimalCulture)}", edit);
         }
 
         public override bool IsValid(SpecialAction action)

--- a/DS4Windows/DS4Forms/ViewModels/SpecialActions/LaunchProgramViewModel.cs
+++ b/DS4Windows/DS4Forms/ViewModels/SpecialActions/LaunchProgramViewModel.cs
@@ -17,7 +17,7 @@ namespace DS4WinWPF.DS4Forms.ViewModels.SpecialActions
     public class LaunchProgramViewModel : NotifyDataErrorBase
     {
         private string filepath;
-        private int delay;
+        private double delay;
         private string arguments;
 
         public string Filepath
@@ -31,7 +31,7 @@ namespace DS4WinWPF.DS4Forms.ViewModels.SpecialActions
             }
         }
         public event EventHandler FilepathChanged;
-        public int Delay { get => delay; set => delay = value; }
+        public double Delay { get => delay; set => delay = value; }
         public string Arguments { get => arguments; set => arguments = value; }
 
         public ImageSource ProgramIcon
@@ -84,13 +84,13 @@ namespace DS4WinWPF.DS4Forms.ViewModels.SpecialActions
         public void LoadAction(SpecialAction action)
         {
             filepath = action.details;
-            delay = (int)action.delayTime;
+            delay = action.delayTime;
             arguments = action.extra;
         }
 
         public void SaveAction(SpecialAction action, bool edit = false)
         {
-            Global.SaveAction(action.name, action.controls, 2, $"{filepath}?{delay}", edit, arguments);
+            Global.SaveAction(action.name, action.controls, 2, $"{filepath}?{delay.ToString("#.##", Global.configFileDecimalCulture)}", edit, arguments);
         }
 
         public override bool IsValid(SpecialAction action)

--- a/DS4Windows/DS4Forms/ViewModels/SpecialActions/SASteeringWheelViewModel.cs
+++ b/DS4Windows/DS4Forms/ViewModels/SpecialActions/SASteeringWheelViewModel.cs
@@ -10,17 +10,17 @@ namespace DS4WinWPF.DS4Forms.ViewModels.SpecialActions
 {
     public class SASteeringWheelViewModel : NotifyDataErrorBase
     {
-        private int delay;
-        public int Delay { get => delay; set => delay = value; }
+        private double delay;
+        public double Delay { get => delay; set => delay = value; }
 
         public void LoadAction(SpecialAction action)
         {
-            delay = (int)action.delayTime;
+            delay = action.delayTime;
         }
 
         public void SaveAction(SpecialAction action, bool edit = false)
         {
-            Global.SaveAction(action.name, action.controls, 8, delay.ToString(), edit);
+            Global.SaveAction(action.name, action.controls, 8, delay.ToString("#.##", Global.configFileDecimalCulture), edit);
         }
 
         public override bool IsValid(SpecialAction action)

--- a/DS4Windows/DS4Library/InputDevices/DualSenseDevice.cs
+++ b/DS4Windows/DS4Library/InputDevices/DualSenseDevice.cs
@@ -387,7 +387,7 @@ namespace DS4Windows.InputDevices
                 ds4InactiveFrame = true;
                 idleInput = true;
                 bool syncWriteReport = conType != ConnectionType.BT;
-                bool forceWrite = false;
+                //bool forceWrite = false;
 
                 int maxBatteryValue = 0;
                 int tempBattery = 0;
@@ -811,7 +811,7 @@ namespace DS4Windows.InputDevices
                     }
 
                     outputDirty = false;
-                    forceWrite = false;
+                    //forceWrite = false;
 
                     if (!string.IsNullOrEmpty(currerror))
                         error = currerror;

--- a/DS4Windows/DS4Library/InputDevices/JoyConDevice.cs
+++ b/DS4Windows/DS4Library/InputDevices/JoyConDevice.cs
@@ -343,7 +343,7 @@ namespace DS4Windows.InputDevices
             //short gyroPitch = 0, gyroPitch2 = 0, gyroPitch3 = 0;
             //short gyroRoll = 0, gyroRoll2 = 0, gyroRoll3 = 0;
             short tempShort = 0;
-            int tempAxis = 0;
+            //int tempAxis = 0;
             int tempAxisX = 0;
             int tempAxisY = 0;
 
@@ -369,14 +369,14 @@ namespace DS4Windows.InputDevices
                 ds4InactiveFrame = true;
                 idleInput = true;
                 bool syncWriteReport = conType != ConnectionType.BT;
-                bool forceWrite = false;
+                //bool forceWrite = false;
 
-                int maxBatteryValue = 0;
+                //int maxBatteryValue = 0;
                 int tempBattery = 0;
                 bool tempCharging = charging;
-                uint tempStamp = 0;
+                //uint tempStamp = 0;
                 double elapsedDeltaTime = 0.0;
-                uint tempDelta = 0;
+                //uint tempDelta = 0;
                 byte tempByte = 0;
                 long latencySum = 0;
 
@@ -691,7 +691,7 @@ namespace DS4Windows.InputDevices
                     Report?.Invoke(this, EventArgs.Empty);
                     WriteReport();
 
-                    forceWrite = false;
+                    //forceWrite = false;
 
                     if (!string.IsNullOrEmpty(currerror))
                         error = currerror;
@@ -791,7 +791,7 @@ namespace DS4Windows.InputDevices
         public void SetInitRumble()
         {
             bool result;
-            HidDevice.ReadStatus res;
+            //HidDevice.ReadStatus res;
             //byte[] tmpReport = new byte[64];
             byte[] rumble_data = new byte[8];
             rumble_data[0] = 0x0;

--- a/DS4Windows/DS4Library/InputDevices/SwitchProDevice.cs
+++ b/DS4Windows/DS4Library/InputDevices/SwitchProDevice.cs
@@ -324,14 +324,14 @@ namespace DS4Windows.InputDevices
                 ds4InactiveFrame = true;
                 idleInput = true;
                 bool syncWriteReport = conType != ConnectionType.BT;
-                bool forceWrite = false;
-
-                int maxBatteryValue = 0;
+                //bool forceWrite = false;
+                
+                //int maxBatteryValue = 0;
                 int tempBattery = 0;
                 bool tempCharging = charging;
-                uint tempStamp = 0;
+                //uint tempStamp = 0;
                 double elapsedDeltaTime = 0.0;
-                uint tempDelta = 0;
+                //uint tempDelta = 0;
                 byte tempByte = 0;
                 long latencySum = 0;
 
@@ -611,7 +611,7 @@ namespace DS4Windows.InputDevices
                     Report?.Invoke(this, EventArgs.Empty);
                     WriteReport();
 
-                    forceWrite = false;
+                    //forceWrite = false;
 
                     if (!string.IsNullOrEmpty(currerror))
                         error = currerror;
@@ -776,7 +776,7 @@ namespace DS4Windows.InputDevices
         public void SetInitRumble()
         {
             bool result;
-            HidDevice.ReadStatus res;
+            //HidDevice.ReadStatus res;
             //byte[] tmpReport = new byte[64];
             byte[] rumble_data = new byte[8];
             rumble_data[0] = 0x0;

--- a/DS4Windows/HidLibrary/HidDevice.cs
+++ b/DS4Windows/HidLibrary/HidDevice.cs
@@ -24,7 +24,7 @@ namespace DS4Windows
         private readonly HidDeviceAttributes _deviceAttributes;
 
         private readonly HidDeviceCapabilities _deviceCapabilities;
-        private bool _monitorDeviceEvents;
+        //private bool _monitorDeviceEvents;
         private string serial = null;
         private const string BLANK_SERIAL = "00:00:00:00:00:00";
 


### PR DESCRIPTION
"Hold for X secs" special actions now support decimal delay values (precision of 2 decimals, GUI DoubleUpDown increments by 0.5).  The config file is always saved using en-US cultureVariation to make sure reading and writing of the decimal value as string uses dot char as decimal separator and not a comma even when the default localization would have a comma char. Related to #2244 

Also commented out unused variables to get rid of compiler warnings.
