### PR TITLE
DeviceOptions with "Verbose log messages" option to show additional log messages when a gamepad is connected

### DIFF
--- a/DS4Windows/DS4Control/ControlServiceDeviceOptions.cs
+++ b/DS4Windows/DS4Control/ControlServiceDeviceOptions.cs
@@ -13,8 +13,7 @@ namespace DS4Windows
         private DS4DeviceOptions dS4DeviceOpts = new DS4DeviceOptions();
         public DS4DeviceOptions DS4DeviceOpts { get => dS4DeviceOpts; }
 
-        private DualSenseDeviceOptions dualSenseOpts =
-            new DualSenseDeviceOptions();
+        private DualSenseDeviceOptions dualSenseOpts = new DualSenseDeviceOptions();
         public DualSenseDeviceOptions DualSenseOpts { get => dualSenseOpts; }
 
         private SwitchProDeviceOptions switchProDeviceOpts = new SwitchProDeviceOptions();
@@ -22,6 +21,16 @@ namespace DS4Windows
 
         private JoyConDeviceOptions joyConDeviceOpts = new JoyConDeviceOptions();
         public JoyConDeviceOptions JoyConDeviceOpts { get => joyConDeviceOpts; }
+
+        private bool verboseLogMessages;
+        public bool VerboseLogMessages { get => verboseLogMessages; set => verboseLogMessages = value; }
+
+        public ControlServiceDeviceOptions()
+        {
+            // If enabled then DS4Windows shows additional log messages when a gamepad is connected (may be useful to diagnose connection problems).
+            // This option is not persistent (ie. not saved into config files), so if enabled then it is reset back to FALSE when DS4Windows is restarted.
+            verboseLogMessages = false;
+        }
     }
 
     public abstract class ControllerOptionsStore

--- a/DS4Windows/DS4Forms/ControllerRegisterOptionsWindow.xaml
+++ b/DS4Windows/DS4Forms/ControllerRegisterOptionsWindow.xaml
@@ -19,6 +19,10 @@
                 <CheckBox Content="JoyCon Controller Support" IsChecked="{Binding JoyConDeviceOpts.Enabled}" />
             </StackPanel>
 
+            <StackPanel DockPanel.Dock="Top" Margin="0,16,0,0">
+                <CheckBox Content="Enable verbose log" IsChecked="{Binding VerboseLogMessages}" ToolTip="Show additional log messages when a gamepad is connected"/>
+            </StackPanel>
+            
             <DockPanel DockPanel.Dock="Bottom" Margin="0,20,0,0">
                 <Label Content="Detected Controllers" ContentStringFormat="{}{0}:" DockPanel.Dock="Top" FontWeight="Bold" />
                 <ListBox x:Name="controllerListBox" ItemsSource="{Binding CurrentInputDevices}" SelectedIndex="{Binding ControllerSelectedIndex}"

--- a/DS4Windows/DS4Forms/ViewModels/ControllerRegDeviceOptsViewModel.cs
+++ b/DS4Windows/DS4Forms/ViewModels/ControllerRegDeviceOptsViewModel.cs
@@ -29,6 +29,8 @@ namespace DS4WinWPF.DS4Forms.ViewModels
         public SwitchProDeviceOptions SwitchProDeviceOpts { get => serviceDeviceOpts.SwitchProDeviceOpts; }
         public JoyConDeviceOptions JoyConDeviceOpts { get => serviceDeviceOpts.JoyConDeviceOpts; }
 
+        public bool VerboseLogMessages { get => serviceDeviceOpts.VerboseLogMessages; set => serviceDeviceOpts.VerboseLogMessages = value; }
+
         private List<DeviceListItem> currentInputDevices = new List<DeviceListItem>();
         public List<DeviceListItem> CurrentInputDevices { get => currentInputDevices; }
 

--- a/DS4Windows/HidLibrary/HidDevices.cs
+++ b/DS4Windows/HidLibrary/HidDevices.cs
@@ -45,7 +45,7 @@ namespace DS4Windows
 
         public static IEnumerable<HidDevice> EnumerateDS4(VidPidInfo[] devInfo)
         {
-            //int iDebugDevCount = 0;
+            int iEnumeratedDevCount = 0;
             List<HidDevice> foundDevs = new List<HidDevice>();
             int devInfoLen = devInfo.Length;
             IEnumerable<DeviceInfo> temp = EnumerateDevices();
@@ -55,8 +55,7 @@ namespace DS4Windows
                 DeviceInfo x = devEnum.Current;
                 //DeviceInfo x = temp.ElementAt(i);               
                 HidDevice tempDev = new HidDevice(x.Path, x.Description, x.Parent);
-                //iDebugDevCount++;
-                //AppLogger.LogToGui($"DEBUG: HID#{iDebugDevCount} Path={x.Path}  Description={x.Description}  VID={tempDev.Attributes.VendorHexId}  PID={tempDev.Attributes.ProductHexId}  Usage=0x{tempDev.Capabilities.Usage.ToString("X")}  Version=0x{tempDev.Attributes.Version.ToString("X")}", false);
+                iEnumeratedDevCount++;
                 bool found = false;
                 for (int j = 0; !found && j < devInfoLen; j++)
                 {
@@ -71,6 +70,24 @@ namespace DS4Windows
                         foundDevs.Add(tempDev);
                     }
                 }
+
+                if (Global.DeviceOptions.VerboseLogMessages)
+                {
+                    if (found)
+                    {
+                        AppLogger.LogToGui($"HID#{iEnumeratedDevCount} CONNECTING to {x.Description}  VID={tempDev.Attributes.VendorHexId}  PID={tempDev.Attributes.ProductHexId}  Usage=0x{tempDev.Capabilities.Usage.ToString("X")}  Version=0x{tempDev.Attributes.Version.ToString("X")}  Path={x.Path}", false);
+                    }
+                    else
+                    {
+                        AppLogger.LogToGui($"HID#{iEnumeratedDevCount} Unknown device {x.Description}  VID={tempDev.Attributes.VendorHexId}  PID={tempDev.Attributes.ProductHexId}  Usage=0x{tempDev.Capabilities.Usage.ToString("X")}  Version=0x{tempDev.Attributes.Version.ToString("X")}  Path={x.Path}", false);
+                    }
+                }
+            }
+
+            if (Global.DeviceOptions.VerboseLogMessages && iEnumeratedDevCount > 0)
+            {
+                // This EnumerateDS4 method is called 3-4 times when a gamepad is connected. Print out "separator" log msg line between different enumeration loops to make the logfile easier to read
+                AppLogger.LogToGui($"-------------------------", false);
             }
 
             return foundDevs;


### PR DESCRIPTION
DeviceOptions has a new "Verbose log messages" option to show additional log msg lines when a gamepad is connected (may help to track down connection issues and when trying to add support for new gamepads). The option is NOT persistent (ie. the current value is not saved in config files, so verbose log option resets back to default FALSE when DS4Windows app is restarted while this option is enabled)

![DS4Win_VerboseLogOption](https://user-images.githubusercontent.com/35538525/122652330-f566c100-d146-11eb-9f6d-1a8fc130ccad.png)
