### PR TITLE
Allow setting output region for touchpad absolute mouse mode.

### DIFF
--- a/DS4Windows/DS4Control/ProfilePropGroups.cs
+++ b/DS4Windows/DS4Control/ProfilePropGroups.cs
@@ -605,18 +605,30 @@ namespace DS4Windows
 
     public class TouchpadAbsMouseSettings
     {
-        public const int DEFAULT_MAXZONE_X = 90;
-        public const int DEFAULT_MAXZONE_Y = 90;
+        public const double DEFAULT_MAXZONE_X = 90.0;
+        public const double DEFAULT_MAXZONE_Y = 90.0;
+        public const double DEFAULT_MINPOS_X = 0.0;
+        public const double DEFAULT_MINPOS_Y = 0.0;
+        public const double DEFAULT_MAXPOS_X = 100.0;
+        public const double DEFAULT_MAXPOS_Y = 100.0;
         public const bool DEFAULT_SNAP_CENTER = false;
 
-        public int maxZoneX = DEFAULT_MAXZONE_X;
-        public int maxZoneY = DEFAULT_MAXZONE_Y;
+        public double maxZoneX = DEFAULT_MAXZONE_X;
+        public double maxZoneY = DEFAULT_MAXZONE_Y;
+        public double minPosX = DEFAULT_MINPOS_X;
+        public double minPosY = DEFAULT_MINPOS_Y;
+        public double maxPosX = DEFAULT_MAXPOS_X;
+        public double maxPosY = DEFAULT_MAXPOS_Y;
         public bool snapToCenter = DEFAULT_SNAP_CENTER;
 
         public void Reset()
         {
             maxZoneX = DEFAULT_MAXZONE_X;
             maxZoneY = DEFAULT_MAXZONE_Y;
+            minPosX = DEFAULT_MINPOS_X;
+            minPosY = DEFAULT_MINPOS_Y;
+            maxPosX = DEFAULT_MAXPOS_X;
+            maxPosY = DEFAULT_MAXPOS_Y;
             snapToCenter = DEFAULT_SNAP_CENTER;
         }
     }

--- a/DS4Windows/DS4Control/ScpUtil.cs
+++ b/DS4Windows/DS4Control/ScpUtil.cs
@@ -3693,6 +3693,10 @@ namespace DS4Windows
                 XmlElement xmlTouchAbsMouseGroupEl = m_Xdoc.CreateElement("TouchpadAbsMouseSettings");
                 XmlElement xmlTouchAbsMouseMaxZoneX = m_Xdoc.CreateElement("MaxZoneX"); xmlTouchAbsMouseMaxZoneX.InnerText = touchpadAbsMouse[device].maxZoneX.ToString(); xmlTouchAbsMouseGroupEl.AppendChild(xmlTouchAbsMouseMaxZoneX);
                 XmlElement xmlTouchAbsMouseMaxZoneY = m_Xdoc.CreateElement("MaxZoneY"); xmlTouchAbsMouseMaxZoneY.InnerText = touchpadAbsMouse[device].maxZoneY.ToString(); xmlTouchAbsMouseGroupEl.AppendChild(xmlTouchAbsMouseMaxZoneY);
+                XmlElement xmlTouchAbsMouseMinPosX = m_Xdoc.CreateElement("MinPosX"); xmlTouchAbsMouseMinPosX.InnerText = touchpadAbsMouse[device].minPosX.ToString(); xmlTouchAbsMouseGroupEl.AppendChild(xmlTouchAbsMouseMinPosX);
+                XmlElement xmlTouchAbsMouseMinPosY = m_Xdoc.CreateElement("MinPosY"); xmlTouchAbsMouseMinPosY.InnerText = touchpadAbsMouse[device].minPosY.ToString(); xmlTouchAbsMouseGroupEl.AppendChild(xmlTouchAbsMouseMinPosY);
+                XmlElement xmlTouchAbsMouseMaxPosX = m_Xdoc.CreateElement("MaxPosX"); xmlTouchAbsMouseMaxPosX.InnerText = touchpadAbsMouse[device].maxPosX.ToString(); xmlTouchAbsMouseGroupEl.AppendChild(xmlTouchAbsMouseMaxPosX);
+                XmlElement xmlTouchAbsMouseMaxPosY = m_Xdoc.CreateElement("MaxPosY"); xmlTouchAbsMouseMaxPosY.InnerText = touchpadAbsMouse[device].maxPosY.ToString(); xmlTouchAbsMouseGroupEl.AppendChild(xmlTouchAbsMouseMaxPosY);
                 XmlElement xmlTouchAbsMouseSnapCenter = m_Xdoc.CreateElement("SnapToCenter"); xmlTouchAbsMouseSnapCenter.InnerText = touchpadAbsMouse[device].snapToCenter.ToString(); xmlTouchAbsMouseGroupEl.AppendChild(xmlTouchAbsMouseSnapCenter);
                 rootElement.AppendChild(xmlTouchAbsMouseGroupEl);
 
@@ -5593,7 +5597,7 @@ namespace DS4Windows
                     try
                     {
                         Item = touchpadAbsMouseElement.SelectSingleNode("MaxZoneX");
-                        int.TryParse(Item.InnerText, out int temp);
+                        double.TryParse(Item.InnerText, out double temp);
                         touchpadAbsMouse[device].maxZoneX = temp;
                     }
                     catch { touchpadAbsMouse[device].maxZoneX = TouchpadAbsMouseSettings.DEFAULT_MAXZONE_X; missingSetting = true; }
@@ -5601,10 +5605,42 @@ namespace DS4Windows
                     try
                     {
                         Item = touchpadAbsMouseElement.SelectSingleNode("MaxZoneY");
-                        int.TryParse(Item.InnerText, out int temp);
+                        double.TryParse(Item.InnerText, out double temp);
                         touchpadAbsMouse[device].maxZoneY = temp;
                     }
                     catch { touchpadAbsMouse[device].maxZoneY = TouchpadAbsMouseSettings.DEFAULT_MAXZONE_Y; missingSetting = true; }
+
+                    try
+                    {
+                        Item = touchpadAbsMouseElement.SelectSingleNode("MinPosX");
+                        double.TryParse(Item.InnerText, out double temp);
+                        touchpadAbsMouse[device].minPosX = temp;
+                    }
+                    catch { touchpadAbsMouse[device].minPosX = TouchpadAbsMouseSettings.DEFAULT_MINPOS_X; missingSetting = true; }
+
+                    try
+                    {
+                        Item = touchpadAbsMouseElement.SelectSingleNode("MinPosY");
+                        double.TryParse(Item.InnerText, out double temp);
+                        touchpadAbsMouse[device].minPosY = temp;
+                    }
+                    catch { touchpadAbsMouse[device].minPosY = TouchpadAbsMouseSettings.DEFAULT_MINPOS_Y; missingSetting = true; }
+
+                    try
+                    {
+                        Item = touchpadAbsMouseElement.SelectSingleNode("MaxPosX");
+                        double.TryParse(Item.InnerText, out double temp);
+                        touchpadAbsMouse[device].maxPosX = temp;
+                    }
+                    catch { touchpadAbsMouse[device].maxPosX = TouchpadAbsMouseSettings.DEFAULT_MAXPOS_X; missingSetting = true; }
+
+                    try
+                    {
+                        Item = touchpadAbsMouseElement.SelectSingleNode("MaxPosY");
+                        double.TryParse(Item.InnerText, out double temp);
+                        touchpadAbsMouse[device].maxPosY = temp;
+                    }
+                    catch { touchpadAbsMouse[device].maxPosY = TouchpadAbsMouseSettings.DEFAULT_MAXPOS_Y; missingSetting = true; }
 
                     try
                     {

--- a/DS4Windows/DS4Forms/ProfileEditor.xaml
+++ b/DS4Windows/DS4Forms/ProfileEditor.xaml
@@ -1087,7 +1087,10 @@
             <TabItem Header="Touchpad">
                 <TabItem.Resources>
                     <Thickness x:Key="spaceMargin" Bottom="8" />
-                </TabItem.Resources>
+					<Style x:Key="gridRowHeight" TargetType="{x:Type RowDefinition}">
+						<Setter Property="Height" Value="30" />
+					</Style>
+				</TabItem.Resources>
 
                 <StackPanel Margin="4">
                     <StackPanel Orientation="Horizontal" Margin="{StaticResource spaceMargin}">
@@ -1240,22 +1243,104 @@
                                                           Margin="5,8,0,0" />
                             </StackPanel>
                         </TabItem>
-                        <TabItem Header="Absolute Mouse" Visibility="Collapsed">
-                            <StackPanel>
-                                <StackPanel Orientation="Horizontal" Margin="{StaticResource spaceMargin}">
-                                    <Label Content="Max Zone X:" />
-                                    <xctk:IntegerUpDown d:IsHidden="True" MinWidth="80" Height="20" Minimum="0" Maximum="100" Value="{Binding TouchAbsMouseMaxZoneX}" Margin="8,0,0,0" />
-                                </StackPanel>
-                                <StackPanel Orientation="Horizontal" Margin="{StaticResource spaceMargin}">
-                                    <Label Content="Max Zone Y:" />
-                                    <xctk:IntegerUpDown d:IsHidden="True" MinWidth="80" Height="20" Minimum="0" Maximum="100" Value="{Binding TouchAbsMouseMaxZoneY}" Margin="8,0,0,0" />
-                                </StackPanel>
-                                <StackPanel Orientation="Horizontal" Margin="{StaticResource spaceMargin}">
-                                    <Label Content="Snap To Center on Release:" />
-                                    <CheckBox IsChecked="{Binding TouchAbsMouseSnapCenter}" VerticalAlignment="Center" Margin="8,0,0,0" />
-                                </StackPanel>
-                            </StackPanel>
-                        </TabItem>
+						<TabItem Header="Absolute Mouse" Visibility="Collapsed">
+							<StackPanel>
+
+								<Grid Margin="{StaticResource spaceMargin}">
+									<Grid.RowDefinitions>
+										<RowDefinition></RowDefinition>
+										<RowDefinition Style="{StaticResource gridRowHeight}"></RowDefinition>
+										<RowDefinition Style="{StaticResource gridRowHeight}"></RowDefinition>
+										<RowDefinition Style="{StaticResource gridRowHeight}"></RowDefinition>
+									</Grid.RowDefinitions>
+
+									<Grid.ColumnDefinitions>
+										<ColumnDefinition/>
+										<ColumnDefinition/>
+										<ColumnDefinition/>
+									</Grid.ColumnDefinitions>
+
+									<TextBlock Text="X" Grid.Row="0" Grid.Column="1" FontWeight="Bold" HorizontalAlignment="Center" Margin="0,0,0,8" />
+									<TextBlock Text="Y" Grid.Row="0" Grid.Column="2" FontWeight="Bold" HorizontalAlignment="Center" Margin="0,0,0,8" />
+									
+									<Label Content="Max Zone:" Grid.Row="1" Grid.Column="0" />
+									<DockPanel Grid.Row="1" Grid.Column="1">
+										<Label Content="%" DockPanel.Dock="Right" />
+										<xctk:DoubleUpDown d:IsHidden="True" FormatString="F0" Value="{Binding TouchAbsMouseMaxZoneX}" MinWidth="50" Maximum="100.0" Minimum="0.0" Increment="1"
+                                                   Margin="{StaticResource spaceMargin}">
+											<xctk:DoubleUpDown.ToolTip>
+												<TextBlock TextWrapping="Wrap">
+                                                Determines what percentage of the touchpad will be used. If this is set to 90, any inputs outside the middle 90% of the touchpad will be clamped to the minimum or maximim value.
+												</TextBlock>
+											</xctk:DoubleUpDown.ToolTip>
+										</xctk:DoubleUpDown>
+									</DockPanel>
+									<DockPanel Grid.Row="1" Grid.Column="2">
+										<Label Content="%" DockPanel.Dock="Right" />
+										<xctk:DoubleUpDown d:IsHidden="True" FormatString="F0" Value="{Binding TouchAbsMouseMaxZoneY}" MinWidth="50" Maximum="100.0" Minimum="0.0" Increment="1"
+                                                   Margin="{StaticResource spaceMargin}">
+											<xctk:DoubleUpDown.ToolTip>
+												<TextBlock TextWrapping="Wrap">
+                                                Determines what percentage of the touchpad will be used. If this is set to 90, any inputs outside the middle 90% of the touchpad will be clamped to the minimum or maximim value.
+												</TextBlock>
+											</xctk:DoubleUpDown.ToolTip>
+										</xctk:DoubleUpDown>
+									</DockPanel>
+
+									<Label Content="Min Position:" Grid.Row="2" Grid.Column="0" />
+									<DockPanel Grid.Row="2" Grid.Column="1">
+										<Label Content="%" DockPanel.Dock="Right" />
+										<xctk:DoubleUpDown d:IsHidden="True" FormatString="F2" Value="{Binding TouchAbsMouseMinPosX}" MinWidth="50" Maximum="100.0" Minimum="0.0" Increment="0.01"
+                                                   Margin="{StaticResource spaceMargin}">
+											<xctk:DoubleUpDown.ToolTip>
+												<TextBlock TextWrapping="Wrap">
+                                                Determines what portion of the screen will be used as outputs. If this is set to 10, the minimum input will place the cursor 10% of the way along the screen.
+												</TextBlock>
+											</xctk:DoubleUpDown.ToolTip>
+										</xctk:DoubleUpDown>
+									</DockPanel>
+									<DockPanel Grid.Row="2" Grid.Column="2">
+										<Label Content="%" DockPanel.Dock="Right" />
+										<xctk:DoubleUpDown d:IsHidden="True" FormatString="F2" Value="{Binding TouchAbsMouseMinPosY}" MinWidth="50" Maximum="100.0" Minimum="0.0" Increment="0.01"
+                                                   Margin="{StaticResource spaceMargin}">
+											<xctk:DoubleUpDown.ToolTip>
+												<TextBlock TextWrapping="Wrap">
+                                                Determines what portion of the screen will be used as outputs. If this is set to 10, the minimum input will place the cursor 10% of the way down the screen.
+												</TextBlock>
+											</xctk:DoubleUpDown.ToolTip>
+										</xctk:DoubleUpDown>
+									</DockPanel>
+
+									<Label Content="Max Position:" Grid.Row="3" Grid.Column="0" />
+									<DockPanel Grid.Row="3" Grid.Column="1">
+										<Label Content="%" DockPanel.Dock="Right" />
+										<xctk:DoubleUpDown d:IsHidden="True" FormatString="F2" Value="{Binding TouchAbsMouseMaxPosX}" MinWidth="50" Maximum="100.0" Minimum="0.0" Increment="0.01"
+                                                   Margin="{StaticResource spaceMargin}">
+											<xctk:DoubleUpDown.ToolTip>
+												<TextBlock TextWrapping="Wrap">
+                                                Determines what portion of the screen will be used as outputs. If this is set to 90, the maximum input will place the cursor 90% of the way along the screen.
+												</TextBlock>
+											</xctk:DoubleUpDown.ToolTip>
+										</xctk:DoubleUpDown>
+									</DockPanel>
+									<DockPanel Grid.Row="3" Grid.Column="2">
+										<Label Content="%" DockPanel.Dock="Right" />
+										<xctk:DoubleUpDown d:IsHidden="True" FormatString="F2" Value="{Binding TouchAbsMouseMaxPosY}" MinWidth="50" Maximum="100.0" Minimum="0.0" Increment="0.01"
+                                                   Margin="{StaticResource spaceMargin}">
+											<xctk:DoubleUpDown.ToolTip>
+												<TextBlock TextWrapping="Wrap">
+                                                Determines what portion of the screen will be used as outputs. If this is set to 90, the maximum input will place the cursor 90% of the way down the screen.
+												</TextBlock>
+											</xctk:DoubleUpDown.ToolTip>
+										</xctk:DoubleUpDown>
+									</DockPanel>
+								</Grid>
+								<StackPanel Orientation="Horizontal" Margin="{StaticResource spaceMargin}">
+									<Label Content="Snap to Center on Release:" />
+									<CheckBox IsChecked="{Binding TouchAbsMouseSnapCenter}" VerticalAlignment="Center" Margin="8,0,0,0" />
+								</StackPanel>
+							</StackPanel>
+						</TabItem>
                         <TabItem Header="Passthru" Visibility="Collapsed">
                             <StackPanel>
                                 <TextBlock Foreground="Red">

--- a/DS4Windows/DS4Forms/ViewModels/ProfileSettingsViewModel.cs
+++ b/DS4Windows/DS4Forms/ViewModels/ProfileSettingsViewModel.cs
@@ -1810,25 +1810,69 @@ namespace DS4WinWPF.DS4Forms.ViewModels
             set => Global.TrackballFriction[device] = value;
         }
 
-        public int TouchAbsMouseMaxZoneX
+        public double TouchAbsMouseMaxZoneX
         {
             get => Global.TouchAbsMouse[device].maxZoneX;
             set
             {
-                int temp = Global.TouchAbsMouse[device].maxZoneX;
+                double temp = Global.TouchAbsMouse[device].maxZoneX;
                 if (temp == value) return;
                 Global.TouchAbsMouse[device].maxZoneX = value;
             }
         }
 
-        public int TouchAbsMouseMaxZoneY
+        public double TouchAbsMouseMaxZoneY
         {
             get => Global.TouchAbsMouse[device].maxZoneY;
             set
             {
-                int temp = Global.TouchAbsMouse[device].maxZoneY;
+                double temp = Global.TouchAbsMouse[device].maxZoneY;
                 if (temp == value) return;
                 Global.TouchAbsMouse[device].maxZoneY = value;
+            }
+        }
+
+        public double TouchAbsMouseMinPosX
+        {
+            get => Global.TouchAbsMouse[device].minPosX;
+            set
+            {
+                double temp = Global.TouchAbsMouse[device].minPosX;
+                if (temp == value) return;
+                Global.TouchAbsMouse[device].minPosX = value;
+            }
+        }
+
+        public double TouchAbsMouseMinPosY
+        {
+            get => Global.TouchAbsMouse[device].minPosY;
+            set
+            {
+                double temp = Global.TouchAbsMouse[device].minPosY;
+                if (temp == value) return;
+                Global.TouchAbsMouse[device].minPosY = value;
+            }
+        }
+
+        public double TouchAbsMouseMaxPosX
+        {
+            get => Global.TouchAbsMouse[device].maxPosX;
+            set
+            {
+                double temp = Global.TouchAbsMouse[device].maxPosX;
+                if (temp == value) return;
+                Global.TouchAbsMouse[device].maxPosX = value;
+            }
+        }
+
+        public double TouchAbsMouseMaxPosY
+        {
+            get => Global.TouchAbsMouse[device].maxPosY;
+            set
+            {
+                double temp = Global.TouchAbsMouse[device].maxPosY;
+                if (temp == value) return;
+                Global.TouchAbsMouse[device].maxPosY = value;
             }
         }
 


### PR DESCRIPTION
This PR restructures and adds functionality to the absolute mouse mode of the touchpad. In particular, it adds four new parameters: a minimum and maximum position for both the x and y axis. These parameters are percentages of the screen resolution and change where the minimum and maximum inputs place the cursor onto the screen. If the minimum x position is set to 10, then the minimum touchpad x input sets the x axis of the cursor 10% of the way along the screen. 

For my use case, I want the touchpad to only control a small window in the corner of my screen, as this is the only touch-sensitive part of my Citra window (I don't like passing the touchpad straight through into Cirta. I find it doesn't work particularly well).

Additionally, I changed the existing max zone parameters to `double`s so my code could treat everything uniformly. I also refactored the existing formulas for computing `absX` and  `absY`, but it is algebraically equivalent so that part should be computed the same modulo floating point error. I also changed the absolute mouse mode configuration screen to be in a grid layout and added percentage markers and tooltips (I didn't know what Max Zone was until I read the code).

I believe that I changed all the relevant portions of the program to make sure the configurations are saved correctly and such, but this is my first time looking at this project or actually using Visual Studio, C#, or .NET, so might have missed something. Relatedly, please feel free to give me any feedback whatsoever as to how I could have improved this PR.

Thanks for such an awesome program. :)