### PR TITLE
Fix combo box cutoff in dark theme

### DIFF
--- a/DS4Windows/DS4Forms/Themes/DarkTheme.xaml
+++ b/DS4Windows/DS4Forms/Themes/DarkTheme.xaml
@@ -643,7 +643,7 @@
                     <Grid>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*"/>
-                            <ColumnDefinition MinWidth="{x:Static SystemParameters.VerticalScrollBarWidth}"/>
+                            <ColumnDefinition MinWidth="{x:Static SystemParameters.VerticalScrollBarWidth}" Width="0"/>
                         </Grid.ColumnDefinitions>
 
                         <ToggleButton Style="{StaticResource ComboBoxToggle}" BorderBrush="{TemplateBinding BorderBrush}"


### PR DESCRIPTION
Fix combo box cutoff bug on dark theme in `Output Slots` tab introduced in #2302.

Before:
![image](https://user-images.githubusercontent.com/16513942/126318541-77ef96d0-ba6b-4876-acbe-bfa90cd2d34b.png)

After:
![image](https://user-images.githubusercontent.com/16513942/126318555-9aacf8d1-cad2-4361-8bf7-b1ef9a2562b7.png)
