### PR TITLE
Read description

### DIFF
--- a/DS4Windows/DS4Forms/MainWindow.xaml.cs
+++ b/DS4Windows/DS4Forms/MainWindow.xaml.cs
@@ -373,9 +373,12 @@ namespace DS4WinWPF.DS4Forms
                 if (!IsActive && (Global.Notifications == 2 ||
                     (Global.Notifications == 1 && e.Warning)))
                 {
-                    notifyIcon.ShowBalloonTip(TrayIconViewModel.ballonTitle,
-                    e.Data, !e.Warning ? Hardcodet.Wpf.TaskbarNotification.BalloonIcon.Info :
-                    Hardcodet.Wpf.TaskbarNotification.BalloonIcon.Warning);
+                    notifyIcon.ShowNotification(
+                        title: TrayIconViewModel.ballonTitle,
+                        message: e.Data,
+                        icon: !e.Warning
+                            ? H.NotifyIcon.Core.NotificationIcon.Info
+                            : H.NotifyIcon.Core.NotificationIcon.Warning);
                 }
             }));
         }
@@ -638,8 +641,10 @@ Suspend support not enabled.", true);
         {
             if (!IsActive && (Global.Notifications == 2))
             {
-                notifyIcon.ShowBalloonTip(TrayIconViewModel.ballonTitle,
-                message, Hardcodet.Wpf.TaskbarNotification.BalloonIcon.Info);
+                notifyIcon.ShowNotification(
+                    title: TrayIconViewModel.ballonTitle,
+                    message: message,
+                    icon: H.NotifyIcon.Core.NotificationIcon.Info);
             }
         }
 

--- a/DS4Windows/DS4Forms/ViewModels/AutoProfilesViewModel.cs
+++ b/DS4Windows/DS4Forms/ViewModels/AutoProfilesViewModel.cs
@@ -463,7 +463,7 @@ namespace DS4WinWPF.DS4Forms.ViewModels
         }
         public event EventHandler MatchedAutoProfileChanged;
         public delegate void AutoProfileHandler(ProgramItem sender, bool added);
-        public event AutoProfileHandler AutoProfileAction;
+        //public event AutoProfileHandler AutoProfileAction;
         public string Filename { get => filename;  }
         public ImageSource Exeicon { get => exeicon; }
 

--- a/DS4Windows/DS4WinWPF.csproj
+++ b/DS4Windows/DS4WinWPF.csproj
@@ -69,14 +69,14 @@
 
   <ItemGroup>
     <PackageReference Include="bloomtom.HttpProgress" Version="2.3.2" />
-    <PackageReference Include="DotNetProjects.Extended.Wpf.Toolkit" Version="4.6.97" />
-    <PackageReference Include="Hardcodet.NotifyIcon.Wpf.NetCore" Version="1.0.18" />
-    <PackageReference Include="MdXaml" Version="1.10.0" />
-    <PackageReference Include="NLog" Version="4.7.9" />
-    <PackageReference Include="Ookii.Dialogs.Wpf" Version="3.1.0" />
+    <PackageReference Include="DotNetProjects.Extended.Wpf.Toolkit" Version="5.0.103" />
+    <PackageReference Include="H.NotifyIcon.Wpf" Version="2.0.53" />
+    <PackageReference Include="MdXaml" Version="1.15.0" />
+    <PackageReference Include="NLog" Version="5.0.1" />
+    <PackageReference Include="Ookii.Dialogs.Wpf" Version="5.0.1" />
     <PackageReference Include="System.Management" Version="6.0.0" />
-    <PackageReference Include="TaskScheduler" Version="2.9.1" />
-    <PackageReference Include="WPFLocalizeExtension" Version="3.8.0" />
+    <PackageReference Include="TaskScheduler" Version="2.10.1" />
+    <PackageReference Include="WPFLocalizeExtension" Version="3.9.4" />
 
     <Reference Include="Nefarius.ViGEm.Client">
       <HintPath>..\libs\$(Platform)\Nefarius.ViGEm.Client\Nefarius.ViGEm.Client.dll</HintPath>


### PR DESCRIPTION
- Replace deprecated “Hardcodet.NotifyIcon.Wpf.NetCore” library with “H.NotifyIcon.Wpf”.
- Update packages.
- Comment unused variable.