### PR TITLE
Hardened virtual device check

### DIFF
--- a/DS4Windows/DS4Control/ControlService.cs
+++ b/DS4Windows/DS4Control/ControlService.cs
@@ -13,6 +13,7 @@ using SharpOSC;
 using static DS4Windows.Global;
 using DS4WinWPF.DS4Control;
 using DS4Windows.DS4Control;
+using Nefarius.Utilities.DeviceManagement.PnP;
 
 namespace DS4Windows
 {
@@ -239,7 +240,6 @@ namespace DS4Windows
             deviceOptions = Global.DeviceOptions;
 
             DS4Devices.RequestElevation += DS4Devices_RequestElevation;
-            DS4Devices.checkVirtualFunc = CheckForVirtualDevice;
             DS4Devices.PrepareDS4Init = PrepareDS4DeviceInit;
             DS4Devices.PostDS4Init = PostDS4DeviceInit;
             DS4Devices.PreparePendingDevice = CheckForSupportedDevice;
@@ -498,22 +498,8 @@ namespace DS4Windows
             // Does nothing now
         }
 
-        public CheckVirtualInfo CheckForVirtualDevice(string deviceInstanceId)
-        {
-            string temp = Global.GetDeviceProperty(deviceInstanceId,
-                NativeMethods.DEVPKEY_Device_UINumber);
-
-            CheckVirtualInfo info = new CheckVirtualInfo()
-            {
-                PropertyValue = temp,
-                DeviceInstanceId = deviceInstanceId,
-            };
-            return info;
-        }
-
         public void ShutDown()
         {
-            DS4Devices.checkVirtualFunc = null;
             outputslotMan.ShutDown();
             OutputSlotPersist.WriteConfig(outputslotMan);
 
@@ -639,7 +625,7 @@ namespace DS4Windows
             bool result = false;
             if (dev != null && hidDeviceHidingEnabled)
             {
-                string deviceInstanceId = DS4Devices.devicePathToInstanceId(dev.HidDevice.DevicePath);
+                string deviceInstanceId = PnPDevice.GetInstanceIdFromInterfaceId(dev.HidDevice.DevicePath);
                 if (Global.hidHideInstalled)
                 {
                     result = Global.CheckHidHideAffectedStatus(deviceInstanceId,

--- a/DS4Windows/DS4Library/DS4Devices.cs
+++ b/DS4Windows/DS4Library/DS4Devices.cs
@@ -6,6 +6,7 @@ using System.Runtime.InteropServices;
 using System.Security.Principal;
 using System.Threading;
 using DS4Windows.InputDevices;
+using Nefarius.Utilities.DeviceManagement.PnP;
 
 namespace DS4Windows
 {
@@ -106,7 +107,6 @@ namespace DS4Windows
         private static List<HidDevice> DisabledDevices = new List<HidDevice>();
         private static Stopwatch sw = new Stopwatch();
         public static event RequestElevationDelegate RequestElevation;
-        public static CheckVirtualDelegate checkVirtualFunc = null;
         public static PrepareInitDelegate PrepareDS4Init = null;
         public static PrepareInitDelegate PostDS4Init = null;
         public static CheckPendingDevice PreparePendingDevice = null;
@@ -161,46 +161,11 @@ namespace DS4Windows
             new VidPidInfo(0x7331, 0x0001, "DualShock 3 (DS4 Emulation)", InputDeviceType.DS4, VidPidFeatureSet.NoGyroCalib | VidPidFeatureSet.VendorDefinedDevice), // Sony DualShock 3 using DsHidMini driver. DsHidMini uses vendor-defined HID device type when it's emulating DS3 using DS4 button layout
         };
 
-        public static string devicePathToInstanceId(string devicePath)
-        {
-            string deviceInstanceId = devicePath;
-            if (!string.IsNullOrEmpty(deviceInstanceId))
-            {
-                int searchIdx = deviceInstanceId.LastIndexOf("?\\");
-                if (searchIdx + 2 <= deviceInstanceId.Length)
-                {
-                    deviceInstanceId = deviceInstanceId.Remove(0, searchIdx + 2);
-                    deviceInstanceId = deviceInstanceId.Remove(deviceInstanceId.LastIndexOf('{'));
-                    deviceInstanceId = deviceInstanceId.Replace('#', '\\');
-                    if (deviceInstanceId.EndsWith("\\"))
-                    {
-                        deviceInstanceId = deviceInstanceId.Remove(deviceInstanceId.Length - 1);
-                    }
-                }
-                else
-                {
-                    deviceInstanceId = string.Empty;
-                }
-            }
-
-            return deviceInstanceId;
-        }
-
         private static bool IsRealDS4(HidDevice hDevice)
         {
-            // Assume true by default
-            bool result = true;
-            string deviceInstanceId = devicePathToInstanceId(hDevice.DevicePath);
-            if (!string.IsNullOrEmpty(deviceInstanceId))
-            {
-                CheckVirtualInfo info = checkVirtualFunc(deviceInstanceId);
-                result = string.IsNullOrEmpty(info.PropertyValue);
-            }
+            var device = PnPDevice.GetDeviceByInterfaceId(hDevice.DevicePath);
 
-            return result;
-            //string temp = Global.GetDeviceProperty(deviceInstanceId,
-            //    NativeMethods.DEVPKEY_Device_UINumber);
-            //return string.IsNullOrEmpty(temp);
+            return !device.IsVirtual();
         }
 
         // Enumerates ds4 controllers in the system
@@ -216,12 +181,9 @@ namespace DS4Windows
                     return PreparePendingDevice(d, metainfo);
                 });
 
-                if (checkVirtualFunc != null)
-                {
-                    hDevices = hDevices.Where(dev => IsRealDS4(dev)).Select(dev => dev);
-                }
+                hDevices = hDevices.Where(IsRealDS4).Select(dev => dev);
 
-                //hDevices = from dev in hDevices where IsRealDS4(dev) select dev;
+                    //hDevices = from dev in hDevices where IsRealDS4(dev) select dev;
                 // Sort Bluetooth first in case USB is also connected on the same controller.
                 hDevices = hDevices.OrderBy<HidDevice, ConnectionType>((HidDevice d) =>
                 {
@@ -269,7 +231,7 @@ namespace DS4Windows
                                 {
                                     // Tell the client to launch routine to re-enable a device
                                     RequestElevationArgs eleArgs = 
-                                        new RequestElevationArgs(devicePathToInstanceId(hDevice.DevicePath));
+                                        new RequestElevationArgs(PnPDevice.GetInstanceIdFromInterfaceId(hDevice.DevicePath));
                                     RequestElevation?.Invoke(eleArgs);
                                     if (eleArgs.StatusCode == RequestElevationArgs.STATUS_SUCCESS)
                                     {
@@ -278,7 +240,7 @@ namespace DS4Windows
                                 }
                                 else
                                 {
-                                    reEnableDevice(devicePathToInstanceId(hDevice.DevicePath));
+                                    reEnableDevice(PnPDevice.GetInstanceIdFromInterfaceId(hDevice.DevicePath));
                                     hDevice.OpenDevice(isExclusiveMode);
                                 }
                             }

--- a/DS4Windows/DS4WinWPF.csproj
+++ b/DS4Windows/DS4WinWPF.csproj
@@ -75,6 +75,7 @@
     <PackageReference Include="DotNetProjects.Extended.Wpf.Toolkit" Version="5.0.103" />
     <PackageReference Include="H.NotifyIcon.Wpf" Version="2.0.60" />
     <PackageReference Include="MdXaml" Version="1.15.0" />
+    <PackageReference Include="Nefarius.Utilities.DeviceManagement" Version="2.9.116" />
     <PackageReference Include="NLog" Version="5.0.2" />
     <PackageReference Include="Ookii.Dialogs.Wpf" Version="5.0.1" />
     <PackageReference Include="System.Management" Version="6.0.0" />


### PR DESCRIPTION
While reworking and ironing out long standing bugs in BthPS3 [I stumbled upon an issue with virtual device detection](https://github.com/ViGEm/BthPS3/issues/49). The DMF bus driver plumbing sets the `DEVPKEY_Device_UINumber` device property which fake-triggered the virtual device detection and filtered the wireless DS3 out.

I've added an `IsVirtual` method [to my own device helper library](https://github.com/nefarius/Nefarius.Utilities.DeviceManagement) which performs a more sophisticated check: it walks up the chain of parent devices of a given controller and checks if the topmost bus driver is root enumerated which is a 99.9% sign that it's an emulator.

Also took liberty in replacing the symlink to instance ID conversion method with the recommended WinApi calls.