### PR TITLE
Added Razer Raion Fightpad PS4 VID/PID and flags to DS4Devices

### DIFF
--- a/DS4Windows/DS4Library/DS4Devices.cs
+++ b/DS4Windows/DS4Library/DS4Devices.cs
@@ -130,6 +130,7 @@ namespace DS4Windows
             new VidPidInfo(SONY_VID, 0x09CC, "DS4 v.2", InputDeviceType.DS4),
             new VidPidInfo(SONY_VID, 0x0CE6, "DualSense", InputDeviceType.DualSense, VidPidFeatureSet.DefaultDS4, DualSenseDevice.DetermineConnectionType),
             new VidPidInfo(RAZER_VID, 0x1000, "Razer Raiju PS4"),
+            new VidPidInfo(RAZER_VID, 0x1100, "Razer Raion Fightpad PS4", InputDeviceType.DS4, VidPidFeatureSet.NoGyroCalib),
             new VidPidInfo(NACON_VID, 0x0D01, "Nacon Revol Pro v.1", InputDeviceType.DS4, VidPidFeatureSet.NoGyroCalib), // Nacon Revolution Pro v1 and v2 doesn't support DS4 gyro calibration routines
             new VidPidInfo(NACON_VID, 0x0D02, "Nacon Revol Pro v.2", InputDeviceType.DS4, VidPidFeatureSet.NoGyroCalib),
             new VidPidInfo(HORI_VID, 0x00EE, "Hori PS4 Mini", InputDeviceType.DS4, VidPidFeatureSet.NoOutputData | VidPidFeatureSet.NoBatteryReading | VidPidFeatureSet.NoGyroCalib),  // Hori PS4 Mini Wired Gamepad


### PR DESCRIPTION
[A user asked for the Razer Raion Fightpad controller for PS4 to be added to DS4Windows](https://github.com/Ryochan7/DS4Windows/discussions/2529). It's a USB only controller.

I've created a test build for him by just adding the controller's VID/PID (without the flags) to DS4Devices list. Accordingly to the user, the controller works as normal with DS4Windows in the test build.

I later discovered the controller does not have lightbar, rumble nor gyro, so I added the `VidPidFeatureSet.NoGyroCalib` flag. We didn't make a test to check if the having the flag or not makes a difference but since the controller does not have gyro I'm assuming it does not.