### PR TITLE
Add Auto-Profile Exe to HIDHide

### DIFF
--- a/DS4Windows/AutoProfileHolder.cs
+++ b/DS4Windows/AutoProfileHolder.cs
@@ -108,8 +108,6 @@ namespace DS4WinWPF
                         el.AppendChild(doc.CreateElement("Controller8")).InnerText = entity.ProfileNames[7];
                     }
                     el.AppendChild(doc.CreateElement("TurnOff")).InnerText = entity.Turnoff.ToString();
-                    
-                    App.rootHub.CheckHidHidePresence(entity.Path, entity.Turnoff);
 
                     Node.AppendChild(el);
                 }

--- a/DS4Windows/AutoProfileHolder.cs
+++ b/DS4Windows/AutoProfileHolder.cs
@@ -108,6 +108,8 @@ namespace DS4WinWPF
                         el.AppendChild(doc.CreateElement("Controller8")).InnerText = entity.ProfileNames[7];
                     }
                     el.AppendChild(doc.CreateElement("TurnOff")).InnerText = entity.Turnoff.ToString();
+                    
+                    App.rootHub.CheckHidHidePresence(entity.Path, entity.Turnoff);
 
                     Node.AppendChild(el);
                 }

--- a/DS4Windows/DS4Control/ControlService.cs
+++ b/DS4Windows/DS4Control/ControlService.cs
@@ -551,7 +551,7 @@ namespace DS4Windows
             catch { }
         }
 
-        public void CheckHidHidePresence()
+        public void CheckHidHidePresence(string ExePath = "", bool RemoveExe = false) // Default value for D4W Startup
         {
             if (Global.hidHideInstalled)
             {
@@ -562,12 +562,15 @@ namespace DS4Windows
                     {
                         return;
                     }
-
+                    // Catch Blank Values and initialize for Startup. Also catches empty Values.
+                    // Also Catches Empty values in auto-profiler, and defaults to trying to re-add D4W. Will fail harmlessly later.
+                    if (ExePath == "") { ExePath = Global.exelocation; RemoveExe = False; } 
+                    
                     List<string> dosPaths = hidHideDevice.GetWhitelist();
 
                     int maxPathCheckLength = 512;
                     StringBuilder sb = new StringBuilder(maxPathCheckLength);
-                    string driveLetter = Path.GetPathRoot(Global.exelocation).Replace("\\", "");
+                    string driveLetter = Path.GetPathRoot(ExePath).Replace("\\", "");
                     uint _ = NativeMethods.QueryDosDevice(driveLetter, sb, maxPathCheckLength);
                     //int error = Marshal.GetLastWin32Error();
 
@@ -578,15 +581,21 @@ namespace DS4Windows
                         dosDrivePath = dosDrivePath.Remove(0, 4);
                     }
 
-                    string partial = Global.exelocation.Replace(driveLetter, "");
+                    string partial = ExePath.Replace(driveLetter, "");
                     // Need to trim starting '\\' from path2 or Path.Combine will
                     // treat it as an absolute path and only return path2
                     string realPath = Path.Combine(dosDrivePath, partial.TrimStart('\\'));
                     bool exists = dosPaths.Contains(realPath);
-                    if (!exists)
+                    if (!exists && !RemoveExe)
                     {
-                        LogDebug("DS4Windows not found in HidHide whitelist. Adding DS4Windows to list");
+                        LogDebug("Exe not found in HidHide whitelist. Adding Exe to list");
                         dosPaths.Add(realPath);
+                        hidHideDevice.SetWhitelist(dosPaths);
+                    }
+                    if (exists && RemoveExe)
+                    {
+                        LogDebug("Exe found in HidHide whitelist. Removing Exe from list");
+                        dosPaths.Remove(realPath);
                         hidHideDevice.SetWhitelist(dosPaths);
                     }
                 }

--- a/DS4Windows/DS4Control/ControlService.cs
+++ b/DS4Windows/DS4Control/ControlService.cs
@@ -551,7 +551,7 @@ namespace DS4Windows
             catch { }
         }
 
-        public void CheckHidHidePresence(string ExePath = "", bool RemoveExe = false) // Default value for D4W Startup
+        public void CheckHidHidePresence(string ExePath = "", bool AddExe = true) // Default value for D4W Startup
         {
             if (Global.hidHideInstalled)
             {
@@ -564,7 +564,7 @@ namespace DS4Windows
                     }
                     // Catch Blank Values and initialize for Startup. Also catches empty Values.
                     // Also Catches Empty values in auto-profiler, and defaults to trying to re-add D4W. Will fail harmlessly later.
-                    if (ExePath == "") { ExePath = Global.exelocation; RemoveExe = False; } 
+                    if (ExePath == "") { ExePath = Global.exelocation; AddExe = true; } 
                     
                     List<string> dosPaths = hidHideDevice.GetWhitelist();
 
@@ -586,13 +586,13 @@ namespace DS4Windows
                     // treat it as an absolute path and only return path2
                     string realPath = Path.Combine(dosDrivePath, partial.TrimStart('\\'));
                     bool exists = dosPaths.Contains(realPath);
-                    if (!exists && !RemoveExe)
+                    if (!exists && AddExe)
                     {
                         LogDebug("Exe not found in HidHide whitelist. Adding Exe to list");
                         dosPaths.Add(realPath);
                         hidHideDevice.SetWhitelist(dosPaths);
                     }
-                    if (exists && RemoveExe)
+                    if (exists && !AddExe)
                     {
                         LogDebug("Exe found in HidHide whitelist. Removing Exe from list");
                         dosPaths.Remove(realPath);

--- a/DS4Windows/DS4Forms/AutoProfiles.xaml.cs
+++ b/DS4Windows/DS4Forms/AutoProfiles.xaml.cs
@@ -312,6 +312,7 @@ namespace DS4WinWPF.DS4Forms
             if (autoProfVM.SelectedItem != null)
             {
                 editControlsPanel.DataContext = null;
+                AddExeToHIDHideWhenSaving(autoProfVM.SelectedItem.Path, false);// set to False, to remove the EXE from HIDHide
                 autoProfVM.RemoveAutoProfileEntry(autoProfVM.SelectedItem);
                 autoProfVM.AutoProfileHolder.Save(DS4Windows.Global.appdatapath + @"\Auto Profiles.xml");
                 autoProfVM.SelectedItem = null;
@@ -330,6 +331,8 @@ namespace DS4WinWPF.DS4Forms
                 {
                     autoProfVM.PersistAutoProfileEntry(autoProfVM.SelectedItem);
                 }
+                
+                AddExeToHIDHideWhenSaving(autoProfVM.SelectedItem.Path, autoProfVM.SelectedItem.Turnoff);
 
                 autoProfVM.AutoProfileHolder.Save(DS4Windows.Global.appdatapath + @"\Auto Profiles.xml");
             }
@@ -364,6 +367,14 @@ namespace DS4WinWPF.DS4Forms
             {
                 if(autoProfVM.MoveItemUpDown(autoProfVM.SelectedItem, ((sender as MenuItem).Name == "MoveUp") ? -1 : 1))
                     autoProfVM.AutoProfileHolder.Save(DS4Windows.Global.appdatapath + @"\Auto Profiles.xml");
+            }
+        }
+        
+        private void AddExeToHIDHideWhenSaving(string exePath, bool addExe)
+        {
+            if (exePath.Substring((exePath.Length)-4, 4) == ".exe") //Filter out autoprofiles that do not lead to EXEs.
+            {
+                App.rootHub.CheckHidHidePresence(exePath, addExe);
             }
         }
     }


### PR DESCRIPTION
During testing, I've been turning D4W off often in the auto-profiles, only to remember that we have HidHide now.... making this function effectively useless, enless we also add the target to the whitelist... So, here's my contribution. :D

Checks Auto-profile's "Turn of DS4Windows Temporarily" Checkbox and either adds or removes the targetted app to HidHide's Whitelist. I only barely touched the code, and made it backwards compatible with the automatic check that happens at startup to add DS4Windows to the whitelist.

The ControlService.CheckHidHidePresence() method now accepts 2 arguments: A string for Exe path, and a Bool for adding/removing the Exe.

On startup, the method is initialized as ("", true) and will replace the empty string with the D4W location just as it normally does. On saving an Auto-Profile, it will instead send the targeted app's path and the state of the checkbox, either removing or adding as directed from the checkbox's state. Removing an item not in the list, or adding one that's already there has no effect, as the write is skipped. Likewise, adding a blank path entry will also skip, as it will try to add D4W again, and be skipped.