### PR TITLE
Enable DualSense improved rumble emulation for controllers on newer firmware

### DIFF
--- a/DS4Windows/DS4Library/InputDevices/DualSenseDevice.cs
+++ b/DS4Windows/DS4Library/InputDevices/DualSenseDevice.cs
@@ -989,10 +989,12 @@ namespace DS4Windows.InputDevices
                 // Volume of internal speaker (0-7; ties in with index 6. The PS5 default appears to be set a 4)
                 //outputReport[38] = 0x00;
 
-                /* Player LED section */
+                /* Player LED section (and improved rumble flag) */
                 // 0x01 Enabled LED brightness (value in index 43)
                 // 0x02 Uninterruptable blue LED pulse (action in index 42)
-                outputReport[39] = 0x02;
+                // 0x04 Enable improved rumble emulation (Requires 2.24 firmware or newer)
+                outputReport[39] = useRumble ? (byte)0x06 : (byte)0x02;
+
                 // 0x01 Slowly (2s?) fade to blue (scheduled to when the regular LED settings are active)
                 // 0x02 Slowly (2s?) fade out (scheduled after fade-in completion) with eventual switch back to configured LED color; only a fade-out can cancel the pulse (neither index 2, 0x08, nor turning this off will cancel it!)
                 outputReport[42] = 0x02;
@@ -1124,10 +1126,12 @@ namespace DS4Windows.InputDevices
                 // Volume of internal speaker (0-7; ties in with index 6. The PS5 default appears to be set a 4)
                 //outputReport[39] = 0x00;
 
-                /* Player LED section */
+                /* Player LED section (and improved rumble  flag) */
                 // 0x01 Enabled LED brightness (value in index 43)
                 // 0x02 Uninterruptable blue LED pulse (action in index 42)
-                outputReport[40] = 0x02;
+                // 0x04 Enable improved rumble emulation (Requires 2.24 firmware or newer)
+                outputReport[40] = useRumble ? (byte)0x06 : (byte)0x02; 
+
                 // 0x01 Slowly (2s?) fade to blue (scheduled to when the regular LED settings are active)
                 // 0x02 Slowly (2s?) fade out (scheduled after fade-in completion) with eventual switch back to configured LED color; only a fade-out can cancel the pulse (neither index 2, 0x08, nor turning this off will cancel it!)
                 outputReport[43] = 0x02;

--- a/DS4Windows/DS4Library/InputDevices/DualSenseDevice.cs
+++ b/DS4Windows/DS4Library/InputDevices/DualSenseDevice.cs
@@ -153,12 +153,12 @@ namespace DS4Windows.InputDevices
                     case HapticIntensity.Low:
                         hapticsIntensityByte = 0x05;
                         break;
-                    case HapticIntensity.High:
-                        hapticsIntensityByte = 0x00;
-                        break;
                     case HapticIntensity.Medium:
-                    default:
                         hapticsIntensityByte = 0x02;
+                        break;
+                    case HapticIntensity.High:
+                    default:
+                        hapticsIntensityByte = 0x00;
                         break;
                 }
             }


### PR DESCRIPTION
DualSense controllers on firmware 2.24 or newer have a improved rumble emulation that is far better than the old implementation. The differences are explained ~~in the first topics of this issue: #2571~~ in a comment down below

From what I know:

1. have the new flags enabled makes no difference for controllers using the old firmware, and...
2. There is no problem in maintaining both Rumble Emulation flags (old and new) enabled at the same time  since the improved rumble takes priority anyway.


Therefore, there is no need to implement any more logic to check which firmware the controller is using to enable just the correct rumble mode.

Also, the improved rumble strength level at High is comparable to the DualShock 4, so I've set the High level strength as the default mode.