### PR TITLE
Moved HIDHide code to View Model

### DIFF
--- a/DS4Windows/DS4Control/ControlService.cs
+++ b/DS4Windows/DS4Control/ControlService.cs
@@ -551,7 +551,7 @@ namespace DS4Windows
             catch { }
         }
 
-        public void CheckHidHidePresence(string ExePath = "", bool AddExe = true) // Default value for D4W Startup
+        public void CheckHidHidePresence(string ExePath = "", string ExeName = "Autoprofile Exe", bool AddExe = true) // Default value for D4W Startup
         {
             if (Global.hidHideInstalled)
             {
@@ -564,7 +564,7 @@ namespace DS4Windows
                     }
                     // Catch Blank Values and initialize for Startup. Also catches empty Values.
                     // Also Catches Empty values in auto-profiler, and defaults to trying to re-add D4W. Will fail harmlessly later.
-                    if (ExePath == "") { ExePath = Global.exelocation; AddExe = true; } 
+                    if (ExePath == "") { ExePath = Global.exelocation; ExeName = "DS4Windows"; AddExe = true; } 
                     
                     List<string> dosPaths = hidHideDevice.GetWhitelist();
 
@@ -588,13 +588,13 @@ namespace DS4Windows
                     bool exists = dosPaths.Contains(realPath);
                     if (!exists && AddExe)
                     {
-                        LogDebug("Exe not found in HidHide whitelist. Adding Exe to list");
+                        LogDebug($"{ExeName} not found in HidHide whitelist. Adding to list");
                         dosPaths.Add(realPath);
                         hidHideDevice.SetWhitelist(dosPaths);
                     }
                     if (exists && !AddExe)
                     {
-                        LogDebug("Exe found in HidHide whitelist. Removing Exe from list");
+                        LogDebug($"{ExeName} found in HidHide whitelist. Removing from list");
                         dosPaths.Remove(realPath);
                         hidHideDevice.SetWhitelist(dosPaths);
                     }

--- a/DS4Windows/DS4Forms/AutoProfiles.xaml.cs
+++ b/DS4Windows/DS4Forms/AutoProfiles.xaml.cs
@@ -312,6 +312,7 @@ namespace DS4WinWPF.DS4Forms
             if (autoProfVM.SelectedItem != null)
             {
                 editControlsPanel.DataContext = null;
+                autoProfVM.AddExeToHIDHideWhenSaving(autoProfVM.SelectedItem, false);
                 autoProfVM.RemoveAutoProfileEntry(autoProfVM.SelectedItem);
                 autoProfVM.AutoProfileHolder.Save(DS4Windows.Global.appdatapath + @"\Auto Profiles.xml");
                 autoProfVM.SelectedItem = null;
@@ -331,6 +332,7 @@ namespace DS4WinWPF.DS4Forms
                     autoProfVM.PersistAutoProfileEntry(autoProfVM.SelectedItem);
                 }
 
+                autoProfVM.AddExeToHIDHideWhenSaving(autoProfVM.SelectedItem, autoProfVM.SelectedItem.Turnoff);
                 autoProfVM.AutoProfileHolder.Save(DS4Windows.Global.appdatapath + @"\Auto Profiles.xml");
             }
         }

--- a/DS4Windows/DS4Forms/AutoProfiles.xaml.cs
+++ b/DS4Windows/DS4Forms/AutoProfiles.xaml.cs
@@ -312,7 +312,6 @@ namespace DS4WinWPF.DS4Forms
             if (autoProfVM.SelectedItem != null)
             {
                 editControlsPanel.DataContext = null;
-                AddExeToHIDHideWhenSaving(autoProfVM.SelectedItem.Path, false);// set to False, to remove the EXE from HIDHide
                 autoProfVM.RemoveAutoProfileEntry(autoProfVM.SelectedItem);
                 autoProfVM.AutoProfileHolder.Save(DS4Windows.Global.appdatapath + @"\Auto Profiles.xml");
                 autoProfVM.SelectedItem = null;
@@ -331,8 +330,6 @@ namespace DS4WinWPF.DS4Forms
                 {
                     autoProfVM.PersistAutoProfileEntry(autoProfVM.SelectedItem);
                 }
-                
-                AddExeToHIDHideWhenSaving(autoProfVM.SelectedItem.Path, autoProfVM.SelectedItem.Turnoff);
 
                 autoProfVM.AutoProfileHolder.Save(DS4Windows.Global.appdatapath + @"\Auto Profiles.xml");
             }
@@ -367,14 +364,6 @@ namespace DS4WinWPF.DS4Forms
             {
                 if(autoProfVM.MoveItemUpDown(autoProfVM.SelectedItem, ((sender as MenuItem).Name == "MoveUp") ? -1 : 1))
                     autoProfVM.AutoProfileHolder.Save(DS4Windows.Global.appdatapath + @"\Auto Profiles.xml");
-            }
-        }
-        
-        private void AddExeToHIDHideWhenSaving(string exePath, bool addExe)
-        {
-            if (exePath.Substring((exePath.Length)-4, 4) == ".exe") //Filter out autoprofiles that do not lead to EXEs.
-            {
-                App.rootHub.CheckHidHidePresence(exePath, addExe);
             }
         }
     }

--- a/DS4Windows/DS4Forms/ViewModels/AutoProfilesViewModel.cs
+++ b/DS4Windows/DS4Forms/ViewModels/AutoProfilesViewModel.cs
@@ -235,6 +235,8 @@ namespace DS4WinWPF.DS4Forms.ViewModels
                         AutoProfileEntity.NONE_STRING;
                 }
 
+                AddExeToHIDHideWhenSaving(item.Path, item.Filename, item.Turnoff);
+
                 item.MatchedAutoProfile = tempEntry;
                 autoProfileHolder.AutoProfileColl.Add(item.MatchedAutoProfile);
             }
@@ -279,11 +281,13 @@ namespace DS4WinWPF.DS4Forms.ViewModels
                     tempEntry.ProfileNames[7] = tempindex > 0 ? profileList.ProfileListCol[tempindex - 1].Name :
                         AutoProfileEntity.NONE_STRING;
                 }
+                AddExeToHIDHideWhenSaving(item.Path, item.Filename, item.Turnoff);
             }
         }
 
         public void RemoveAutoProfileEntry(ProgramItem item)
         {
+            AddExeToHIDHideWhenSaving(item.Path, item.Filename, false);// set to False, to remove the EXE from HIDHide
             autoProfileHolder.AutoProfileColl.Remove(item.MatchedAutoProfile);
             item.MatchedAutoProfile = null;
         }
@@ -391,6 +395,14 @@ namespace DS4WinWPF.DS4Forms.ViewModels
                 itemMoved = false;
 
             return itemMoved;
+        }
+        
+        private void AddExeToHIDHideWhenSaving(string exePath, string exeTitle, bool addExe)
+        {
+            if (exePath.Substring((exePath.Length) - 4, 4) == ".exe") //Filter out autoprofiles that do not lead to EXEs.
+            {
+                App.rootHub.CheckHidHidePresence(exePath, exeTitle, addExe);
+            }
         }
     }
 

--- a/DS4Windows/DS4Forms/ViewModels/AutoProfilesViewModel.cs
+++ b/DS4Windows/DS4Forms/ViewModels/AutoProfilesViewModel.cs
@@ -235,8 +235,6 @@ namespace DS4WinWPF.DS4Forms.ViewModels
                         AutoProfileEntity.NONE_STRING;
                 }
 
-                AddExeToHIDHideWhenSaving(item.Path, item.Filename, item.Turnoff);
-
                 item.MatchedAutoProfile = tempEntry;
                 autoProfileHolder.AutoProfileColl.Add(item.MatchedAutoProfile);
             }
@@ -281,13 +279,11 @@ namespace DS4WinWPF.DS4Forms.ViewModels
                     tempEntry.ProfileNames[7] = tempindex > 0 ? profileList.ProfileListCol[tempindex - 1].Name :
                         AutoProfileEntity.NONE_STRING;
                 }
-                AddExeToHIDHideWhenSaving(item.Path, item.Filename, item.Turnoff);
             }
         }
 
         public void RemoveAutoProfileEntry(ProgramItem item)
         {
-            AddExeToHIDHideWhenSaving(item.Path, item.Filename, false);// set to False, to remove the EXE from HIDHide
             autoProfileHolder.AutoProfileColl.Remove(item.MatchedAutoProfile);
             item.MatchedAutoProfile = null;
         }
@@ -397,11 +393,11 @@ namespace DS4WinWPF.DS4Forms.ViewModels
             return itemMoved;
         }
         
-        private void AddExeToHIDHideWhenSaving(string exePath, string exeTitle, bool addExe)
+        public void AddExeToHIDHideWhenSaving(ProgramItem autoProf, bool addExe)
         {
-            if (exePath.Substring((exePath.Length) - 4, 4) == ".exe") //Filter out autoprofiles that do not lead to EXEs.
+            if (autoProf.Path.Substring((autoProf.Path.Length) - 4, 4) == ".exe") //Filter out autoprofiles that do not lead to EXEs.
             {
-                App.rootHub.CheckHidHidePresence(exePath, exeTitle, addExe);
+                App.rootHub.CheckHidHidePresence(autoProf.Path, autoProf.Filename, addExe);
             }
         }
     }


### PR DESCRIPTION
Moved all the HIDHide code to AutoProfileViewModel

Also added an ExeName field to CheckHidHidePresence(), so that the filename shows up in the logs. Again, backwards compatible and shows "DS4Windows not found in HidHide whitelist. Adding to list" if it's not already added. otherwise, it shows the appropriate filename, or a generic placeholder if filename cannot be found for any reason. The generic filename shouldn't ever appear, though.