### PR TITLE
Added UAC Warning

### DIFF
--- a/DS4Windows/App.xaml.cs
+++ b/DS4Windows/App.xaml.cs
@@ -202,7 +202,7 @@ namespace DS4WinWPF
             CreateIPCClassNameMMF(source.Handle);
 
             window.CheckMinStatus();
-            rootHub.LogDebug($"Running as {(DS4Windows.Global.IsAdministrator() ? "Admin" : "User")}");
+            rootHub.LogDebug($"Running as {(DS4Windows.Global.IsAdministrator() ? "Admin" : "User. Some applications may block controller inputs. (Windows UAC Conflictions)")}");
 
             if (DS4Windows.Global.hidHideInstalled)
             {


### PR DESCRIPTION
Added a small UAC warning to the debug log, informing users not running as admin that inputs may lock in some applications, due to Windows' UAC.