### PR TITLE
Added PowerA FUSION Wired Fightpad for PS4 VID/PID and flags to DS4Devices

### DIFF
--- a/DS4Windows/DS4Library/DS4Devices.cs
+++ b/DS4Windows/DS4Library/DS4Devices.cs
@@ -159,6 +159,7 @@ namespace DS4Windows
             new VidPidInfo(NINTENDO_VENDOR_ID, JOYCON_R_PRODUCT_ID, "JoyCon (R)", InputDeviceType.JoyConR, VidPidFeatureSet.DefaultDS4, checkConnection: JoyConDevice.DetermineConnectionType),
             new VidPidInfo(0x7545, 0x1122, "Gioteck VX4", InputDeviceType.DS4), // Gioteck VX4 (no real lightbar, only some RGB leds)
             new VidPidInfo(0x7331, 0x0001, "DualShock 3 (DS4 Emulation)", InputDeviceType.DS4, VidPidFeatureSet.NoGyroCalib | VidPidFeatureSet.VendorDefinedDevice), // Sony DualShock 3 using DsHidMini driver. DsHidMini uses vendor-defined HID device type when it's emulating DS3 using DS4 button layout
+            new VidPidInfo(0x20D6, 0x792A, "PowerA FUSION Wired Fightpad for PS4", InputDeviceType.DS4, VidPidFeatureSet.NoGyroCalib), // No lightbar, gyro, or sticks
         };
 
         public static string devicePathToInstanceId(string devicePath)


### PR DESCRIPTION
Controller:

![image](https://user-images.githubusercontent.com/24910442/191270594-eb16bfaf-1acd-4d56-ac71-a3f09746fda6.png)

Controller doesn't have touchpad, rumble or gyro.

This is its input report:

![image](https://user-images.githubusercontent.com/24910442/191270945-1de2f2ea-5828-4d03-8d2d-353aaba91805.png)
