### PR TITLE
Tweaked presentation of slots messages

### DIFF
--- a/DS4Windows/DS4Control/ControlService.cs
+++ b/DS4Windows/DS4Control/ControlService.cs
@@ -1299,11 +1299,6 @@ namespace DS4Windows
                         success = true;
                     }
 
-                    if (success)
-                    {
-                        LogDebug($"Associate virtual X360 Controller in{(slotDevice.PermanentType != OutContType.None ? " permanent" : "")} output slot #{slotDevice.Index + 1} for input {device.DisplayName} controller #{index + 1}");
-                    }
-
                     //tempXbox.Connect();
                     //LogDebug("X360 Controller #" + (index + 1) + " connected");
                 }
@@ -1368,11 +1363,6 @@ namespace DS4Windows
                         success = true;
                     }
 
-                    if (success)
-                    {
-                        LogDebug($"Associate virtual DS4 Controller in{(slotDevice.PermanentType != OutContType.None ? " permanent" : "")} output slot #{slotDevice.Index + 1} for input {device.DisplayName} controller #{index + 1}");
-                    }
-
                     //DS4OutDevice tempDS4 = new DS4OutDevice(vigemTestClient);
                     //DS4OutDevice tempDS4 = outputslotMan.AllocateController(OutContType.DS4, vigemTestClient)
                     //    as DS4OutDevice;
@@ -1384,6 +1374,7 @@ namespace DS4Windows
 
                 if (success)
                 {
+                    LogDebug($"Associated input controller #{index + 1} ({device.DisplayName}) to virtual {slotDevice.OutputDevice.GetDeviceType()} Controller in{(slotDevice.PermanentType != OutContType.None ? " permanent" : "")} output slot #{slotDevice.Index + 1}");
                     useDInputOnly[index] = false;
                 }
             }

--- a/DS4Windows/DS4Control/ControlService.cs
+++ b/DS4Windows/DS4Control/ControlService.cs
@@ -1970,12 +1970,6 @@ namespace DS4Windows
 
         private void BeginPrepareConnectedInputController(DS4Device device, bool showlog = false)
         {
-            if (showlog)
-            {
-                LogDebug(DS4WinWPF.Properties.Resources.FoundController + " " + device.getMacAddress() + " (" + device.getConnectionType() + ") (" +
-                                            device.DisplayName + ")");
-            }
-
             if (hidDeviceHidingEnabled && CheckAffected(device))
             {
                 //device.CurrentExclusiveStatus = DS4Device.ExclusiveStatus.HidGuardAffected;

--- a/DS4Windows/DS4Control/ControlService.cs
+++ b/DS4Windows/DS4Control/ControlService.cs
@@ -1199,7 +1199,7 @@ namespace DS4Windows
             {
                 OutputDevice outDevice = EstablishOutDevice(-1, contType);
                 outputslotMan.DeferredPlugin(outDevice, -1, outputDevices, contType);
-                LogDebug($"Plugging virtual {contType} Controller");
+
             }
         }
 
@@ -1210,7 +1210,7 @@ namespace DS4Windows
             {
                 OutputDevice outDevice = EstablishOutDevice(-1, contType);
                 outputslotMan.DeferredPlugin(outDevice, -1, outputDevices, contType);
-                LogDebug($"Plugging virtual {contType} Controller");
+
             }
         }
 
@@ -1270,7 +1270,6 @@ namespace DS4Windows
                             outputslotMan.DeferredPlugin(tempXbox, index, outputDevices, contType);
                             //slotDevice.CurrentInputBound = OutSlotDevice.InputBound.Bound;
 
-                            LogDebug("Plugging in virtual X360 Controller");
                             success = true;
                         }
                         else

--- a/DS4Windows/DS4Control/ControlService.cs
+++ b/DS4Windows/DS4Control/ControlService.cs
@@ -1410,7 +1410,6 @@ namespace DS4Windows
                     {
                         //slotDevice.CurrentInputBound = OutSlotDevice.InputBound.Unbound;
                         outputslotMan.DeferredRemoval(dev, index, outputDevices, immediate);
-                        LogDebug($"Unplugging virtual {tempType} Controller");
                     }
                     else if (slotDevice.CurrentAttachedStatus == OutSlotDevice.AttachedStatus.Attached)
                     {

--- a/DS4Windows/DS4Control/ControlService.cs
+++ b/DS4Windows/DS4Control/ControlService.cs
@@ -1336,7 +1336,6 @@ namespace DS4Windows
                             outputslotMan.DeferredPlugin(tempDS4, index, outputDevices, contType);
                             //slotDevice.CurrentInputBound = OutSlotDevice.InputBound.Bound;
 
-                            LogDebug("Plugging in virtual DS4 Controller");
                             success = true;
                         }
                         else

--- a/DS4Windows/DS4Control/ControlService.cs
+++ b/DS4Windows/DS4Control/ControlService.cs
@@ -1390,7 +1390,7 @@ namespace DS4Windows
                 if (dev != null && slotDevice != null)
                 {
                     string tempType = dev.GetDeviceType();
-                    LogDebug($"Disassociate {tempType} Controller from{(slotDevice.CurrentReserveStatus == OutSlotDevice.ReserveStatus.Permanent ? " permanent" : "")} output slot #{slotDevice.Index+1} for input {device.DisplayName} controller #{index + 1}", false);
+                    LogDebug($"Disassociated virtual {tempType} Controller in{(slotDevice.CurrentReserveStatus == OutSlotDevice.ReserveStatus.Permanent ? " permanent" : "")} output slot #{slotDevice.Index+1} from input controller #{index + 1} ({device.DisplayName})", false);
 
                     OutContType currentType = activeOutDevType[index];
                     outputDevices[index] = null;

--- a/DS4Windows/DS4Control/ControlService.cs
+++ b/DS4Windows/DS4Control/ControlService.cs
@@ -1199,7 +1199,6 @@ namespace DS4Windows
             {
                 OutputDevice outDevice = EstablishOutDevice(-1, contType);
                 outputslotMan.DeferredPlugin(outDevice, -1, outputDevices, contType);
-
             }
         }
 
@@ -1210,7 +1209,6 @@ namespace DS4Windows
             {
                 OutputDevice outDevice = EstablishOutDevice(-1, contType);
                 outputslotMan.DeferredPlugin(outDevice, -1, outputDevices, contType);
-
             }
         }
 
@@ -1304,7 +1302,7 @@ namespace DS4Windows
 
                     if (success)
                     {
-                        LogDebug($"Associate X360 Controller in{(slotDevice.PermanentType != OutContType.None ? " permanent" : "")} slot #{slotDevice.Index + 1} for input {device.DisplayName} controller #{index + 1}");
+                        LogDebug($"Associate virtual X360 Controller in{(slotDevice.PermanentType != OutContType.None ? " permanent" : "")} output slot #{slotDevice.Index + 1} for input {device.DisplayName} controller #{index + 1}");
                     }
 
                     //tempXbox.Connect();
@@ -1374,7 +1372,7 @@ namespace DS4Windows
 
                     if (success)
                     {
-                        LogDebug($"Associate DS4 Controller in{(slotDevice.PermanentType != OutContType.None ? " permanent" : "")} slot #{slotDevice.Index + 1} for input {device.DisplayName} controller #{index + 1}");
+                        LogDebug($"Associate virtual DS4 Controller in{(slotDevice.PermanentType != OutContType.None ? " permanent" : "")} output slot #{slotDevice.Index + 1} for input {device.DisplayName} controller #{index + 1}");
                     }
 
                     //DS4OutDevice tempDS4 = new DS4OutDevice(vigemTestClient);
@@ -1403,7 +1401,7 @@ namespace DS4Windows
                 if (dev != null && slotDevice != null)
                 {
                     string tempType = dev.GetDeviceType();
-                    LogDebug($"Disassociate {tempType} Controller from{(slotDevice.CurrentReserveStatus == OutSlotDevice.ReserveStatus.Permanent ? " permanent" : "")} slot #{slotDevice.Index+1} for input {device.DisplayName} controller #{index + 1}", false);
+                    LogDebug($"Disassociate {tempType} Controller from{(slotDevice.CurrentReserveStatus == OutSlotDevice.ReserveStatus.Permanent ? " permanent" : "")} output slot #{slotDevice.Index+1} for input {device.DisplayName} controller #{index + 1}", false);
 
                     OutContType currentType = activeOutDevType[index];
                     outputDevices[index] = null;

--- a/DS4Windows/DS4Control/ControlService.cs
+++ b/DS4Windows/DS4Control/ControlService.cs
@@ -1220,7 +1220,6 @@ namespace DS4Windows
                 string tempType = dev.GetDeviceType();
                 slotDevice.CurrentInputBound = OutSlotDevice.InputBound.Unbound;
                 outputslotMan.DeferredRemoval(dev, -1, outputDevices, false);
-                LogDebug($"Unplugging virtual {tempType} Controller");
             }
         }
 

--- a/DS4Windows/DS4Control/OutputSlotManager.cs
+++ b/DS4Windows/DS4Control/OutputSlotManager.cs
@@ -158,7 +158,7 @@ namespace DS4Windows
                     if (contType == OutContType.X360)
                     {
                         var tempXbox = outputDevice as Xbox360OutDevice;
-                        AppLogger.LogToGui($"Plugging in virtual X360 controller (XInput slot #{ ( tempXbox.XinputSlotNum < 0 ? "unkown" : tempXbox.XinputSlotNum + 1 )}) in output slot #{slot + 1}", false);
+                        AppLogger.LogToGui($"Plugging in virtual X360 controller (XInput slot #{(tempXbox.XinputSlotNum < 0 ? "?" : tempXbox.XinputSlotNum + 1 )}) in output slot #{slot + 1}", false);
                     }
                     else
                     {

--- a/DS4Windows/DS4Control/OutputSlotManager.cs
+++ b/DS4Windows/DS4Control/OutputSlotManager.cs
@@ -155,6 +155,16 @@ namespace DS4Windows
                         return;
                     }
 
+                    if (contType == OutContType.X360)
+                    {
+                        var tempXbox = outputDevice as Xbox360OutDevice;
+                        AppLogger.LogToGui($"Plugging in virtual X360 controller (XInput slot #{ ( tempXbox.XinputSlotNum < 0 ? "unkown" : tempXbox.XinputSlotNum + 1 )}) in output slot #{slot + 1}", false);
+                    }
+                    else
+                    {
+                        AppLogger.LogToGui($"Plugging in virtual {contType} Controller in output slot #{slot + 1}",false);
+                    }
+
                     outputDevices[slot] = outputDevice;
                     deviceDict.Add(slot, outputDevice);
                     revDeviceDict.Add(outputDevice, slot);

--- a/DS4Windows/DS4Control/OutputSlotManager.cs
+++ b/DS4Windows/DS4Control/OutputSlotManager.cs
@@ -208,6 +208,7 @@ namespace DS4Windows
 
                     outputSlots[slot].DetachDevice();
                     SlotUnassigned?.Invoke(this, slot, outputSlots[slot]);
+                    AppLogger.LogToGui($"Unplugging virtual {outputDevice.GetDeviceType()} Controller from output slot #{slot + 1}",false);
 
                     //if (!immediate)
                     //{

--- a/DS4Windows/DS4Control/Xbox360OutDevice.cs
+++ b/DS4Windows/DS4Control/Xbox360OutDevice.cs
@@ -181,7 +181,7 @@ namespace DS4Windows
             {
                 // Need a delay here
                 Thread.Sleep(USER_INDEX_WAIT);
-                _xInputSlotNum = cont.UserIndex;
+                XinputSlotNum = cont.UserIndex;
             }
         }
         public override void Disconnect()

--- a/DS4Windows/DS4Control/Xbox360OutDevice.cs
+++ b/DS4Windows/DS4Control/Xbox360OutDevice.cs
@@ -32,7 +32,14 @@ namespace DS4Windows
             new Dictionary<int, Xbox360FeedbackReceivedEventHandler>();
 
         private int _xInputSlotNum = -1;
-        public int XinputSlotNum => _xInputSlotNum;
+        public int XinputSlotNum
+        {
+            get => _xInputSlotNum;
+            set
+            {
+                if (value >= 0 && value < 16) _xInputSlotNum = value;
+            }
+        }
 
         private X360Features _features;
         public X360Features Features => _features;

--- a/DS4Windows/DS4Forms/ViewModels/CurrentOutDeviceViewModel.cs
+++ b/DS4Windows/DS4Forms/ViewModels/CurrentOutDeviceViewModel.cs
@@ -275,7 +275,7 @@ namespace DS4WinWPF.DS4Forms.ViewModels
         {
             get
             {
-                var xinputSlot = "Unkown";
+                var xinputSlot = "?";
                 if (outSlotDevice.CurrentType == OutContType.X360)
                 {
                     var tempX360 = outSlotDevice.OutputDevice as Xbox360OutDevice;

--- a/DS4Windows/DS4Forms/ViewModels/CurrentOutDeviceViewModel.cs
+++ b/DS4Windows/DS4Forms/ViewModels/CurrentOutDeviceViewModel.cs
@@ -271,18 +271,17 @@ namespace DS4WinWPF.DS4Forms.ViewModels
         }
 
 
-        public int XInputSlotNum
+        public string XInputSlotNum
         {
             get
             {
-                int result = -1;
+                var xinputSlot = "Unkown";
                 if (outSlotDevice.CurrentType == OutContType.X360)
                 {
-                    result = (outSlotDevice.OutputDevice as Xbox360OutDevice).XinputSlotNum;
-                    result = result >= 0 ? result + 1 : result;
+                    var tempX360 = outSlotDevice.OutputDevice as Xbox360OutDevice;
+                    if (tempX360.XinputSlotNum >= 0) xinputSlot = $"{tempX360.XinputSlotNum + 1}";
                 }
-
-                return result;
+                return xinputSlot;
             }
 
         }

--- a/DS4Windows/DS4Library/DS4Devices.cs
+++ b/DS4Windows/DS4Library/DS4Devices.cs
@@ -322,6 +322,7 @@ namespace DS4Windows
                                 DevicePaths.Add(hDevice.DevicePath);
                                 deviceSerials.Add(serial);
                                 serialDevices.Add(serial, ds4Device);
+                                AppLogger.LogToGui($"{DS4WinWPF.Properties.Resources.FoundController} {ds4Device.getMacAddress()} ({ds4Device.getConnectionType()}) {ds4Device.DisplayName}).",false);
                             }
                         }
                     }

--- a/DS4Windows/DS4Library/InputDevices/SwitchProDevice.cs
+++ b/DS4Windows/DS4Library/InputDevices/SwitchProDevice.cs
@@ -39,7 +39,8 @@ namespace DS4Windows.InputDevices
 
         private const int AMP_REAL_MIN = 0;
         //private const int AMP_REAL_MAX = 1003;
-        private const int AMP_LIMIT_MAX = 404;
+        //private const int AMP_LIMIT_MAX = 404;
+        private const int AMP_LIMIT_MAX = 800;
 
         private static RumbleTableData[] fixedRumbleTable = new RumbleTableData[]
         {


### PR DESCRIPTION
- DS4Windows will only consider slots valid if they are from 1-16
    - Any value outside of this range is probably outside of the usual windows Xinput range or because vigembus failed to inform the actual slot (old versions)
    - Slots outside of this range will appear as "?"
- Made virtual xbox 360 plug-in messages display the current xinput slot
- Tweaked some log messages
    - tried to make it clearer when DS4Windows means its output slots and not xinput slots
    - tried to make it clearer when DS4Windows means virtual controllers
    - made the "found controller X" log occur everytime a new controller is found and not only on app startup
    - Small code refactor in some places to simplify code and remove redundant code blocks

![image](https://user-images.githubusercontent.com/24910442/191809443-b6939efe-2ac2-4e6f-befd-339908159183.png)

![image](https://user-images.githubusercontent.com/24910442/191850808-a64c86c1-cb0f-4001-a639-0b4cb10679e3.png)


    
   