### PR TITLE
Added Thrustmaster eSwap Pro VID/PID to DS4Devices

### DIFF
--- a/DS4Windows/DS4Library/DS4Devices.cs
+++ b/DS4Windows/DS4Library/DS4Devices.cs
@@ -160,6 +160,7 @@ namespace DS4Windows
             new VidPidInfo(NINTENDO_VENDOR_ID, JOYCON_R_PRODUCT_ID, "JoyCon (R)", InputDeviceType.JoyConR, VidPidFeatureSet.DefaultDS4, checkConnection: JoyConDevice.DetermineConnectionType),
             new VidPidInfo(0x7545, 0x1122, "Gioteck VX4", InputDeviceType.DS4), // Gioteck VX4 (no real lightbar, only some RGB leds)
             new VidPidInfo(0x7331, 0x0001, "DualShock 3 (DS4 Emulation)", InputDeviceType.DS4, VidPidFeatureSet.NoGyroCalib | VidPidFeatureSet.VendorDefinedDevice), // Sony DualShock 3 using DsHidMini driver. DsHidMini uses vendor-defined HID device type when it's emulating DS3 using DS4 button layout
+            new VidPidInfo(0x044F, 0xD00E, "Thrustmaster eSwap Pro", InputDeviceType.DS4, VidPidFeatureSet.NoGyroCalib | VidPidFeatureSet.NoBatteryReading) // Thrustmaster eSwap Pro (wired only. No lightbar or gyro)
         };
 
         private static bool IsRealDS4(HidDevice hDevice)


### PR DESCRIPTION
Controller: 
![image](https://user-images.githubusercontent.com/16516667/192519580-fac5a193-62a3-4ecf-b35d-3966845203b1.png)

The Thrustmaster eSwap Pro does not have a lightbar or any gyro functionality.

Input report:
![image](https://user-images.githubusercontent.com/16516667/192519949-d320c96d-ecd1-477c-8475-a12b61ece316.png)

I have been using the controller with DS4Windows the last couple of weeks and it seems to be working without an issue. 
 

