### PR TITLE
Implemented exclusion filter for virtual device check

### DIFF
--- a/DS4Windows/DS4Library/DS4Devices.cs
+++ b/DS4Windows/DS4Library/DS4Devices.cs
@@ -166,7 +166,19 @@ namespace DS4Windows
         {
             var device = PnPDevice.GetDeviceByInterfaceId(hDevice.DevicePath);
 
-            return !device.IsVirtual();
+            return !device.IsVirtual(pDevice =>
+            {
+                var hardwareIds = pDevice.GetProperty<string[]>(DevicePropertyKey.Device_HardwareIds).ToList();
+
+                // hardware IDs of root hubs/controllers that emit supported virtual devices as sources
+                var excludedIds = new[]
+                {
+                    @"ROOT\HIDGAMEMAP", // reWASD
+                    @"ROOT\VHUSB3HC", // VirtualHere
+                };
+
+                return hardwareIds.Any(id => excludedIds.Contains(id.ToUpper()));
+            });
         }
 
         // Enumerates ds4 controllers in the system

--- a/DS4Windows/DS4WinWPF.csproj
+++ b/DS4Windows/DS4WinWPF.csproj
@@ -76,7 +76,7 @@
     <PackageReference Include="H.NotifyIcon.Wpf" Version="2.0.64" />
     <PackageReference Include="MdXaml" Version="1.15.0" />
     <PackageReference Include="NLog" Version="5.0.4" />
-    <PackageReference Include="Nefarius.Utilities.DeviceManagement" Version="3.0.165-pre" />
+    <PackageReference Include="Nefarius.Utilities.DeviceManagement" Version="3.2.184" />
     <PackageReference Include="Ookii.Dialogs.Wpf" Version="5.0.1" />
     <PackageReference Include="System.Management" Version="6.0.0" />
     <PackageReference Include="TaskScheduler" Version="2.10.1" />


### PR DESCRIPTION
This fixes #2610 and a related reWASD issue reported only on Reddit if memory serves me right.

This change adds an exclusion for the USB host controller hardware IDs for reWASD and VirtualHere, reporting them as not virtual despite originating from a software parent bus.