### PR TITLE
Add workflows for issue moderation automation

### DIFF
--- a/.github/workflows/duplicate.yml
+++ b/.github/workflows/duplicate.yml
@@ -1,0 +1,24 @@
+name: 'Duplicate Issue'
+
+on:
+  issues:
+    types: [labeled, unlabeled, reopened]
+
+permissions:
+  issues: write
+
+jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/support-requests@v2
+        with:
+          github-token: ${{ github.token }}
+          support-label: 'duplicate'
+          issue-comment: >
+            :wave: @{issue-author}, one or more issues for this topic already exist, 
+            please follow those instead of opening another one. Use the search function 
+            to find issues related to your troubles. Thank you!
+          close-issue: true
+          lock-issue: true
+          issue-lock-reason: 'off-topic'

--- a/.github/workflows/fix-shipped.yml
+++ b/.github/workflows/fix-shipped.yml
@@ -1,0 +1,23 @@
+name: 'Fix shipped with Release'
+
+on:
+  issues:
+    types: [labeled, unlabeled, reopened]
+
+permissions:
+  issues: write
+
+jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/support-requests@v2
+        with:
+          github-token: ${{ github.token }}
+          support-label: 'fix-shipped'
+          issue-comment: >
+            This issues' topic has been resolved and an update has been published. 
+            Please check out the Releases page for a new version.
+          close-issue: true
+          lock-issue: true
+          issue-lock-reason: 'off-topic'

--- a/.github/workflows/fix-shipped.yml
+++ b/.github/workflows/fix-shipped.yml
@@ -19,5 +19,5 @@ jobs:
             This issues' topic has been resolved and an update has been published. 
             Please check out the Releases page for a new version.
           close-issue: true
-          lock-issue: true
+          lock-issue: false
           issue-lock-reason: 'off-topic'

--- a/.github/workflows/out-of-scope.yml
+++ b/.github/workflows/out-of-scope.yml
@@ -1,0 +1,23 @@
+name: 'Out-of-scope Issue'
+
+on:
+  issues:
+    types: [labeled, unlabeled, reopened]
+
+permissions:
+  issues: write
+
+jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/support-requests@v2
+        with:
+          github-token: ${{ github.token }}
+          support-label: 'out-of-scope'
+          issue-comment: >
+            :wave: @{issue-author}, unfortunately this topic is out of scope 
+            of the projects' overall goals and will not be worked on.
+          close-issue: true
+          lock-issue: true
+          issue-lock-reason: 'off-topic'


### PR DESCRIPTION
*This is a personal suggestion I find useful, feel free to close if you disagree.*

Moderating issues is boring and repetitive. Why not use bots? 😁 

I added 3 example workflows that trigger automatically when you assign specific labels to an issue. Be my guest to adapt the messages the bot should post.

### `duplicate`

Assign this to duplicates and the issue will be closed and locked with a predetermined message encouraging the OP to do better 😉 

### `out-of-scope`

Assign this to close and lock issues that suggest changes (or features) which are out of scope or have already been mentioned to be out-of-scope in the past.

### `fix-shipped`

Sometimes folks are not aware that a fix for an issue has been released. Assign this label to post an informational message that the reader should look for a new version.

Cheers