### PR TITLE
Fix crash on updating tray tooltip text

### DIFF
--- a/DS4Windows/DS4Forms/ViewModels/TrayIconViewModel.cs
+++ b/DS4Windows/DS4Forms/ViewModels/TrayIconViewModel.cs
@@ -33,7 +33,11 @@ namespace DS4WinWPF.DS4Forms.ViewModels
                 if (tooltipText == temp) return;
                 tooltipText = temp;
                 //Trace.WriteLine(tooltipText);
-                TooltipTextChanged?.Invoke(this, EventArgs.Empty);
+                try
+                {
+                    TooltipTextChanged?.Invoke(this, EventArgs.Empty);
+                }
+                catch (InvalidOperationException) { }
             }
         }
         public event EventHandler TooltipTextChanged;


### PR DESCRIPTION
To play some games without crashes (Forza Horizon 4/5 as example), you need to turn off the explorer.exe, but this leads to crash DS4Windows :)

The error is reproduced stably. To reproduce:
1. Windows explorer.exe is running
2. Run DS4Windows
3. Plug gamepad
4. End task "Windows Explorer" in Task Manager
5. Force DS4Windows to change the tooltip text in the tray window, for example, click stop button/wait for the controller charge to change/etc
6. DS4Windows crashed with InvalidOperationException from H.NotifyIcon.Core.TrayIcon

It's because the TrayIcon cannot update the tooltip text:
```c#
    public void UpdateToolTip(string text)
    {
        ...

        if (!TrayIconMethods.TryModifyToolTip(Id, text))
        {
            throw new InvalidOperationException("UpdateToolTip failed.");// HERE
        }
        ToolTip = text;
    }
```

This looks logical and is unlikely to be fixed in the library: no tray -> no TrayIcon -> unable to update tooltip -> exception

But we can just ignore this exception because even without a successful update of the text in the TrayIcon, DS4Windows may continue to function normally.

So this will allow to work DS4Windows with disabled explorer.exe and possibly fix other similar issues (#2731, #2623)

An interesting point is that the error does not occur if you change TrayIcon's icon in settings.