### PR TITLE
Added Playmax PS4 wired controller support

### DIFF
--- a/DS4Windows/DS4Library/DS4Devices.cs
+++ b/DS4Windows/DS4Library/DS4Devices.cs
@@ -166,6 +166,7 @@ namespace DS4Windows
             new VidPidInfo(0x20D6, 0x792A, "PowerA FUSION Wired Fightpad for PS4", InputDeviceType.DS4, VidPidFeatureSet.NoGyroCalib), // No lightbar, gyro, or sticks
             new VidPidInfo(0x044F, 0xD00E, "Thrustmaster eSwap Pro", InputDeviceType.DS4, VidPidFeatureSet.NoGyroCalib | VidPidFeatureSet.NoBatteryReading), // Thrustmaster eSwap Pro (wired only. No lightbar or gyro)
             new VidPidInfo(0x054C, 0x0268, "DualShock 3 (SXS)", InputDeviceType.DS3), // Sony DualShock 3 using DsHidMini driver (SXS) or Sony Sixaxis driver
+            new VidPidInfo(0x0C12, 0x0E15, "Playmax Wired Controller (PS4)", InputDeviceType.DS4, VidPidFeatureSet.NoBatteryReading | VidPidFeatureSet.NoGyroCalib), // Generic PS4 Controller by Playmax (brand primarily in New Zealand). Standard Wired PS4 controller, no Gyro, no Lightbar, no Battery. There is a newer model but I'm not sure if it uses a different Vid or Pid yet.
         };
 
         private static bool IsRealDS4(HidDevice hDevice)


### PR DESCRIPTION
This PR adds support for this controller: https://playmax.co.nz/products/playmax-wired-controller-ps4
It's a cheap generic wired one that is sold here, I have a slightly older design from the same brand but I believe it should be the same, it's the same product SKU mine just looks cosmetically different on the buttons.