### PR TITLE
Improve "OSC Server" functionality and documentation

### DIFF
--- a/DS4Windows/DS4Control/ControlService.cs
+++ b/DS4Windows/DS4Control/ControlService.cs
@@ -289,7 +289,8 @@ namespace DS4Windows
                         {
                             command = MapMonitoringOscMessageToCommand(command);
                         }
-                        else {
+                        else
+                        {
                             return;
                         }
                     }
@@ -342,8 +343,8 @@ namespace DS4Windows
                             case "r1":
                                 oscState[stateInd].R1 = buttonBool;
                                 break;
-                            case "r2btn":
-                                oscState[stateInd].R2Btn = buttonBool;
+                            case "r2":
+                                oscState[stateInd].R2 = Convert.ToByte(buttonBool ? 255 : 0);
                                 break;
                             case "r3":
                                 oscState[stateInd].R3 = buttonBool;
@@ -351,8 +352,8 @@ namespace DS4Windows
                             case "l1":
                                 oscState[stateInd].L1 = buttonBool;
                                 break;
-                            case "l2btn":
-                                oscState[stateInd].L2Btn = buttonBool;
+                            case "l2":
+                                oscState[stateInd].L2 = Convert.ToByte(buttonBool ? 255 : 0);
                                 break;
                             case "l3":
                                 oscState[stateInd].L3 = buttonBool;
@@ -2765,10 +2766,8 @@ namespace DS4Windows
             tempMapState.Circle |= oscMapState.Circle;
             tempMapState.Triangle |= oscMapState.Triangle;
             tempMapState.R1 |= oscMapState.R1;
-            tempMapState.R2Btn |= oscMapState.R2Btn;
             tempMapState.R3 |= oscMapState.R3;
             tempMapState.L1 |= oscMapState.L1;
-            tempMapState.L2Btn |= oscMapState.L2Btn;
             tempMapState.L3 |= oscMapState.L3;
             tempMapState.DpadUp |= oscMapState.DpadUp;
             tempMapState.DpadLeft |= oscMapState.DpadLeft;
@@ -2798,10 +2797,8 @@ namespace DS4Windows
             cState.Circle |= oscMapState.Circle;
             cState.Triangle |= oscMapState.Triangle;
             cState.R1 |= oscMapState.R1;
-            cState.R2Btn |= oscMapState.R2Btn;
             cState.R3 |= oscMapState.R3;
             cState.L1 |= oscMapState.L1;
-            cState.L2Btn |= oscMapState.L2Btn;
             cState.L3 |= oscMapState.L3;
             cState.DpadUp |= oscMapState.DpadUp;
             cState.DpadLeft |= oscMapState.DpadLeft;
@@ -2816,12 +2813,13 @@ namespace DS4Windows
             cState.RX = oscMapState.RX != 128 ? oscMapState.RX : cState.RX;
             cState.RY = oscMapState.RY != 128 ? oscMapState.RY : cState.RY;
             cState.R2 = oscMapState.R2 != 0 ? oscMapState.R2 : cState.R2;
-            //AppLogger.LogToGui("I HEARD SOMETHING " + pCState.Cross+" : "+tempMapState.Cross, false);
+            
             CompareAndSendChangesToOSC(ind, tempMapState, cState);
         }
 
         private void CompareAndSendChangesToOSC(int index, DS4State oldState, DS4State newState)
         {
+            // Buttons 
             if(oldState.Square != newState.Square)
             {
                 oscSender.Send(new OscMessage("/ds4windows/monitor/" + index + "/square", newState.Square == true ? 1 : 0));
@@ -2867,11 +2865,6 @@ namespace DS4Windows
                 oscSender.Send(new OscMessage("/ds4windows/monitor/" + index + "/l1", newState.L1 == true ? 1 : 0));
             }
 
-            if (oldState.L2 != newState.L2)
-            {
-                oscSender.Send(new OscMessage("/ds4windows/monitor/" + index + "/l2", Convert.ToInt32(newState.L2)));
-            }
-
             if (oldState.L3 != newState.L3)
             {
                 oscSender.Send(new OscMessage("/ds4windows/monitor/" + index + "/l3", newState.L3 == true ? 1 : 0));
@@ -2882,37 +2875,16 @@ namespace DS4Windows
                 oscSender.Send(new OscMessage("/ds4windows/monitor/" + index + "/r1", newState.R1 == true ? 1 : 0));
             }
 
-            if (oldState.R2 != newState.R2)
-            {
-                oscSender.Send(new OscMessage("/ds4windows/monitor/" + index + "/r2", Convert.ToInt32(newState.R2)));
-            }
-
             if (oldState.R3 != newState.R3)
             {
                 oscSender.Send(new OscMessage("/ds4windows/monitor/" + index + "/r3", newState.R3 == true ? 1 : 0));
-            }
-
-            if (oldState.LX != newState.LX)
-            {
-                oscSender.Send(new OscMessage("/ds4windows/monitor/" + index + "/lx", Convert.ToInt32(newState.LX)));
-            }
-            if (oldState.LY != newState.LY)
-            {
-                oscSender.Send(new OscMessage("/ds4windows/monitor/" + index + "/ly", Convert.ToInt32(newState.LY)));
-            }
-            if (oldState.RX != newState.RX)
-            {
-                oscSender.Send(new OscMessage("/ds4windows/monitor/" + index + "/rx", Convert.ToInt32(newState.RX)));
-            }
-            if (oldState.RY != newState.RY)
-            {
-                oscSender.Send(new OscMessage("/ds4windows/monitor/" + index + "/ry", Convert.ToInt32(newState.RY)));
             }
 
             if (oldState.Options != newState.Options)
             {
                 oscSender.Send(new OscMessage("/ds4windows/monitor/" + index + "/options", newState.Options == true ? 1 : 0));
             }
+
             if (oldState.Share != newState.Share)
             {
                 oscSender.Send(new OscMessage("/ds4windows/monitor/" + index + "/share", newState.Share == true ? 1 : 0));
@@ -2922,7 +2894,39 @@ namespace DS4Windows
             {
                 oscSender.Send(new OscMessage("/ds4windows/monitor/" + index + "/ps", newState.PS == true ? 1 : 0));
             }
-            
+
+            // Sticks
+            if (oldState.LX != newState.LX)
+            {
+                oscSender.Send(new OscMessage("/ds4windows/monitor/" + index + "/lx", Convert.ToInt32(newState.LX)));
+            }
+
+            if (oldState.LY != newState.LY)
+            {
+                oscSender.Send(new OscMessage("/ds4windows/monitor/" + index + "/ly", Convert.ToInt32(newState.LY)));
+            }
+
+            if (oldState.RX != newState.RX)
+            {
+                oscSender.Send(new OscMessage("/ds4windows/monitor/" + index + "/rx", Convert.ToInt32(newState.RX)));
+            }
+
+            if (oldState.RY != newState.RY)
+            {
+                oscSender.Send(new OscMessage("/ds4windows/monitor/" + index + "/ry", Convert.ToInt32(newState.RY)));
+            }
+
+            // Triggers
+            if (oldState.L2 != newState.L2)
+            {
+                oscSender.Send(new OscMessage("/ds4windows/monitor/" + index + "/l2", Convert.ToInt32(newState.L2)));
+            }
+
+            if (oldState.R2 != newState.R2)
+            {
+                oscSender.Send(new OscMessage("/ds4windows/monitor/" + index + "/r2", Convert.ToInt32(newState.R2)));
+            }
+
             // if (oldState.Battery != newState.Battery)
             // {
             //     AppLogger.LogToGui("BATTERY " + oldState.Battery + " : " + newState.Battery, false);

--- a/DS4Windows/DS4Control/ControlService.cs
+++ b/DS4Windows/DS4Control/ControlService.cs
@@ -245,6 +245,10 @@ namespace DS4Windows
                 case "battery":
                     command[3] = "battery";
                     break;
+                case "l2":
+                case "r2":
+                    command[3] = "trigger";
+                    break;
                 case "rx":
                 case "ry":
                 case "lx":
@@ -338,7 +342,7 @@ namespace DS4Windows
                             case "r1":
                                 oscState[stateInd].R1 = buttonBool;
                                 break;
-                            case "r2":
+                            case "r2btn":
                                 oscState[stateInd].R2Btn = buttonBool;
                                 break;
                             case "r3":
@@ -347,7 +351,7 @@ namespace DS4Windows
                             case "l1":
                                 oscState[stateInd].L1 = buttonBool;
                                 break;
-                            case "l2":
+                            case "l2btn":
                                 oscState[stateInd].L2Btn = buttonBool;
                                 break;
                             case "l3":
@@ -411,6 +415,19 @@ namespace DS4Windows
                         {
                             oscState[stateInd].RX = Convert.ToByte(xValue * 255);
                             oscState[stateInd].RY = Convert.ToByte(yValue * 255);
+                        }
+                    }
+
+                    if (command[3] == "trigger")
+                    {
+                        switch (command[4])
+                        {
+                            case "r2":
+                                oscState[stateInd].R2 = Convert.ToByte(Convert.ToSingle(messageReceived.Arguments[0]));
+                                break;
+                            case "l2":
+                                oscState[stateInd].L2 = Convert.ToByte(Convert.ToSingle(messageReceived.Arguments[0]));
+                                break;
                         }
                     }
                 } catch(Exception e) {
@@ -2749,17 +2766,9 @@ namespace DS4Windows
             tempMapState.Triangle |= oscMapState.Triangle;
             tempMapState.R1 |= oscMapState.R1;
             tempMapState.R2Btn |= oscMapState.R2Btn;
-            if (oscMapState.R2Btn == true)
-            {
-                tempMapState.R2 = 255;
-            }
             tempMapState.R3 |= oscMapState.R3;
             tempMapState.L1 |= oscMapState.L1;
             tempMapState.L2Btn |= oscMapState.L2Btn;
-            if (oscMapState.L2Btn == true)
-            {
-                tempMapState.L2 = 255;
-            }
             tempMapState.L3 |= oscMapState.L3;
             tempMapState.DpadUp |= oscMapState.DpadUp;
             tempMapState.DpadLeft |= oscMapState.DpadLeft;
@@ -2770,8 +2779,10 @@ namespace DS4Windows
 
             tempMapState.LX = oscMapState.LX != 128 ? oscMapState.LX : tempMapState.LX;
             tempMapState.LY = oscMapState.LY != 128 ? oscMapState.LY : tempMapState.LY;
+            tempMapState.L2 = oscMapState.L2 != 0 ? oscMapState.L2 : tempMapState.L2;
             tempMapState.RX = oscMapState.RX != 128 ? oscMapState.RX : tempMapState.RX;
             tempMapState.RY = oscMapState.RY != 128 ? oscMapState.RY : tempMapState.RY;
+            tempMapState.R2 = oscMapState.R2 != 0 ? oscMapState.R2 : tempMapState.R2;
         }
 
         private void OSCPreMappingStep(int ind, DS4State cState, DS4State tempMapState,
@@ -2788,17 +2799,9 @@ namespace DS4Windows
             cState.Triangle |= oscMapState.Triangle;
             cState.R1 |= oscMapState.R1;
             cState.R2Btn |= oscMapState.R2Btn;
-            if (oscMapState.R2Btn == true)
-            {
-                cState.R2 = 255;
-            }
             cState.R3 |= oscMapState.R3;
             cState.L1 |= oscMapState.L1;
             cState.L2Btn |= oscMapState.L2Btn;
-            if (oscMapState.L2Btn == true)
-            {
-                cState.L2 = 255;
-            }
             cState.L3 |= oscMapState.L3;
             cState.DpadUp |= oscMapState.DpadUp;
             cState.DpadLeft |= oscMapState.DpadLeft;
@@ -2809,8 +2812,10 @@ namespace DS4Windows
 
             cState.LX = oscMapState.LX != 128 ? oscMapState.LX : cState.LX;
             cState.LY = oscMapState.LY != 128 ? oscMapState.LY : cState.LY;
+            cState.L2 = oscMapState.L2 != 0 ? oscMapState.L2 : cState.L2;
             cState.RX = oscMapState.RX != 128 ? oscMapState.RX : cState.RX;
             cState.RY = oscMapState.RY != 128 ? oscMapState.RY : cState.RY;
+            cState.R2 = oscMapState.R2 != 0 ? oscMapState.R2 : cState.R2;
             //AppLogger.LogToGui("I HEARD SOMETHING " + pCState.Cross+" : "+tempMapState.Cross, false);
             CompareAndSendChangesToOSC(ind, tempMapState, cState);
         }

--- a/DS4Windows/DS4Control/DTOXml/AppSettingsDTO.cs
+++ b/DS4Windows/DS4Control/DTOXml/AppSettingsDTO.cs
@@ -444,6 +444,25 @@ namespace DS4WinWPF.DS4Control.DTOXml
             get; private set;
         }
 
+        [XmlIgnore]
+        public bool InterpretingOscMonitoring
+        {
+            get; private set;
+        }
+
+        [XmlElement("InterpretingOscMonitoring")]
+        public string InterpretingOscMonitoringString
+        {
+            get => InterpretingOscMonitoring.ToString();
+            set
+            {
+                if (bool.TryParse(value, out bool temp))
+                {
+                    InterpretingOscMonitoring = temp;
+                }
+            }
+        }
+
         [XmlElement("UseOSCSender")]
         public string UseOSCSenderString
         {
@@ -756,6 +775,7 @@ namespace DS4WinWPF.DS4Control.DTOXml
             AppTheme = source.useCurrentTheme;
             UseOSCServer = source.useOSCServ;
             OSCServerPort = source.oscServPort;
+            InterpretingOscMonitoring = source.interpretingOscMonitoring;
             UseOSCSender = source.useOSCSend;
             OSCSenderPort = source.oscSendPort;
             OSCSenderAddress = source.oscSendAddress;
@@ -843,6 +863,7 @@ namespace DS4WinWPF.DS4Control.DTOXml
             destination.useCurrentTheme = AppTheme;
             destination.useOSCServ = UseOSCServer;
             destination.oscServPort = OSCServerPort;
+            destination.interpretingOscMonitoring = InterpretingOscMonitoring;
             destination.useOSCSend = UseOSCSender;
             destination.oscSendPort = OSCSenderPort;
             if (!string.IsNullOrEmpty(OSCSenderAddress))

--- a/DS4Windows/DS4Control/ScpUtil.cs
+++ b/DS4Windows/DS4Control/ScpUtil.cs
@@ -1538,10 +1538,18 @@ namespace DS4Windows
         {
             return m_Config.oscServPort;
         }
-
         public static void setOSCServerPort(int value)
         {
             m_Config.oscServPort = value;
+        }
+
+        public static bool isInterpretingOscMonitoring()
+        {
+            return m_Config.interpretingOscMonitoring;
+        }
+        public static void setInterpretingOscMonitoring(bool state)
+        {
+            m_Config.interpretingOscMonitoring = state;
         }
 
         public static bool isUsingOSCSender()
@@ -3359,6 +3367,8 @@ namespace DS4Windows
 
         public const int DEFAULT_OSC_SERV_PORT = 9000;
         public int oscServPort = DEFAULT_OSC_SERV_PORT;
+
+        public bool interpretingOscMonitoring = false;
 
         public bool useOSCSend = false;
 
@@ -7453,6 +7463,8 @@ namespace DS4Windows
                     catch { missingSetting = true; }
                     try { Item = m_Xdoc.SelectSingleNode("/Profile/OSCServerPort"); int temp; int.TryParse(Item.InnerText, out temp); oscServPort = Math.Min(Math.Max(temp, 1024), 65535); }
                     catch { missingSetting = true; }
+                    try { Item = m_Xdoc.SelectSingleNode("/Profile/InterpretingOscMonitoring"); Boolean.TryParse(Item.InnerText, out interpretingOscMonitoring); }
+                    catch { missingSetting = true; }
 
                     try { Item = m_Xdoc.SelectSingleNode("/Profile/UseOSCSender"); Boolean.TryParse(Item.InnerText, out useOSCSend); }
                     catch { missingSetting = true; }
@@ -7762,6 +7774,7 @@ namespace DS4Windows
             XmlNode xmlAppThemeChoice = m_Xdoc.CreateNode(XmlNodeType.Element, "AppTheme", null); xmlAppThemeChoice.InnerText = useCurrentTheme.ToString(); rootElement.AppendChild(xmlAppThemeChoice);
             XmlNode xmlUseOSCServ = m_Xdoc.CreateNode(XmlNodeType.Element, "UseOSCServer", null); xmlUseOSCServ.InnerText = useOSCServ.ToString(); rootElement.AppendChild(xmlUseOSCServ);
             XmlNode xmlOSCServPort = m_Xdoc.CreateNode(XmlNodeType.Element, "OSCServerPort", null); xmlOSCServPort.InnerText = oscServPort.ToString(); rootElement.AppendChild(xmlOSCServPort);
+            XmlNode xmlInterpretingOscMonitoring = m_Xdoc.CreateNode(XmlNodeType.Element, "InterpretingOscMonitoring", null); xmlInterpretingOscMonitoring.InnerText = interpretingOscMonitoring.ToString(); rootElement.AppendChild(xmlInterpretingOscMonitoring);
 
             XmlNode xmlUseOSCSend = m_Xdoc.CreateNode(XmlNodeType.Element, "UseOSCSender", null); xmlUseOSCSend.InnerText = useOSCSend.ToString(); rootElement.AppendChild(xmlUseOSCSend);
             XmlNode xmlOSCSendPort = m_Xdoc.CreateNode(XmlNodeType.Element, "OSCSenderPort", null); xmlOSCSendPort.InnerText = oscSendPort.ToString(); rootElement.AppendChild(xmlOSCSendPort);

--- a/DS4Windows/DS4Forms/MainWindow.xaml
+++ b/DS4Windows/DS4Forms/MainWindow.xaml
@@ -334,19 +334,19 @@
                                 <ComboBoxItem Content="{lex:Loc Days}" />
                             </ComboBox>
                         </StackPanel>
-                        <GroupBox Header="External OSC Control &amp; Monitoring" Padding="0,10,0,0" Margin="{StaticResource spaceMargin}">
+                        <GroupBox Header="{lex:Loc OscServerHeading}" Padding="0,10,0,0" Margin="{StaticResource spaceMargin}">
                             <StackPanel>
                                 <StackPanel Orientation="Horizontal" MinHeight="20">
-                                    <CheckBox x:Name="useOscServerCk" Content="Enable Control Server" IsChecked="{Binding UseOSCServer}" Click="UseOscServerCk_Click" VerticalAlignment="Center" />
+                                    <CheckBox x:Name="useOscServerCk" Content="{lex:Loc EnableOscServer}" IsChecked="{Binding UseOSCServer}" Click="UseOscServerCk_Click" VerticalAlignment="Center" />
                                     <Label Content="Port" Padding="0" VerticalAlignment="Center" Margin="20,0,0,0" />
                                     <xctk:IntegerUpDown d:IsHidden="False" x:Name="oscPortNum" IsEnabled="{Binding UseOSCServer}" MinWidth="20" Margin="8,0,0,0"
                                         Value="{Binding OscPort, UpdateSourceTrigger=LostFocus,FallbackValue='9000'}" ButtonSpinnerLocation="Right" Increment="1" Maximum="65535" Minimum="0" />
                                 </StackPanel>
 
-                                <CheckBox x:Name="interpretingOscMonitoringCk" Content="Interpret Monitoring Messages" Margin="0,4,0,10" IsChecked="{Binding InterpretingOscMonitoring}" IsEnabled="{Binding UseOSCServer}" />
+                                <CheckBox x:Name="interpretingOscMonitoringCk" Content="{lex:Loc EnableInterpretingOscMonitoring}" Margin="0,4,0,10" IsChecked="{Binding InterpretingOscMonitoring}" IsEnabled="{Binding UseOSCServer}" />
                                 
                                 <StackPanel Orientation="Horizontal" MinHeight="20">
-                                    <CheckBox x:Name="useOscSenderCk" Content="Enable Monitoring Service" IsChecked="{Binding UseOSCSender}" Click="UseOscSenderCk_Click" VerticalAlignment="Center" />
+                                    <CheckBox x:Name="useOscSenderCk" Content="{lex:Loc EnableOscSender}" IsChecked="{Binding UseOSCSender}" Click="UseOscSenderCk_Click" VerticalAlignment="Center" />
                                     <TextBox x:Name="oscSenderTxt" IsEnabled="{Binding UseOSCSender,Mode=OneWay}" Text="{Binding OscSenderAddress, UpdateSourceTrigger=LostFocus,FallbackValue='127.0.0.1'}"
                                  Margin="8,0,0,0" />
                                     <Label Content="Port" Padding="0" Margin="20,0,0,0" VerticalAlignment="Center"/>

--- a/DS4Windows/DS4Forms/MainWindow.xaml
+++ b/DS4Windows/DS4Forms/MainWindow.xaml
@@ -334,19 +334,22 @@
                                 <ComboBoxItem Content="{lex:Loc Days}" />
                             </ComboBox>
                         </StackPanel>
-                        <GroupBox Header="OSC Server" Padding="0,10,0,0" Margin="{StaticResource spaceMargin}">
+                        <GroupBox Header="External OSC Control &amp; Monitoring" Padding="0,10,0,0" Margin="{StaticResource spaceMargin}">
                             <StackPanel>
                                 <StackPanel Orientation="Horizontal" MinHeight="20">
-                                    <CheckBox x:Name="useOscServerCk" Content="Enable OSC Server" IsChecked="{Binding UseOSCServer}" Click="UseOscServerCk_Click" />
-                                    <Label Content="Port" Padding="0" Margin="20,0,0,0" />
+                                    <CheckBox x:Name="useOscServerCk" Content="Enable Control Server" IsChecked="{Binding UseOSCServer}" Click="UseOscServerCk_Click" VerticalAlignment="Center" />
+                                    <Label Content="Port" Padding="0" VerticalAlignment="Center" Margin="20,0,0,0" />
                                     <xctk:IntegerUpDown d:IsHidden="False" x:Name="oscPortNum" IsEnabled="{Binding UseOSCServer}" MinWidth="20" Margin="8,0,0,0"
-                                            Value="{Binding OscPort, UpdateSourceTrigger=LostFocus,FallbackValue='9000'}" ButtonSpinnerLocation="Right" Increment="1" Maximum="65535" Minimum="0" />
+                                        Value="{Binding OscPort, UpdateSourceTrigger=LostFocus,FallbackValue='9000'}" ButtonSpinnerLocation="Right" Increment="1" Maximum="65535" Minimum="0" />
                                 </StackPanel>
+
+                                <CheckBox x:Name="interpretingOscMonitoringCk" Content="Interpret Monitoring Messages" Margin="0,4,0,10" IsChecked="{Binding InterpretingOscMonitoring}" IsEnabled="{Binding UseOSCServer}" />
+                                
                                 <StackPanel Orientation="Horizontal" MinHeight="20">
-                                    <CheckBox x:Name="useOscSenderCk" Content="Send Realtime Data" IsChecked="{Binding UseOSCSender}" Click="UseOscSenderCk_Click" />
+                                    <CheckBox x:Name="useOscSenderCk" Content="Enable Monitoring Service" IsChecked="{Binding UseOSCSender}" Click="UseOscSenderCk_Click" VerticalAlignment="Center" />
                                     <TextBox x:Name="oscSenderTxt" IsEnabled="{Binding UseOSCSender,Mode=OneWay}" Text="{Binding OscSenderAddress, UpdateSourceTrigger=LostFocus,FallbackValue='127.0.0.1'}"
                                  Margin="8,0,0,0" />
-                                    <Label Content="Port" Padding="0" Margin="20,0,0,0" />
+                                    <Label Content="Port" Padding="0" Margin="20,0,0,0" VerticalAlignment="Center"/>
                                     <xctk:IntegerUpDown d:IsHidden="False" x:Name="oscSendPort" IsEnabled="{Binding UseOSCSender}" MinWidth="20" Margin="8,0,0,0"
                                             Value="{Binding OscSendPort, UpdateSourceTrigger=LostFocus,FallbackValue='9000'}" ButtonSpinnerLocation="Right" Increment="1" Maximum="65535" Minimum="0" />
                                 </StackPanel>
@@ -355,10 +358,10 @@
                         <GroupBox Header="UDP Server" Padding="0,10,0,0" Margin="{StaticResource spaceMargin}">
                             <StackPanel>
                                 <StackPanel Orientation="Horizontal" MinHeight="20">
-                                    <CheckBox x:Name="useUdpServerCk" Content="Enable Server" IsChecked="{Binding UseUDPServer}" Click="UseUdpServerCk_Click" />
+                                    <CheckBox x:Name="useUdpServerCk" Content="Enable Server" IsChecked="{Binding UseUDPServer}" Click="UseUdpServerCk_Click" VerticalAlignment="Center" />
                                     <TextBox x:Name="udpServerTxt" IsEnabled="{Binding UseUDPServer,Mode=OneWay}" Text="{Binding UdpIpAddress, UpdateSourceTrigger=LostFocus,FallbackValue='127.0.0.1'}"
                                  Margin="8,0,0,0" />
-                                    <Label Content="Port" Padding="0" Margin="20,0,0,0" />
+                                    <Label Content="Port" Padding="0" Margin="20,0,0,0" VerticalAlignment="Center" />
                                     <!--<TextBox x:Name="updPortNum" IsEnabled="{Binding UseUDPServer}" Text="{Binding UdpPort, UpdateSourceTrigger=LostFocus,FallbackValue='26760'}" />-->
                                     <xctk:IntegerUpDown d:IsHidden="True" x:Name="updPortNum" IsEnabled="{Binding UseUDPServer}" MinWidth="20" Margin="8,0,0,0"
                                             Value="{Binding UdpPort, UpdateSourceTrigger=LostFocus,FallbackValue='26760'}" ButtonSpinnerLocation="Right" Increment="1" Maximum="65535" Minimum="0" />
@@ -450,7 +453,7 @@
                             </WrapPanel>
                         </GroupBox>
 
-                        <Button x:Name="deviceOptionSettingsBtn" MaxWidth="140" HorizontalAlignment="Left" Content="{lex:Loc DeviceOptions}" Click="DeviceOptionSettingsBtn_Click" />
+                        <Button x:Name="deviceOptionSettingsBtn" MaxWidth="140" HorizontalAlignment="Center" Content="{lex:Loc DeviceOptions}" Click="DeviceOptionSettingsBtn_Click" />
                     </WrapPanel>
                 </ScrollViewer>
 

--- a/DS4Windows/DS4Forms/ViewModels/SettingsViewModel.cs
+++ b/DS4Windows/DS4Forms/ViewModels/SettingsViewModel.cs
@@ -197,6 +197,8 @@ namespace DS4WinWPF.DS4Forms.ViewModels
         }
         public event EventHandler UseOSCServerChanged;
         public int OscPort { get => DS4Windows.Global.getOSCServerPortNum(); set => DS4Windows.Global.setOSCServerPort(value); }
+        
+        public bool InterpretingOscMonitoring { get => DS4Windows.Global.isInterpretingOscMonitoring(); set => DS4Windows.Global.setInterpretingOscMonitoring(value); }
 
         public bool UseOSCSender
         {

--- a/DS4Windows/Translations/Strings.de.resx
+++ b/DS4Windows/Translations/Strings.de.resx
@@ -342,6 +342,18 @@
   <data name="HidNinja" xml:space="preserve">
     <value>HidNinja</value>
   </data>
+  <data name="OscServerHeading" xml:space="preserve">
+    <value>Externe OSC Steuerung &amp; Überwachung</value>
+  </data>
+  <data name="EnableOscServer" xml:space="preserve">
+    <value>Aktiviere Steuerungsserver</value>
+  </data>
+  <data name="EnableInterpretingOscMonitoring" xml:space="preserve">
+    <value>Interpretiere Überwachungsnachrichten</value>
+  </data>
+    <data name="EnableOscSender" xml:space="preserve">
+    <value>Aktiviere Überwachungsservice</value>
+  </data>
   <data name="CustomExeName" xml:space="preserve">
     <value>Eigener EXE-Name</value>
   </data>

--- a/DS4Windows/Translations/Strings.resx
+++ b/DS4Windows/Translations/Strings.resx
@@ -670,6 +670,18 @@ Disabled:
   <data name="CheckEvery" xml:space="preserve">
     <value>Check every</value>
   </data>
+  <data name="OscServerHeading" xml:space="preserve">
+    <value>External OSC Control &amp; Monitoring</value>
+  </data>
+  <data name="EnableOscServer" xml:space="preserve">
+    <value>Enable Control Server</value>
+  </data>
+  <data name="EnableInterpretingOscMonitoring" xml:space="preserve">
+    <value>Interpret Monitoring Messages</value>
+  </data>
+    <data name="EnableOscSender" xml:space="preserve">
+    <value>Enable Monitoring Service</value>
+  </data>
   <data name="ControllerSupportDS4" xml:space="preserve">
     <value>DS4 Controller Support</value>
   </data>

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ The **Other** tab contains the settings for which controller is being emulated, 
 **Output Slots** shows which controllers that are connected are designated to the 8 slots that DS4Windows allows to be plugged in at one time. Here you can also select a controller and virtually plug and unplug it in.
 
 ### Settings
-![Settings Screenshot](https://user-images.githubusercontent.com/32114370/189569023-19eacbfd-6f4c-45ee-8fd5-fbf691ce81a0.png)
+![Settings Screenshot](https://user-images.githubusercontent.com/75176311/232901882-6e271499-cdff-4f93-bfa5-921205c7fb69.PNG)
 
 The **Settings** tab is where the settings for the DS4Windows application are. Options such as *Run at Startup*, *Start Minimized*, or *Show Notifications* live here.
 
@@ -121,7 +121,9 @@ The **Settings** tab is where the settings for the DS4Windows application are. O
 
 **Icon Choice** - Changes the Icon of the DS4Windows application
 
-**App Theme** - Switch DS4Windows to Light or Dark mode.
+**App Theme** - Switch DS4Windows to Light or Dark mode
+
+**External OSC Control & Monitoring** - Use Open Sound Control messages to remotely control and monitor buttons, sticks, triggers, and battery levels
 
 **UDP Server** - Setting for connecting the motion controls of a compatible controller to another program
 


### PR DESCRIPTION
# Changes

This PR includes the following changes:

- Add _analog trigger_ support to **OSC**
- Improve error handling in the **OSC** **callback**, that prevents crashing from malformed **OSC messages**
- Improve naming to be more descriptive and translatable
- Add documentation to the _README_ and _Wiki_. For the _Wiki_ change please see [my own fork](https://github.com/xAdler/DS4Windows/wiki/Settings#external-osc-control--monitoring)
- Add the functionality to remote control a **DS4Windows** instance from a different **DS4Windows** instance using **OSC messages**. This feature is controlled by  a new checkbox under the _OSC Settings_.

# OSC Monitoring Interpretation

Our first interpretation of the **OSC Server** was that two **DS4Windows** instances can be strung together, so we can remote control the other instance. That resulted in a crashing of **DS4Windows**. After digging through the source code, as the documentation was very sparse, we found that this was not supported out-of-the box. 

We implemented this feature and think that it might be useful for a lot of different use-cases. We used it to have **more than 7 wireless controllers** on one Windows machine, which is under normal circumstances not easily possible.

# Performance Impact

With the _OSC Sender_ disabled, there should be no performance impact.

With it enabled the added **OSC messages** to communicate the state of the triggers have a minor performance impact, but those do not exceed the already existing performance impact of the communication of the sticks.

_OSC Monitoring Interpretation_ does also only introduce a minimal performance hit, when enabled.

# Acknowledgments

Thank you @phsete for your late night debugging sessions and code contributions