### PR TITLE
Improved detection logic for vendor-defined devices

### DIFF
--- a/DS4Windows/DS4Library/DS4Devices.cs
+++ b/DS4Windows/DS4Library/DS4Devices.cs
@@ -232,7 +232,7 @@ namespace DS4Windows
                         x.pid == hDevice.Attributes.ProductId);
 
                     if (!metainfo.featureSet.HasFlag(VidPidFeatureSet.VendorDefinedDevice) && hDevice.Capabilities.UsagePage >= 0xFF00)
-                        continue; // ignore the Nacon Revolution Pro programming interface
+                        continue; // Ignore devices using Vendor-Defined HID Usage Pages (expected to ignore the Nacon Revolution Pro programming interface)
                     else if (DevicePaths.Contains(hDevice.DevicePath))
                         continue; // BT/USB endpoint already open once
 

--- a/DS4Windows/DS4Library/DS4Devices.cs
+++ b/DS4Windows/DS4Library/DS4Devices.cs
@@ -231,7 +231,7 @@ namespace DS4Windows
                     VidPidInfo metainfo = knownDevices.Single(x => x.vid == hDevice.Attributes.VendorId &&
                         x.pid == hDevice.Attributes.ProductId);
 
-                    if (!metainfo.featureSet.HasFlag(VidPidFeatureSet.VendorDefinedDevice) && hDevice.Description == "HID-compliant vendor-defined device")
+                    if (!metainfo.featureSet.HasFlag(VidPidFeatureSet.VendorDefinedDevice) && hDevice.Capabilities.UsagePage >= 0xFF00)
                         continue; // ignore the Nacon Revolution Pro programming interface
                     else if (DevicePaths.Contains(hDevice.DevicePath))
                         continue; // BT/USB endpoint already open once


### PR DESCRIPTION
DS4Windows has an edge-case in which it needs to ignore the Nacon Revolution Pro programming interface. It does this by checking if it's a vendor-defined device, but this verification is done by checking if the device description string is `HID-compliant vendor-defined device`. There are 2 issues with this method:

1. This description is localized based on the system language, meaning that this verification will fail if the user system's language is not english even if the device is, in fact, vendor-defined
2. In the case of DS3 controllers using DsHidMini, sometimes this description is "vendor-defined" even if the actual HID capabilities report the joystick or gamepad usage pages
    - This seems to happen sometimes when the controller is in DS4W mode, which is vendor-defined, and the user later changes to SXS mode, which is joystick, but the cosmetic device HID description is not updated

I've tweaked the verification logic to compare the actual device's usage page. Anything over 0xFF00 is vendor defined, accordingly to the table in the page 16 of the following document: https://usb.org/sites/default/files/hut1_2.pdf