### PR TITLE
DualSense LED: Swap player 4 & player 6 so that player 4 looks normal, and players 6 looks odd

### DIFF
--- a/DS4Windows/DS4Library/InputDevices/DualSenseDevice.cs
+++ b/DS4Windows/DS4Library/InputDevices/DualSenseDevice.cs
@@ -1390,13 +1390,13 @@ namespace DS4Windows.InputDevices
                     deviceSlotMask = 0x01 | 0x04 | 0x10;
                     break;
                 case 3:
-                    deviceSlotMask = 0x02 | 0x04 | 0x08;
+                    deviceSlotMask = 0x01 | 0x02 | 0x08 | 0x10;
                     break;
                 case 4:
                     deviceSlotMask = 0x01 | 0x10;
                     break;
                 case 5:
-                    deviceSlotMask = 0x01 | 0x02 | 0x08 | 0x10;
+                    deviceSlotMask = 0x02 | 0x04 | 0x08;
                     break;
                 case 6:
                     deviceSlotMask = 0x01 | 0x02 | 0x04 | 0x08 | 0x10;


### PR DESCRIPTION
It is more common for games to support 1 to 4 players than to support 5+ players. Because of this, the player LED indicators for players 1 through 4 should look normal, and 5 - 8 should be the ones that are more difficult to understand.

I'm accomplishing this by swapping player 4 (currently 3 close dots) and player 6 (currently 4 dots spread apart.)