### PR TITLE
Add missing buttons to gyroTriggerItems list

### DIFF
--- a/DS4Windows/DS4Forms/ViewModels/ProfileSettingsViewModel.cs
+++ b/DS4Windows/DS4Forms/ViewModels/ProfileSettingsViewModel.cs
@@ -43,6 +43,7 @@ namespace DS4WinWPF.DS4Forms.ViewModels
             "Up", "Down", "Left", "Right",
             "L3", "R3", "Finger on Touchpad", "2 Fingers on Touchpad",
             "Options", "Share", "PS", "Touchpad Click",
+            "Mute", "Side L", "Side R",
             // START Extra buttons for DualSense Edge controller
             "Function Left", "Function Right", "Bottom Left Paddle", "Bottom Right Paddle",
             // END Extra buttons for DualSense Edge controller


### PR DESCRIPTION
This adds the missing buttons to the gyroTriggerItems list, so the extra DSE buttons/Mute can actually be used as gyro trigger buttons.

Without it, "Function Left" actually means the "Mute" button, and "Bottom Right Paddle" actually means "Function Left."